### PR TITLE
Fix mentions' avatar are wrongly displayed

### DIFF
--- a/Source/UI/AboutCellView.swift
+++ b/Source/UI/AboutCellView.swift
@@ -202,6 +202,10 @@ class MiniAboutCellView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func reset() {
+        self.update(with: About())
+    }
+    
     func update(with about: About) {
         self.imageView.set(image: about.image)
         self.nameLabel.text = about.nameOrIdentity

--- a/Source/UI/AboutsMenu.swift
+++ b/Source/UI/AboutsMenu.swift
@@ -131,4 +131,9 @@ private class MiniAboutTableViewCell: UITableViewCell {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        aboutView.reset()
+    }
 }


### PR DESCRIPTION
Problem: When typing a mention @something sometimes an avatar is not
correct because the cell doesn't prepare for reuse.

Solution: Reset the view when prepareForReuse is called.