### PR TITLE
Fix links being opened while scrolling

### DIFF
--- a/Source/UI/PostCellView.swift
+++ b/Source/UI/PostCellView.swift
@@ -39,8 +39,6 @@ class PostCellView: KeyValueView {
     private lazy var textView: UITextView = {
         let view = UITextView.forAutoLayout()
         view.addGestureRecognizer(self.tapGesture.recognizer)
-        view.dataDetectorTypes = .link
-        view.delegate = self
         view.isEditable = false
         view.isScrollEnabled = false
         view.textContainer.lineFragmentPadding = 0
@@ -203,19 +201,5 @@ class PostCellView: KeyValueView {
         // always do this in case of constraint changes
         self.setNeedsLayout()
         self.layoutIfNeeded()
-    }
-}
-
-// MARK:- UITextViewDelegate
-
-extension PostCellView: UITextViewDelegate {
-
-    func textView(_ textView: UITextView,
-                  shouldInteractWith URL: URL,
-                  in characterRange: NSRange,
-                  interaction: UITextItemInteraction) -> Bool
-    {
-        AppController.shared.open(url: URL)
-        return false
     }
 }


### PR DESCRIPTION
Problem: If you tap on a link in a post while scrolling
the app opens the link instead of allowing the user continue
scrolling through the feed.

Solution: Remove link decection on text views because they
are already handled by the tap gesture.