### PR TITLE
Fixes crash when opening the app from background

### DIFF
--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -55,15 +55,24 @@ class GoBot: Bot {
     // MARK: App Lifecycle
 
     func resume()  {
-        self.bot.dialSomePeers()
+        Thread.assertIsMainThread()
+        self.queue.async {
+            self.bot.dialSomePeers()
+        }
     }
 
     func suspend() {
-        self.bot.disconnectAll()
+        Thread.assertIsMainThread()
+        self.queue.async {
+            self.bot.disconnectAll()
+        }
     }
 
     func exit() {
-        self.bot.disconnectAll()
+        Thread.assertIsMainThread()
+        self.queue.async {
+            self.bot.disconnectAll()
+        }
     }
 
     // MARK: Login/Logout


### PR DESCRIPTION
Problem: I see some random crashes in GoBot code regarding exc_bad_access.
This kind of errors are hard to spot because are most of the time related
to multrithreading issues. I found that when opening the app from background
we call resume to gobot, but inside we don't use the gobot thread, this should
be causing memory issues a bit later.

Solution: Use the thread inside the appcycle functions.