### PR TITLE
hotfix sync and old abouts

### DIFF
--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -70,7 +70,7 @@ func ssbConnectPeers(count uint32) bool {
 		return false
 	}
 
-	worked := 0
+	worked := uint32(0)
 	for i, row := range addrs {
 		err = sbot.Network.Connect(longCtx, row.addr.WrappedAddr())
 		if err != nil {

--- a/go-ssb-bindings/streams.go
+++ b/go-ssb-bindings/streams.go
@@ -113,6 +113,19 @@ func newLogDrain(sourceLog margaret.Log, seq uint64, limit int) (*bytes.Buffer, 
 		}
 
 		if msg.Claimed().Before(sixMonthAgo) {
+			var typeMsg struct {
+				Type string
+			}
+
+			err := json.Unmarshal(msg.ContentBytes(), &typeMsg)
+			typeStr := typeMsg.Type
+			if err != nil {
+				return false, nil
+			}
+			// the app viewdb needs older about and contact info
+			if typeStr == "about" || typeStr == "contact" {
+				return return true, nil
+			}
 			return false, nil
 		}
 		return true, nil

--- a/go-ssb-bindings/streams.go
+++ b/go-ssb-bindings/streams.go
@@ -124,7 +124,7 @@ func newLogDrain(sourceLog margaret.Log, seq uint64, limit int) (*bytes.Buffer, 
 			}
 			// the app viewdb needs older about and contact info
 			if typeStr == "about" || typeStr == "contact" {
-				return return true, nil
+				return true, nil
 			}
 			return false, nil
 		}


### PR DESCRIPTION
I introduced two small bugs in #3.

## The skipping of old content now happens on the go side
* This makes `bot.refresh()` much faster since we don't need to marshal > copy > unmarshal all those messages.
* I forgot **not** to skip about and contact messages since these are always needed

## the scheduler table doesnt always update
It runs into a `database locked` problem. I need to re-write it so that it batches it's connect updates at the end of the loop as I cant hold a transaction lock for the whole connect loop process. For now it just logs those and keeps on connecting.

