### PR TITLE
some quick improvments

### DIFF
--- a/Scripts/go_install.sh
+++ b/Scripts/go_install.sh
@@ -4,7 +4,7 @@ set -e
 
 # source: https://github.com/canha/golang-tools-install-script
 
-VERSION="1.14"
+VERSION="1.13.8"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -54,17 +54,11 @@ class GoBot: Bot {
 
     // MARK: App Lifecycle
 
-    func resume()  {
-        self.queue.async {
-            // make some sync connections to pull new messages
-            let n = 2 // how many connections to establish
-            if !self.bot.dialSomePeers() {
-                Log.unexpected(.botError, "failed to make \(n) sync connections after app resume")
-            }
-        }
-    }
+    func resume()  { }
 
-    func suspend() { }
+    func suspend() {
+        self.bot.disconnectAll()
+    }
 
     func exit() {
         self.bot.disconnectAll()

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -92,8 +92,9 @@ class GoBotInternal {
     // the Verse REST API
     // tuple of primary and fallbacks TODO: undo this once the live-streaming is in place
     private var allPeers: [ String : (Peer, [Peer]) ] = [
-        NetworkKey.ssb.string: ( Peer(tcpAddr: "pub3.planetary.social:8008", pubKey: Identities.ssb.pubs["planetary-pub3"]!) , [
-            Peer(tcpAddr: "pub2.planetary.social:8008", pubKey: Identities.ssb.pubs["planetary-pub1"]!),
+        NetworkKey.ssb.string: ( Peer(tcpAddr: "main2.planetary.social:8008", pubKey: Identities.ssb.pubs["planetary-pub2"]!) , [
+            Peer(tcpAddr: "main1.planetary.social:8008", pubKey: Identities.ssb.pubs["planetary-pub1"]!),
+            Peer(tcpAddr: "main3.planetary.social:8008", pubKey: Identities.ssb.pubs["planetary-pub3"]!),
             Peer(tcpAddr: "pub4.planetary.social:8008", pubKey: Identities.ssb.pubs["planetary-pub4"]!)
         ]),
 
@@ -104,10 +105,10 @@ class GoBotInternal {
         NetworkKey.planetary.string: (Peer(tcpAddr: "pub1.planetary.social:7227", pubKey: Identities.planetary.pubs["testpub_go2"]!), [
             Peer(tcpAddr: "pub1.planetary.social:7117", pubKey: Identities.planetary.pubs["testpub_go1"]!),
             Peer(tcpAddr: "pub3.planetary.social:7337", pubKey: Identities.planetary.pubs["testpub_go3"]!),
-            Peer(tcpAddr: "pub3.planetary.social:7447", pubKey: Identities.planetary.pubs["testpub_go4"]!),
+            Peer(tcpAddr: "demo4.planetary.social:7447", pubKey: Identities.planetary.pubs["testpub_go4"]!),
             
             Peer(tcpAddr: "pub2.planetary.social:7557", pubKey: Identities.planetary.pubs["testpub_go_testing1"]!),
-            Peer(tcpAddr: "pub2.planetary.social:7667", pubKey: Identities.planetary.pubs["testpub_go_testing2"]!)
+            Peer(tcpAddr: "demo6.planetary.social:7667", pubKey: Identities.planetary.pubs["testpub_go_testing2"]!)
         ]),
 
         NetworkKey.integrationTests.string: (Peer(tcpAddr: "testing-ci.planetary.social:9119", pubKey: Identities.testNet.pubs["integrationpub1"]!), [])
@@ -281,8 +282,8 @@ class GoBotInternal {
     
     @discardableResult
     func dialSomePeers() -> Bool {
-        ssbConnectPeers(4)
-        if let p = self.peers.randomSample(1).first {
+        ssbConnectPeers(3)
+        if let p = self.peers.randomSample(2).first {
             let worked = self.dialOne(peer: p)
             if worked {
                 return true

--- a/Source/Model/Identities.swift
+++ b/Source/Model/Identities.swift
@@ -12,7 +12,7 @@ typealias Identities = [Identity]
 
 struct SSBIdentities {
     let pubs = [ "planetary-pub1": "@cgZaEEyNixAnq7tMH2CHdusBHV80OwqOSGIcc6Hr6aA=.ed25519",
-//                "planetary-pub2": "@ZOSbNTyKgIecMcSCPlOJt1veIAP1D8p5Ptao+8cRO6c=.ed25519",
+                "planetary-pub2": "@ZOSbNTyKgIecMcSCPlOJt1veIAP1D8p5Ptao+8cRO6c=.ed25519",
                 "planetary-pub3": "@oRMrLWs3AP0VwVw3AtBRL3TfOaxeTOFml33CibRtfcE=.ed25519",
                 "planetary-pub4": "@9Vyi928zwolkNcyDSA6S3p+ycQ8GD87iSU//0dNc0pw=.ed25519",
                 "cryptix-pub": "@xxZeuBUKIXYZZ7y+CIHUuy0NOFXz2MhUBkHemr86S3M=.ed25519"]


### PR DESCRIPTION
* downgrade to go1.13.8 (i think the new stuff in 14 is causing the interface scroll lag/jitter)
* `bot.disconnectAll` on resume (to save ram when going in the background)
* don't make connections on startup (might need to wait for a timer but is less cpu and network heavy, also going back and forth makes lots since there is no cap yet.)
* update pub addresses


ps: you need to remove `go-ssb-bindings/.goroot` for it to update the toolchain correctly. Patch for a version check pending.