### PR TITLE
Fix crash when repair fails

### DIFF
--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -513,7 +513,7 @@ class GoBot: Bot {
                 // TODO: we need to spawn the _in progress_ spinner here because this can take a while...
                 var (params, err) = self.repairViewConstraints21012020(with: author, current: current)
                 if let e = err {
-                    params["repair_failed"] = e
+                    params["repair_failed"] = e.localizedDescription
                 }
 
                 Analytics.track(event: .did,


### PR DESCRIPTION
Problem: App crashes when repair fails because we are sending to Mixpanel
a Error instance which is not supported.

Solution: Send the description (String) instead.