### PR TITLE
Fix issue with reply count different that replies shown

### DIFF
--- a/Source/Controller/ThreadViewController.swift
+++ b/Source/Controller/ThreadViewController.swift
@@ -167,7 +167,7 @@ class ThreadViewController: ContentViewController {
         self.dataSource.keyValues = replies.posts.sortedByDateAscending()
         self.tableView.forceReload()
         self.scrollIfNecessary(animated: animated)
-        self.interactionView.replyCount = replies.count
+        self.interactionView.replyCount = replies.posts.count
     }
 
 

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -836,6 +836,7 @@ class ViewDatabase {
                 .join(self.msgs, on: self.msgs[colMessageID] == self.tangles[colMessageRef])
                 .join(self.authors, on: self.msgs[colAuthorID] == self.authors[colID])
                 .join(self.abouts, on: self.authors[colID] == self.abouts[colAboutID])
+                .filter(colMsgType == ContentType.post.rawValue)
                 .filter(colRoot == msgID)
 
             let count = try self.openDB!.scalar(replies.count)


### PR DESCRIPTION
Problem: We show the reply count that is different that the replies
we show because a reply can be a post, a vote, or anything, but we
just show posts.

Solution: Filter posts when calculating the number of replies.