### PR TITLE
Decode unformatted links in posts

### DIFF
--- a/Source/Markdown/String+Markdown.swift
+++ b/Source/Markdown/String+Markdown.swift
@@ -18,19 +18,52 @@ extension String {
             let attributedString = try down.toAttributedString(.default,
                                                                styler: styler)
             let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
-            let hashtags = attributedString.string.hashtagsWithRanges()
-            for (hashtag, range) in hashtags.reversed() {
-                let attributedHashtag = attributedString.attributedSubstring(from: range)
-                let mutableAttributedHashtag = NSMutableAttributedString(attributedString: attributedHashtag)
-                styler.style(link: mutableAttributedHashtag, title: hashtag.string, url: hashtag.string)
-                mutableAttributedString.replaceCharacters(in: range, with: mutableAttributedHashtag)
-            }
-            
+            addHashtagsLinks(in: mutableAttributedString, styler: styler)
+            addUnformattedLinks(in: mutableAttributedString, styler: styler)
             return mutableAttributedString
         } catch let error {
             Log.optional(error)
             CrashReporting.shared.reportIfNeeded(error: error)
             return NSAttributedString(string: self)
+        }
+    }
+
+    func addHashtagsLinks(in mutableAttributedString: NSMutableAttributedString, styler: DownStyler) {
+        let hashtags = mutableAttributedString.string.hashtagsWithRanges()
+        for (hashtag, range) in hashtags.reversed() {
+            let attributedHashtag = mutableAttributedString.attributedSubstring(from: range)
+            let mutableAttributedHashtag = NSMutableAttributedString(attributedString: attributedHashtag)
+            styler.style(link: mutableAttributedHashtag, title: hashtag.string, url: hashtag.string)
+            mutableAttributedString.replaceCharacters(in: range, with: mutableAttributedHashtag)
+        }
+    }
+
+    func addUnformattedLinks(in mutableAttributedString: NSMutableAttributedString, styler: DownStyler) {
+        let string = mutableAttributedString.string
+        let types: NSTextCheckingResult.CheckingType = [.link]
+        let detector = try! NSDataDetector(types: types.rawValue)
+        let range = NSRange(location: 0, length: mutableAttributedString.length)
+        detector.enumerateMatches(in: string, options: [], range: range) { (result, _, _) in
+            guard let result = result else {
+                return
+            }
+            switch result.resultType {
+            case .link:
+                let url = result.url!
+                let range = result.range
+
+                let currentAttributes = mutableAttributedString.attributes(at: range.location, effectiveRange: nil)
+                guard !currentAttributes.keys.contains(.link) else {
+                    return
+                }
+
+                let attributedLink = mutableAttributedString.attributedSubstring(from: result.range)
+                let mutableAttributedLink = NSMutableAttributedString(attributedString: attributedLink)
+                styler.style(link: mutableAttributedLink, title: nil, url: url.absoluteString)
+                mutableAttributedString.replaceCharacters(in: range, with: mutableAttributedLink)
+            default:
+                return
+            }
         }
     }
     

--- a/UnitTests/MarkdownTests.swift
+++ b/UnitTests/MarkdownTests.swift
@@ -86,5 +86,32 @@ class MarkdownTests: XCTestCase {
         XCTAssertEqual(mentions[0].name, "!bang")
         XCTAssertEqual(mentions[0].link, "https://duckduckgo.com/bang")
     }
-    
+
+    func test_decodeLinkWithoutFormat() {
+        let markdown = "This is a link http://www.one.com without format"
+        let attributedString = markdown.decodeMarkdown()
+        let mentions = attributedString.mentions()
+        XCTAssertEqual(mentions.count, 1)
+        XCTAssertEqual(mentions[0].link, "http://www.one.com")
+    }
+
+    func test_decodeTwoDifferentLinks() {
+        let markdown = "This is a test for [one](http://www.one.com) link in markdown plus a http://www.second.com link not formatted."
+        let attributedString = markdown.decodeMarkdown()
+        let mentions = attributedString.mentions()
+        XCTAssertEqual(mentions.count, 2)
+        XCTAssertEqual(mentions[0].name, "one")
+        XCTAssertEqual(mentions[0].link, "http://www.one.com")
+        XCTAssertEqual(mentions[1].link, "http://www.second.com")
+    }
+
+    func test_decodeLinkWithUrlAsName() {
+        let markdown = "This is a test for [http://www.one.com](http://www.second.com) link in markdown"
+        let attributedString = markdown.decodeMarkdown()
+        let mentions = attributedString.mentions()
+        XCTAssertEqual(mentions.count, 1)
+        XCTAssertEqual(mentions[0].name, "http://www.one.com")
+        XCTAssertEqual(mentions[0].link, "http://www.second.com")
+    }
+
 }


### PR DESCRIPTION
Problem: User unaware of markdown format could just type a link
without paranthesis.

Solution: Detect those cases and display a link in the post.