### PR TITLE
Fix post button not appearing when keyboard is undocked

### DIFF
--- a/Source/Controller/ThreadViewController.swift
+++ b/Source/Controller/ThreadViewController.swift
@@ -215,23 +215,6 @@ class ThreadViewController: ContentViewController {
         }
     }
 
-    // Adjusts the buttons view height and scrolls the table view at the same time
-    // as the superclass ContentViewController handles the keyboard.  Because the
-    // superclass implementation wraps the constraint change in an animation, the
-    // changes here are also animated.
-    override func setKeyboardTopConstraint(constant: CGFloat,
-                                           duration: TimeInterval,
-                                           curve: UIView.AnimationCurve)
-    {
-        super.setKeyboardTopConstraint(constant: constant, duration: duration, curve: curve)
-        if constant == 0 {
-            self.buttonsView.minimize(duration: duration)
-        } else {
-            self.buttonsView.maximize(duration: duration)
-            self.scrollToLastVisibleIndexPath()
-        }
-    }
-
     // Forces the reply text view to be first responder if the controller
     // was inited to start replying immediately.
     private func replyTextViewBecomeFirstResponderIfNecessary() {
@@ -263,6 +246,17 @@ class ThreadViewController: ContentViewController {
         self.textViewDelegate.didChangeMention = {
             [unowned self] string in
             self.menu.filter(by: string)
+        }
+        
+        let buttonViewAnimationDuration: TimeInterval = 0.5
+        
+        self.textViewDelegate.didBeginEditing = { _ in
+            self.buttonsView.maximize(duration: buttonViewAnimationDuration)
+            self.scrollToLastVisibleIndexPath()
+        }
+        
+        self.textViewDelegate.didEndEditing = { _ in
+            self.buttonsView.minimize(duration: buttonViewAnimationDuration)
         }
     }
 

--- a/Source/UI/MentionTextViewDelegate.swift
+++ b/Source/UI/MentionTextViewDelegate.swift
@@ -180,7 +180,10 @@ class MentionTextViewDelegate: NSObject, UITextViewDelegate {
         textView.typingAttributes = self.fontAttributes
     }
 
+    var didBeginEditing: ((UITextView) -> Void)?
+    
     func textViewDidBeginEditing(_ textView: UITextView) {
+        self.didBeginEditing?(textView)
         guard let placeholder = placeholder else { return }
         if let text = textView.text, text == placeholder {
             textView.text = ""
@@ -188,8 +191,11 @@ class MentionTextViewDelegate: NSObject, UITextViewDelegate {
             textView.typingAttributes = self.fontAttributes
         }
     }
+    
+    var didEndEditing: ((UITextView) -> Void)?
 
     func textViewDidEndEditing(_ textView: UITextView) {
+        self.didEndEditing?(textView)
         guard let placeholder = placeholder else { return }
         if let text = textView.text, text.isEmpty {
             textView.text = placeholder

--- a/Source/UI/PostButtonsView.swift
+++ b/Source/UI/PostButtonsView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 class PostButtonsView: UIView {
 
-    static var viewHeight: CGFloat = 50
+    static let viewHeight: CGFloat = 50
 
     let topSeparator = Layout.separatorView()
 


### PR DESCRIPTION
Problem: When the keyboard is undocked, normal notifications are
not sent so post button is never shown.

Solution: Use UITextViewDelegate didBeginEditing and didEndEditing
to show/hide the post button.