### PR TITLE
fix syncing

### DIFF
--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -54,7 +54,9 @@ class GoBot: Bot {
 
     // MARK: App Lifecycle
 
-    func resume()  { }
+    func resume()  {
+        self.bot.dialSomePeers()
+    }
 
     func suspend() {
         self.bot.disconnectAll()

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -278,6 +278,7 @@ class GoBotInternal {
     
     @discardableResult
     func dialSomePeers() -> Bool {
+        guard self.openConnections() == 0 else { return true } // only make connections if we dont have any
         ssbConnectPeers(3)
         self.dial(atLeast: 2, tries: 10)
         return true

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -279,13 +279,8 @@ class GoBotInternal {
     @discardableResult
     func dialSomePeers() -> Bool {
         ssbConnectPeers(3)
-        if let p = self.peers.randomSample(2).first {
-            let worked = self.dialOne(peer: p)
-            if worked {
-                return true
-            }
-        }
-        return false
+        self.dial(atLeast: 2, tries: 10)
+        return true
     }
     
     func dialOne(peer: Peer) -> Bool {

--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -96,6 +96,34 @@ func ssbConnectPeers(count uint32) bool {
 		return false
 	}
 
+	tx, err := viewDB.Begin()
+	if err != nil {
+		retErr = errors.Wrap(err, "failed to make transaction on viewdb")
+		return false
+	}
+
+	for res := range connErrs {
+		if res.err == nil {
+			_, err := tx.Exec(`UPDATE addresses set worked_last=strftime("%Y-%m-%dT%H:%M:%f", 'now') where address_id = ?`, res.row.addrID)
+			if err != nil {
+				retErr = errors.Wrapf(err, "updateFailed: working pub %d", res.row.addrID)
+				return false
+			}
+			continue
+		}
+
+		_, err := tx.Exec(`UPDATE addresses set worked_last=0,last_err=? where address_id = ?`, res.err.Error(), res.row.addrID)
+		if err != nil {
+			retErr = errors.Wrapf(err, "updateFailed: failing pub %d", res.row.addrID)
+			return false
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		retErr = errors.Wrap(err, "failed to commit viewdb transaction")
+		return false
+	}
 	return true
 }
 
@@ -149,7 +177,13 @@ func queryAddresses(count uint32) ([]*addrRow, error) {
 
 		msAddr, err := multiserver.ParseNetAddress([]byte(addr))
 		if err != nil {
-			continue
+			_, execErr := viewDB.Exec(`UPDATE addresses set use=false,last_err=? where address_id = ?`, err.Error(), id)
+			if execErr != nil {
+				execErr = errors.Wrapf(execErr, "queryAddresses(%d): failed to update parse error row %d", i, id)
+				level.Warn(log).Log("event", "broken address record update failed", "err", execErr)
+				continue // would be better to UPDATE these but might also be an intermittent resolve error
+			}
+			return nil, errors.Wrapf(err, "queryAddresses(%d): row %d (%q) not a multiserver", i, id, addr)
 		}
 
 		addresses = append(addresses, &addrRow{
@@ -157,7 +191,6 @@ func queryAddresses(count uint32) ([]*addrRow, error) {
 			addr:   msAddr,
 		})
 
-		fmt.Fprintf(os.Stderr, "\t\tTODO[debug]: addr%d: %s\n", i, addr)
 		i++
 	}
 

--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"math"
-	"os"
 	"runtime"
 
 	"github.com/go-kit/kit/log/level"

--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -133,7 +133,8 @@ type connectResult struct {
 func makeConnWorker(workCh <-chan *addrRow, connErrs chan<- *connectResult) func() error {
 	return func() error {
 		for row := range workCh {
-			err := sbot.Network.Connect(longCtx, row.addr.WrappedAddr())
+			ctx, _ := context.WithTimeout(longCtx, 10*60*time.Second)) // kill connections after a while until we have live streaming
+			err := sbot.Network.Connect(ctx, row.addr.WrappedAddr())
 			level.Info(log).Log("event", "ssbConnectPeers", "dial", row.addrID, "err", err)
 			connErrs <- &connectResult{
 				row: row,

--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"math"
 	"runtime"
+	"time"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
@@ -133,7 +134,7 @@ type connectResult struct {
 func makeConnWorker(workCh <-chan *addrRow, connErrs chan<- *connectResult) func() error {
 	return func() error {
 		for row := range workCh {
-			ctx, _ := context.WithTimeout(longCtx, 10*60*time.Second)) // kill connections after a while until we have live streaming
+			ctx, _ := context.WithTimeout(longCtx, 10*60*time.Second) // kill connections after a while until we have live streaming
 			err := sbot.Network.Connect(ctx, row.addr.WrappedAddr())
 			level.Info(log).Log("event", "ssbConnectPeers", "dial", row.addrID, "err", err)
 			connErrs <- &connectResult{


### PR DESCRIPTION
This should fix the need to manually tap "Sync" in the debug menu.

In some cases `dialSomePeers()` did nothing, especially during onboarding.

