### PR TITLE
Fix issue when attempting to background sync

### DIFF
--- a/Source/Bot/Bot+AppConfiguration.swift
+++ b/Source/Bot/Bot+AppConfiguration.swift
@@ -33,11 +33,10 @@ extension Bot {
     {
         guard configuration.canLaunch else { completion(false); return }
         guard let network = configuration.network else { completion(false); return }
-        guard let key = configuration.hmacKey else { completion(false); return }
         guard let secret = configuration.secret else { completion(false); return }
 
         Bots.current.login(network: network,
-                           hmacKey: key,
+                           hmacKey: configuration.hmacKey,
                            secret: secret)
         {
             error in


### PR DESCRIPTION
Problem: Bot is not logging in when syncing in the background.

Solution: Remove requirement to have a hmac key.