### PR TITLE
add dialing peers after login was successfull

### DIFF
--- a/Source/App/AppController+BackgroundSync.swift
+++ b/Source/App/AppController+BackgroundSync.swift
@@ -38,9 +38,7 @@ extension AppController {
             if notificationsOnly {
                 self?.syncNotifications(task: task, completion: completion)
             } else {
-                
-                
-                //self?.syncEverything(task: task, completion: completion)
+                self?.syncEverything(task: task, completion: completion)
             }
         }
     }


### PR DESCRIPTION
We wait a bit so that the UI can finish loading, though.

This should get us updates right after the app starts. Still looking for why the background timer doesnt work anymore.

ps: sorry for the noisy diff but this was indented wrong...