### PR TITLE
Disable phone number validation

### DIFF
--- a/Source/Onboarding/Onboarding.swift
+++ b/Source/Onboarding/Onboarding.swift
@@ -79,7 +79,10 @@ class Onboarding {
                       completion: @escaping StartCompletion)
     {
         guard birthdate.olderThan(yearsAgo: 16) else { completion(nil, .invalidBirthdate); return }
-        guard phone.isValidPhoneNumber else { completion(nil, .invalidPhoneNumber); return }
+        
+        // Phone verification is not used anymore
+        // guard phone.isValidPhoneNumber else { completion(nil, .invalidPhoneNumber); return }
+        
         guard name.isValidName else { completion(nil, .invalidName); return }
         guard Bots.current.identity == nil else { completion(nil, .cannotOnboardWhileLoggedIn); return }
 


### PR DESCRIPTION
Problem: Phone verification is disabled in the app. However,
the hardcoded phone number doesn't have the country code so
in a non-us machine it fails when validating the number.

Solution: Disable phone number validation.