### PR TITLE
Fix issue with no post notice in Home screen

### DIFF
--- a/Source/Controller/HomeViewController.swift
+++ b/Source/Controller/HomeViewController.swift
@@ -206,6 +206,7 @@ class HomeViewController: ContentViewController {
             self.reloadTimer.start(fireImmediately: false)
         } else {
             self.emptyView.removeFromSuperview()
+            self.tableView.backgroundView = nil
             self.reloadTimer.stop()
         }
         self.dataSource.keyValues = roots


### PR DESCRIPTION
Problem: A notice is shown when there aren't posts in the home screen. However, it
doesn't disappear if the user post a new post.

Solution: Set table view background view to nil when there are posts.