### PR TITLE
Fix issue with downloading logs

### DIFF
--- a/Source/Analytics/Log.swift
+++ b/Source/Analytics/Log.swift
@@ -21,6 +21,7 @@ enum LogReason: String {
 /// `typealias Log = OSLog`.  This allows the implementation
 /// to be changed on a per target level based on needs.
 protocol LogService {
+    static func configure()
     static func optional(_ error: Error?, _ detail: String?) -> Bool
     static func info(_ string: String)
     static func unexpected(_ reason: LogReason, _ detail: String?)

--- a/Source/Analytics/NullLog.swift
+++ b/Source/Analytics/NullLog.swift
@@ -14,6 +14,8 @@ typealias Log = NullLog
 /// for use with unit or API test targets.
 class NullLog: LogService {
 
+    static func configure() { }
+    
     @discardableResult
     static func optional(_ error: Error?, _ detail: String? = nil) -> Bool {
         guard let _ = error else { return false }

--- a/Source/Analytics/OSLog.swift
+++ b/Source/Analytics/OSLog.swift
@@ -17,6 +17,10 @@ typealias Log = OSLog
 /// https://developer.apple.com/documentation/os/logging
 class OSLog: LogService {
     
+    static func configure() {
+        os_log("%@", self.fileLogger.debugDescription)
+    }
+    
     private static let fileLogger: DDFileLogger = {
         let fileLogger = DDFileLogger() // File Logger
         fileLogger.rollingFrequency = 60 * 60 * 24 // 24 hours

--- a/Source/App/AppDelegate.swift
+++ b/Source/App/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window.makeKeyAndVisible()
         self.window = window
         
+        Log.configure()
         CrashReporting.configure()
         
         // reset configurations if user enabled switch in settings

--- a/Source/Debug/DebugViewController.swift
+++ b/Source/Debug/DebugViewController.swift
@@ -361,7 +361,7 @@ class DebugViewController: DebugTableViewController {
                                          actionClosure:
         {
             [unowned self] cell in
-            self.shareLogs()
+            self.shareLogs(cell: cell)
         })]
         
         settings += [DebugTableViewCellModel(title: "Simulate onboarding",
@@ -432,10 +432,18 @@ class DebugViewController: DebugTableViewController {
         }
     }
 
-    private func shareLogs() {
-        let activityController = UIActivityViewController(activityItems: Log.fileUrls,
-                                                          applicationActivities: nil)
-        self.present(activityController, animated: true)
+    private func shareLogs(cell: UITableViewCell) {
+        let fileUrls = Log.fileUrls
+        if fileUrls.isEmpty {
+            self.alert(message: "There aren't logs yet.")
+        } else {
+            let activityController = UIActivityViewController(activityItems: Log.fileUrls,
+                                                              applicationActivities: nil)
+            self.present(activityController, animated: true)
+            if let popOver = activityController.popoverPresentationController {
+                popOver.sourceView = cell
+            }
+        }
     }
     
     private func applyConfigurationAndDismiss() {


### PR DESCRIPTION
Problem: A user reports logs not appearing for downloading
and an iPad user even crashing.

Solution: Consider popover controller in iPad and make sure
DDLog is configured at start.