### PR TITLE
Release 0.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.18] - 2020-04-08
+### Added
+- Complete support of CommonMark (an unambiguous spec of Markdown)
+### Fixed
+- Minor bugfixes regarding the use of Scuttlebutt.
+
 ## [0.9.17] - 2020-04-06
 ### Added
 - Sync when pulling down to refresh on the feed.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.17</string>
+	<string>0.9.18</string>
 	<key>CFBundleVersion</key>
-	<string>186</string>
+	<string>189</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Added:
- Complete support of CommonMark (an unambiguous spec of Markdown)
Fixed:
- Minor bugfixes regarding the use of Scuttlebutt.