### PR TITLE
Sync bot when pulling down to refresh on the home screen

### DIFF
--- a/Source/Controller/HomeViewController.swift
+++ b/Source/Controller/HomeViewController.swift
@@ -174,6 +174,14 @@ class HomeViewController: ContentViewController {
         self.present(controller, animated: true, completion: nil)
     }
 
+    func syncAndRefresh(animated: Bool = false) {
+        Bots.current.sync { [weak self] (error, _, _) in
+            Log.optional(error)
+            CrashReporting.shared.reportIfNeeded(error: error)
+            self?.load(animated: animated)
+        }
+    }
+    
     func refresh() {
         self.load()
     }
@@ -199,7 +207,7 @@ class HomeViewController: ContentViewController {
 
     @objc func refreshControlValueChanged(control: UIRefreshControl) {
         control.beginRefreshing()
-        self.refresh()
+        self.syncAndRefresh()
     }
 
     @objc func newPostButtonTouchUpInside() {


### PR DESCRIPTION
Problem: When pulling down to refresh in the feed doesn't
triggers sync so that the user has to send the app to background
for that to happen.

Solution: Add sync when pulling down to refresh (but not when
loading the app the first time).