### PR TITLE
Release 0.9.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.13] - 2020-03-20
+## [0.9.15] - 2020-03-26
+### Fixed
+- Post button not appearing when undocking the keyboard.
+- Crash when downloading logs in iPad.
+- Empty log when downloading logs.
+- Crash when database repair fails.
+- Bad wording for number of replies in a post.
+
+## [0.9.14] - 2020-03-25
 ### Added
 - Show spinning wheel when processing new messages.
 ### Fixed

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.14</string>
+	<string>0.9.15</string>
 	<key>CFBundleVersion</key>
-	<string>181</string>
+	<string>183</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Fixed:
- Post button not appearing when undocking the keyboard.
- Crash when downloading logs in iPad.
- Empty log when downloading logs.
- Crash when database repair fails.
- Bad wording for number of replies in a post.