### PR TITLE
use mentions for channels

### DIFF
--- a/Deprecated/Channel.swift
+++ b/Deprecated/Channel.swift
@@ -13,12 +13,6 @@ struct Channel: ContentCodable {
 
     let type: ContentType = .channel
     let name: String
-    let root: Identifier?
-
-    init(name: String, root: String?) {
-        self.name = name
-        self.root = root
-    }
 
     init(hashtag: String) {
         self.name = hashtag.withoutHashPrefix

--- a/Shared/Extensions/String+HashtagSubstrings.swift
+++ b/Shared/Extensions/String+HashtagSubstrings.swift
@@ -15,10 +15,10 @@ extension String {
     //
     // # - first required character
     // [a-zA-Z] - alphabet only
-    // [a-zA-Z\\d] - alphanumeric
-    // [a-zA-Z][a-zA-Z\\d] - mixed alphanumeric
+    // [a-zA-Z-\\d] - alphanumeric and the dash
+    // [a-zA-Z][a-zA-Z-\\d] - mixed alphanumeric and the dash
     // ([a-zA-Z\\d]|$) - ending with non-alphanumeric or end of input
-    private static let alphanumericHashtagRegex = "#[a-zA-Z]*[a-zA-Z\\d]*[a-zA-Z][a-zA-Z\\d]*([a-zA-Z\\d]|$)"
+    private static let alphanumericHashtagRegex = "#[a-zA-Z]*[a-zA-Z-\\d]*[a-zA-Z][a-zA-Z-\\d]*([a-zA-Z\\d]|$)"
 
     func hashtagSubstringsWithRanges() -> [(String, NSRange)]
     {

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1368,8 +1368,12 @@ class ViewDatabase {
             try self.insertBlobs(msgID: msgID, blobs: b)
         }
 
-        if let hts = p.hashtags {
-            try self.insertHashtags(msgID: msgID, tags: hts)
+        let hashtagsFromMentions = p.mentions?.filter {
+            m in
+            return m.link.hasPrefix("#")
+        }
+        if let htags = hashtagsFromMentions {
+            try self.insertHashtags(msgID: msgID, tags: htags)
         }
     }
     
@@ -1825,12 +1829,12 @@ class ViewDatabase {
         return blobs
     }
     
-    private func insertHashtags(msgID: Int64, tags: [Hashtag]) throws {
+    private func insertHashtags(msgID: Int64, tags: Mentions) throws {
         guard let db = self.openDB else {
             throw ViewDatabaseError.notOpen
         }
         for h in tags {
-            let chanID = try self.channelID(from: h.name, make: true)
+            let chanID = try self.channelID(from: h.link, make: true)
             try db.run(self.channelAssigned.insert(
                 colMessageRef <- msgID,
                 colChanRef <- chanID

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1368,11 +1368,7 @@ class ViewDatabase {
             try self.insertBlobs(msgID: msgID, blobs: b)
         }
 
-        let hashtagsFromMentions = p.mentions?.filter {
-            m in
-            return m.link.hasPrefix("#")
-        }
-        if let htags = hashtagsFromMentions {
+        if let htags = p.mentions?.asHashtags() {
             try self.insertHashtags(msgID: msgID, tags: htags)
         }
     }
@@ -1829,12 +1825,12 @@ class ViewDatabase {
         return blobs
     }
     
-    private func insertHashtags(msgID: Int64, tags: Mentions) throws {
+    private func insertHashtags(msgID: Int64, tags: [Hashtag]) throws {
         guard let db = self.openDB else {
             throw ViewDatabaseError.notOpen
         }
         for h in tags {
-            let chanID = try self.channelID(from: h.link, make: true)
+            let chanID = try self.channelID(from: h.name, make: true)
             try db.run(self.channelAssigned.insert(
                 colMessageRef <- msgID,
                 colChanRef <- chanID

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1111,6 +1111,7 @@ class ViewDatabase {
             .join(.leftOuter, self.tangles, on: self.tangles[colMessageRef] == self.channelAssigned[colMessageRef])
             .join(.leftOuter, self.posts, on: self.posts[colMessageRef] == self.channelAssigned[colMessageRef])
             .join(.leftOuter, self.votes, on: self.votes[colMessageRef] == self.channelAssigned[colMessageRef])
+            .order(colClaimedAt.desc)
 
         return try self.mapQueryToKeyValue(qry: qry)
     }

--- a/Source/Model/Blob.swift
+++ b/Source/Model/Blob.swift
@@ -13,7 +13,7 @@ struct Blob: Codable {
     // MARK: Required properties
 
     let identifier: BlobIdentifier
-    let name: String
+    let name: String?
 
     // MARK: Optional metadata
 
@@ -39,7 +39,7 @@ struct Blob: Codable {
 
     // MARK: Lifecycle
 
-    init(identifier: BlobIdentifier, name: String = "blob", metadata: Metadata? = nil) {
+    init(identifier: BlobIdentifier, name: String? = nil, metadata: Metadata? = nil) {
         self.identifier = identifier
         self.name = name
         self.metadata = metadata

--- a/Source/Model/Hashtag.swift
+++ b/Source/Model/Hashtag.swift
@@ -48,3 +48,13 @@ extension Hashtags {
         return self.map { $0.name }
     }
 }
+
+extension Mentions {
+    func asHashtags() -> [Hashtag] {
+        return self.filter {
+            return $0.link.hasPrefix("#")
+        }.map {
+            return Hashtag(name: String($0.link.dropFirst()))
+        }
+    }
+}

--- a/Source/Model/Mention+NSAttributedString.swift
+++ b/Source/Model/Mention+NSAttributedString.swift
@@ -44,8 +44,9 @@ extension NSAttributedString {
 extension NSMutableAttributedString {
 
     convenience init(from mention: Mention) {
-        self.init(string: mention.name)
-        let range = NSRange(location: 0, length: mention.name.count)
+        let name = mention.name ?? ""
+        self.init(string: name)
+        let range = NSRange(location: 0, length: name.count)
         self.addAttribute(NSAttributedString.Key.link, value: mention.link, range: range)
     }
 
@@ -57,7 +58,8 @@ extension NSMutableAttributedString {
 
     func replaceMentionLinkAttributesWithNamesOnly() {
         for (mention, range) in self.mentionsWithRanges().reversed() {
-            self.replaceCharacters(in: range, with: mention.name.withoutAtPrefix)
+            let name = mention.name ?? ""
+            self.replaceCharacters(in: range, with: name.withoutAtPrefix)
         }
     }
 }

--- a/Source/Model/Mention.swift
+++ b/Source/Model/Mention.swift
@@ -11,7 +11,7 @@ import Foundation
 struct Mention: Codable {
 
     let link: Identifier
-    let name: String
+    let name: String?
 
     var identity: Identifier {
         return self.link
@@ -23,7 +23,20 @@ struct Mention: Codable {
     let height: Int?
     let type: String?
     
-    init(link: Identifier, name: String, metadata: Blob.Metadata? = nil) {
+    
+    // just for hashtags
+//    init(link: String) {
+//        self.link = link
+//        
+//        // empty
+//        self.name = nil
+//        self.size = nil
+//        self.width = nil
+//        self.height = nil
+//        self.type = nil
+//    }
+    
+    init(link: Identifier, name: String? = nil , metadata: Blob.Metadata? = nil) {
         self.link = link
         self.name = name
 
@@ -44,9 +57,8 @@ struct Mention: Codable {
 extension Mention: Markdownable {
 
     var markdown: String {
-        var markdown = "[\(self.name)]"
-        markdown += "(\(self.link))"
-        return markdown
+        guard let name = self.name else { return "" }
+        return "[\(name)](\(self.link))"
     }
 }
 

--- a/Source/Model/Post+Blob.swift
+++ b/Source/Model/Post+Blob.swift
@@ -42,7 +42,6 @@ extension Post {
 
         return Post(blobs: blobs,
                     branches: self.branch,
-                    hashtags: self.hashtags,
                     mentions: self.mentions,
                     root: self.root,
                     text: textWithImages)

--- a/Source/Model/Post.swift
+++ b/Source/Model/Post.swift
@@ -83,6 +83,11 @@ class Post: ContentCodable {
                 m.append(b.asMention())
             }
         }
+        if let tags = hashtags {
+            for h in tags {
+                m.append(Mention(link: h.string))
+            }
+        }
         // keep it optional
         self.mentions = m.count > 0 ? m : nil
 

--- a/UnitTests/ContentTests.swift
+++ b/UnitTests/ContentTests.swift
@@ -322,7 +322,8 @@ class ContentTests: XCTestCase {
             XCTAssertTrue(content.type == .post)
             XCTAssertTrue(content.isValid)
             guard let post = content.post else { XCTFail(); return }
-            XCTAssertEqual(post.hashtags?.count, 2)
+            guard let tags = post.mentions?.asHashtags() else { XCTFail(); return }
+            XCTAssertEqual(tags.count, 2)
         } catch {
             XCTFail("\(error)")
         }

--- a/UnitTests/ContentTests.swift
+++ b/UnitTests/ContentTests.swift
@@ -304,7 +304,7 @@ class ContentTests: XCTestCase {
             text: "test post with hashtags")
         let d = try! p.encodeToData()
         let s = String(data:d, encoding: .utf8)!
-        XCTAssertTrue(s.contains("hashtags\":[\"helloWorld\"]"))
+        XCTAssertTrue(s.contains("{\"link\":\"#helloWorld\"}"))
     }
 
     func test_postWithInlineHashtagEncode() {
@@ -312,7 +312,7 @@ class ContentTests: XCTestCase {
             attributedText: NSAttributedString(string: "test post with hashtags #helloWorld"))
         let d = try! p.encodeToData()
         let s = String(data:d, encoding: .utf8)!
-        XCTAssertTrue(s.contains("hashtags\":[\"helloWorld\"]"))
+        XCTAssertTrue(s.contains("{\"link\":\"#helloWorld\"}"))
     }
     
     func test_postWithHashtagDecode() {

--- a/UnitTests/FeedFill.swift
+++ b/UnitTests/FeedFill.swift
@@ -543,9 +543,9 @@ class ViewDatabaseTest: XCTestCase {
             if hashtags.count != 3 {
                 return
             }
-            XCTAssertEqual(hashtags[0].name, "extag1")
-            XCTAssertEqual(hashtags[1].name, "extag2")
-            XCTAssertEqual(hashtags[2].name, "extag3")
+            XCTAssertEqual(hashtags[0].name, "hashtag")
+            XCTAssertEqual(hashtags[1].name, "hello")
+            XCTAssertEqual(hashtags[2].name, "world")
         } catch {
             XCTFail("\(error)")
         }
@@ -553,13 +553,13 @@ class ViewDatabaseTest: XCTestCase {
 
     func test61_channel_messages() {
         do {
-            let lMsgs = try self.vdb.messagesForHashtag(name: "extag1")
+            let lMsgs = try self.vdb.messagesForHashtag(name: "hashtag")
             XCTAssertEqual(lMsgs.count, 1)
 
-            let t1msgs = try self.vdb.messagesForHashtag(name: "extag2")
-            XCTAssertEqual(t1msgs.count, 2)
+            let t1msgs = try self.vdb.messagesForHashtag(name: "hello")
+            XCTAssertEqual(t1msgs.count, 1)
 
-            let t2msgs = try self.vdb.messagesForHashtag(name: "extag3")
+            let t2msgs = try self.vdb.messagesForHashtag(name: "world")
             XCTAssertEqual(t2msgs.count, 1)
         } catch {
             XCTFail("\(error)")

--- a/UnitTests/PostWithHashtags.json
+++ b/UnitTests/PostWithHashtags.json
@@ -1,7 +1,7 @@
 {
-    "hashtags": [
-        "extag2",
-        "extag3"
+    "mentions": [
+        {"link": "#extag2"},
+        {"link": "#extag3"},
     ],
     "text": "hashtags test post 2",
     "type": "post"


### PR DESCRIPTION
This uses `mentions: [ {link: #tag1}, {link: #tag2}]` together with the markdown text to indicate which hashtags a post should belong to.

For this I had to make `name: String` optional on the `Hashtag` type.


Need to find the regexp responsible for striping of dashes. Afterwards this is good to go.