### PR TITLE
Loading graphic for notifications and channels tabs

### DIFF
--- a/Source/Controller/ChannelsViewController.swift
+++ b/Source/Controller/ChannelsViewController.swift
@@ -45,11 +45,18 @@ class ChannelsViewController: ContentViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         Layout.fill(view: self.view, with: self.tableView)
+        self.addLoadingAnimation()
+        self.load()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.deeregisterDidSyncAndRefresh()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.load()
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        self.registerDidSyncAndRefresh()
     }
 
     // MARK: Load and refresh
@@ -59,6 +66,7 @@ class ChannelsViewController: ContentViewController {
             [weak self] hashtags, error in
             Log.optional(error)
             self?.update(with: hashtags, animated: false)
+            self?.removeLoadingAnimation()
             self?.refreshControl.endRefreshing()
         }
     }
@@ -76,6 +84,27 @@ class ChannelsViewController: ContentViewController {
 
     @objc func refreshControlValueChanged(control: UIRefreshControl) {
         control.beginRefreshing()
+        self.refresh()
+    }
+    
+    // MARK: Notifications
+
+    override func registerNotifications() {
+        super.registerNotifications()
+        self.registerDidSyncAndRefresh()
+    }
+
+    override func deregisterNotifications() {
+        super.deregisterNotifications()
+        self.deeregisterDidSyncAndRefresh()
+    }
+
+    /// Refreshes the view,  but only if this is the top controller, not when there are any child
+    /// controllers.  The notification will also only be received when the view is not visible,
+    /// check out `viewDidAppear()` and `viewDidDisappear()`.  This is because
+    /// we don't want the view to be updated while someone is looking/scrolling it.
+    override func didSyncAndRefresh(notification: NSNotification) {
+        guard self.navigationController?.topViewController == self else { return }
         self.refresh()
     }
 }

--- a/Source/Controller/ContentViewController.swift
+++ b/Source/Controller/ContentViewController.swift
@@ -191,4 +191,34 @@ class ContentViewController: UIViewController, KeyboardHandling {
     func deregisterNotifications() {
         self.deregisterDidBlockUser()
     }
+    
+    // MARK: Loading animation
+    
+    private lazy var loadingAnimation: PeerConnectionAnimation = {
+        let view = PeerConnectionAnimation.forAutoLayout()
+        view.setDotCount(inside: false, count: 1, animated: false)
+        view.setDotCount(inside: true, count: 2, animated: false)
+        return view
+    }()
+    
+    private lazy var loadingLabel: UILabel = {
+        let view = UILabel.forAutoLayout()
+        view.textAlignment = .center
+        view.numberOfLines = 2
+        view.text = Text.loadingUpdates.text
+        view.textColor = UIColor.tint.default
+        return view
+    }()
+    
+    func addLoadingAnimation() {
+        Layout.center(self.loadingLabel, in: self.view)
+        Layout.centerHorizontally(self.loadingAnimation, in: self.view)
+        self.loadingAnimation.constrainSize(to: self.loadingAnimation.totalDiameter)
+        self.loadingAnimation.pinBottom(toTopOf: self.loadingLabel, constant: -20, activate: true)
+    }
+    
+    func removeLoadingAnimation() {
+        self.loadingLabel.removeFromSuperview()
+        self.loadingAnimation.removeFromSuperview()
+    }
 }

--- a/Source/Controller/HomeViewController.swift
+++ b/Source/Controller/HomeViewController.swift
@@ -107,22 +107,6 @@ class HomeViewController: ContentViewController {
         }
         return timer
     }()
-    
-    private lazy var loadingAnimation: PeerConnectionAnimation = {
-        let view = PeerConnectionAnimation.forAutoLayout()
-        view.setDotCount(inside: false, count: 1, animated: false)
-        view.setDotCount(inside: true, count: 2, animated: false)
-        return view
-    }()
-    
-    private lazy var loadingLabel: UILabel = {
-        let view = UILabel.forAutoLayout()
-        view.textAlignment = .center
-        view.numberOfLines = 2
-        view.text = Text.loadingUpdates.text
-        view.textColor = UIColor.tint.default
-        return view
-    }()
 
     // MARK: Lifecycle
 
@@ -149,18 +133,6 @@ class HomeViewController: ContentViewController {
     }
 
     // MARK: Load and refresh
-    
-    private func addLoadingAnimation() {
-        Layout.center(self.loadingLabel, in: self.view)
-        Layout.centerHorizontally(self.loadingAnimation, in: self.view)
-        self.loadingAnimation.constrainSize(to: self.loadingAnimation.totalDiameter)
-        self.loadingAnimation.pinBottom(toTopOf: self.loadingLabel, constant: -20, activate: true)
-    }
-    
-    private func removeLoadingAnimation() {
-        self.loadingLabel.removeFromSuperview()
-        self.loadingAnimation.removeFromSuperview()
-    }
 
     private func load(animated: Bool = false) {
         Bots.current.refresh() {

--- a/Source/Controller/NotificationsViewController.swift
+++ b/Source/Controller/NotificationsViewController.swift
@@ -46,6 +46,7 @@ class NotificationsViewController: ContentViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         Layout.fill(view: self.view, with: self.tableView)
+        self.addLoadingAnimation()
         self.load()
     }
 
@@ -67,6 +68,7 @@ class NotificationsViewController: ContentViewController {
             [weak self] msgs, error in
             Log.optional(error)
             self?.update(with: msgs, animated: false)
+            self?.removeLoadingAnimation()
             self?.refreshControl.endRefreshing()
         }
     }


### PR DESCRIPTION
Problem: Nothing appears when first loading notifications and channels.

Solution: Add same loading graphic animation when loading the feed.