### PR TITLE
Prevent using Mixpanel if not configured and if in debug

### DIFF
--- a/Configs/Environment.swift
+++ b/Configs/Environment.swift
@@ -14,8 +14,8 @@ enum Environment {
         private enum Keys {
             static let token = "PLMixpanelToken"
         }
-        static let token: String = {
-            return Environment.value(for: Keys.token)
+        static let token: String? = {
+            return Environment.valueIfPresent(for: Keys.token)
         }()
     }
     
@@ -177,7 +177,10 @@ enum Environment {
     }
     
     private static func valueIfPresent(for key: String) -> String? {
-        return Environment.infoDictionary[key] as? String
+        if let value = Environment.infoDictionary[key] as? String, !value.isEmpty {
+            return value
+        }
+        return nil
     }
     
     private static let infoDictionary: [String: Any] = {

--- a/Configs/Shared.debug.xcconfig
+++ b/Configs/Shared.debug.xcconfig
@@ -9,8 +9,6 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-MIXPANEL_TOKEN =
-
 AUTHY_TOKEN =
 
 ZENDESK_APP_ID =

--- a/Source/App/AppController+Push.swift
+++ b/Source/App/AppController+Push.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import Mixpanel
 import UIKit
 import UserNotifications
 

--- a/Source/CrashReporting/CrashReporting.swift
+++ b/Source/CrashReporting/CrashReporting.swift
@@ -18,6 +18,7 @@ class CrashReporting {
             configured = false
             return
         }
+        Log.info("Configuring Bugsnag...")
         Bugsnag.start(withApiKey: token)
         configured = true
     }


### PR DESCRIPTION
Problem: While we have a way of not using Mixpanel, en empty key is still
required to be in the configs file. Also, Mixpanel is being used in Debug config.

Solution: Configure Mixpanel only if key is present and remove the key from Debug config.