### PR TITLE
removing the calls to take over the main thread on background opperat…

### DIFF
--- a/Source/App/AppController+Lifecycle.swift
+++ b/Source/App/AppController+Lifecycle.swift
@@ -18,7 +18,8 @@ extension AppController {
     }
 
     func relaunch() {
-        Caches.blobs.invalidate()
+        //blobs are immutable and we don't delete them, not reason to invalidate their cache.
+        //Caches.blobs.invalidate()
         self.launch()
     }
 

--- a/Source/Bot/Bot+Blobs.swift
+++ b/Source/Bot/Bot+Blobs.swift
@@ -13,7 +13,7 @@ extension Bot {
     func blobsAndDatas(for blobs: Blobs,
                        completion: @escaping (([(Blob, Data)]) -> Void))
     {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
 
         guard blobs.count > 0 else { completion([]) ; return }
         var datas: [(Blob, Data)] = []

--- a/Source/Bot/Bot+Publish.swift
+++ b/Source/Bot/Bot+Publish.swift
@@ -17,7 +17,7 @@ extension Bot {
                  with images: [UIImage] = [],
                  completion: @escaping PublishCompletion)
     {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
 
         // publish all images first
         self.prepare(images) {
@@ -43,7 +43,7 @@ extension Bot {
     func prepare(_ images: [UIImage],
                  completion: @escaping PublishBlobsCompletion)
     {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         if images.isEmpty { completion([], nil); return }
 
         var blobs = [Int: Blob]()

--- a/Source/Cache/AttributedStringCache.swift
+++ b/Source/Cache/AttributedStringCache.swift
@@ -17,7 +17,7 @@ class AttributedStringCache: DictionaryCache {
     func attributedString(for key: String,
                           markdown: String) -> NSAttributedString
     {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
 
         // cached value if possible
         if let string = self.item(for: key) as? NSAttributedString {
@@ -40,7 +40,7 @@ class AttributedStringCache: DictionaryCache {
 
     /// Invalidates the oldest items beyond the `maxNumberOfItems`.
     override func purge() {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         guard self.count > self.maxNumberOfItems else { return }
         let items = self.itemsSortedByDateAscending()
         let itemsToInvalidate = items[self.minNumberOfItems ..< items.endIndex]
@@ -74,7 +74,7 @@ class AttributedStringCache: DictionaryCache {
 
     /// The number of markdowns in the pre-fill queue.
     var prefillCount: Int {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         return self.array.count
     }
 
@@ -83,7 +83,7 @@ class AttributedStringCache: DictionaryCache {
     /// cancelled before new ones are executed.  If any of the markdowns already
     /// exist in the cache, they are filtered out first.
     func prefill(_ markdowns: [KeyMarkdown]) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         let filtered = markdowns.filter { self.item(for: $0.key) == nil }
         guard filtered.count > 0 else { return }
         self.array += filtered
@@ -117,14 +117,14 @@ class AttributedStringCache: DictionaryCache {
 
     /// Cancels pending markdowns by key.
     func cancel(markdownsWithKeys keys: [String]) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         guard self.array.count > 0 else { return }
         for key in keys { self.array.removeAll { $0.key == key } }
     }
 
     /// Cancels all pending markdown renders, except for the one in progress.
     func cancel() {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.array.removeAll()
     }
 }

--- a/Source/Cache/BlobCache.swift
+++ b/Source/Cache/BlobCache.swift
@@ -32,7 +32,7 @@ class BlobCache: DictionaryCache {
     /// Immediately returns the cached image for the identifier.  This will
     /// not request to load the image from the bot, use `image(for:completion)` instead.
     func image(for identifier: BlobIdentifier) -> UIImage? {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         return self.item(for: identifier) as? UIImage
     }
 
@@ -49,7 +49,7 @@ class BlobCache: DictionaryCache {
     func image(for identifier: BlobIdentifier,
                completion: @escaping UIImageCompletion) -> UIImageCompletionHandle?
     {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
 
         // returns the cached image immediately
         if let image = self.item(for: identifier) as? UIImage {
@@ -289,7 +289,7 @@ class BlobCache: DictionaryCache {
     }
 
     private func didLoadBlob(_ notification: Notification) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         guard let identifier = notification.blobIdentifier else { return }
         guard self.completions(for: identifier).isEmpty == false else { return }
         self.loadImage(for: identifier)

--- a/Source/Cache/DictionaryCache.swift
+++ b/Source/Cache/DictionaryCache.swift
@@ -13,12 +13,12 @@ class DictionaryCache: Cache {
     private var dictionary: [String: (Date, Any)] = [:]
 
     var count: Int {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         return self.dictionary.count
     }
 
     var estimatedBytes: Int {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         var bytes = 0
         self.dictionary.forEach {
             bytes += self.bytes(for: $0.value.1)
@@ -27,7 +27,7 @@ class DictionaryCache: Cache {
     }
 
     func bytes(for item: Any) -> Int {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         // subclasses should implement
         return 0
     }
@@ -36,14 +36,14 @@ class DictionaryCache: Cache {
     /// If the item is found, the current `TimeInterval` is updated for that item.
     /// This allows `purge()` to correctly clean up items.
     func item(for key: String) -> Any? {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         guard let (_, item) = self.dictionary[key] else { return nil }
         self.update(item, for: key)
         return item
     }
 
     func itemsSortedByDateAscending() -> [(key: String, value: (Date, Any))] {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         let items = self.dictionary.sorted {
             (first: (key: String, value: (Date, Any)), second: (key: String, value: (Date, Any))) in
             return first.value.0 < second.value.0
@@ -52,7 +52,7 @@ class DictionaryCache: Cache {
     }
 
     internal func update(_ item: Any, for key: String) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.dictionary[key] = (Date(), item)
     }
 
@@ -61,12 +61,12 @@ class DictionaryCache: Cache {
     }
 
     func invalidate() {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.dictionary.removeAll()
     }
 
     func invalidateItem(for key: String) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.dictionary.removeValue(forKey: key)
     }
 }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -742,6 +742,8 @@ class GoBot: Bot {
             let contactOrNilIfError = (error == nil ? contact : nil)
             completion(contactOrNilIfError, error)
         }
+        //resetting the in memory cache of follows
+        self.follows=[]
     }
 
     func unfollow(_ identity: Identity, completion: @escaping ContactCompletion) {
@@ -752,6 +754,8 @@ class GoBot: Bot {
             let contactOrNilIfError = (error == nil ? contact : nil)
             completion(contactOrNilIfError, error)
         }
+        //resetting the in memory cache of follows
+        self.follows=[]
     }
 
     func follows(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
@@ -866,6 +870,9 @@ class GoBot: Bot {
             completion(ref, nil)
             NotificationCenter.default.post(name: .didBlockUser, object: identity)
         }
+        //resetting the in memory cache of blocks
+        self.blocks=[]
+        self.anyBlocks=false
     }
 
     func unblock(_ identity: Identity, completion: @escaping PublishCompletion) {
@@ -886,6 +893,9 @@ class GoBot: Bot {
                 NotificationCenter.default.post(name: .didUnblockUser, object: identity)
             }
         }
+        //resetting the in memory cache of blocks
+        self.blocks=[]
+        self.anyBlocks=false
     }
 
     // MARK: Feeds

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -55,7 +55,7 @@ class GoBot: Bot {
     // MARK: App Lifecycle
 
     func resume()  {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             self.bot.dialSomePeers()
         }
@@ -78,7 +78,7 @@ class GoBot: Bot {
     // MARK: Login/Logout
     
     func createSecret(completion: SecretCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         
         guard let kp = ssbGenKey() else {
             completion(nil, GoBotError.unexpectedFault("createSecret failed"))
@@ -90,7 +90,7 @@ class GoBot: Bot {
     }
     
     func login(network: NetworkKey, hmacKey: HMACKey?, secret: Secret, completion: @escaping ErrorCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             var err: Error? = nil
             defer {
@@ -167,7 +167,7 @@ class GoBot: Bot {
     // MARK: Sync
     
     func knownPubs(completion: @escaping KnownPubsCompletion) {
-       Thread.assertIsMainThread()
+       //Thread.assertIsMainThread()
          self.queue.async {
             var err: Error? = nil
             var kps: [KnownPub] = []
@@ -292,7 +292,7 @@ class GoBot: Bot {
     // MARK: Invites
     
     func inviteRedeem(token: String, completion: @escaping ErrorCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             token.withGoString {
                 goStr in
@@ -311,7 +311,7 @@ class GoBot: Bot {
     private var lastPublishFireTime = DispatchTime.now()
 
     func publish(content: ContentCodable, completion: @escaping PublishCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             self.bot.publish(content) {
                 [weak self] key, error in
@@ -649,7 +649,7 @@ class GoBot: Bot {
     func data(for identifier: BlobIdentifier,
               completion: @escaping ((BlobIdentifier, Data?, Error?) -> Void))
     {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
 
         guard identifier.isValidIdentifier else {
             completion(identifier, nil, BotError.blobInvalidIdentifier)
@@ -690,7 +690,7 @@ class GoBot: Bot {
     var about: About? { return self._about }
 
     func about(completion: @escaping AboutCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         guard let user = self._identity else {
             completion(nil, BotError.notLoggedIn)
             return
@@ -699,7 +699,7 @@ class GoBot: Bot {
     }
     
     func about(identity: Identity, completion: @escaping AboutCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let a = try self.database.getAbout(for: identity)
@@ -714,7 +714,7 @@ class GoBot: Bot {
     }
 
     func abouts(identities: Identities, completion: @escaping AboutsCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             var abouts: [About] = []
             for identity in identities {
@@ -749,7 +749,7 @@ class GoBot: Bot {
     }
 
     func follows(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let follows = try self.database.getFollows(feed: identity)
@@ -762,7 +762,7 @@ class GoBot: Bot {
     }
     
     func followedBy(identity: Identity, completion: @escaping ContactsCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let follows: [Identity] = try self.database.followedBy(feed: identity)
@@ -775,7 +775,7 @@ class GoBot: Bot {
     }
     
     func friends(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let who = try self.database.getBidirectionalFollows(feed: identity)
@@ -787,7 +787,7 @@ class GoBot: Bot {
     }
     
     func blocks(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let who = try self.database.getBlocks(feed: identity)
@@ -803,7 +803,7 @@ class GoBot: Bot {
     }
     
     func blockedBy(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let who = try self.database.blockedBy(feed: identity)
@@ -866,7 +866,7 @@ class GoBot: Bot {
     // MARK: Feeds
 
     func recent(newer than: Date, count: Int, completion: @escaping FeedCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.recentPosts(newer: than, limit: count)
@@ -878,7 +878,7 @@ class GoBot: Bot {
     }
     
     func recent(older than: Date, count: Int, wantPrivate: Bool, completion: @escaping FeedCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.recentPosts(older: than, limit: count)
@@ -891,7 +891,7 @@ class GoBot: Bot {
     
     // old recent
     func recent(completion: @escaping FeedCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.recentPosts(limit: 200)
@@ -904,7 +904,7 @@ class GoBot: Bot {
 
     func thread(keyValue: KeyValue, completion: @escaping ThreadCompletion) {
         assert(keyValue.value.content.isPost)
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             if let rootKey = keyValue.value.content.post?.root {
                 do {
@@ -925,7 +925,7 @@ class GoBot: Bot {
     }
 
     func thread(rootKey: MessageIdentifier, completion: @escaping ThreadCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             self.internalThread(rootKey: rootKey, completion: completion)
         }
@@ -946,7 +946,7 @@ class GoBot: Bot {
     }
 
     func mentions(completion: @escaping FeedCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let messages = try self.database.mentions(limit: 1000)
@@ -959,7 +959,7 @@ class GoBot: Bot {
 
     // TODO consider a different form that returns a tuple of arrays
     func notifications(completion: @escaping FeedCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 /* TODO:
@@ -991,7 +991,7 @@ class GoBot: Bot {
     }
 
     func feed(identity: Identity, completion: @escaping FeedCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.feed(for: identity)
@@ -1005,7 +1005,7 @@ class GoBot: Bot {
     // MARK: Hashtags
 
     func hashtags(completion: @escaping HashtagsCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 var hashtags = try self.database.hashtags()
@@ -1018,7 +1018,7 @@ class GoBot: Bot {
     }
 
     func posts(with hashtag: Hashtag, completion: @escaping FeedCompletion) {
-        Thread.assertIsMainThread()
+        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let keyValues = try self.database.messagesForHashtag(name: hashtag.name)

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -84,8 +84,6 @@ class GoBot: Bot {
     // MARK: Login/Logout
     
     func createSecret(completion: SecretCompletion) {
-        //Thread.assertIsMainThread()
-        
         guard let kp = ssbGenKey() else {
             completion(nil, GoBotError.unexpectedFault("createSecret failed"))
             return
@@ -96,7 +94,6 @@ class GoBot: Bot {
     }
     
     func login(network: NetworkKey, hmacKey: HMACKey?, secret: Secret, completion: @escaping ErrorCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             var err: Error? = nil
             defer {
@@ -158,7 +155,6 @@ class GoBot: Bot {
     }
     
     func logout(completion: @escaping ErrorCompletion) {
-        Thread.assertIsMainThread()
         if self._identity == nil {
             DispatchQueue.main.async { completion(BotError.notLoggedIn) }
             return
@@ -173,7 +169,6 @@ class GoBot: Bot {
     // MARK: Sync
     
     func knownPubs(completion: @escaping KnownPubsCompletion) {
-       //Thread.assertIsMainThread()
          self.queue.async {
             var err: Error? = nil
             var kps: [KnownPub] = []
@@ -198,8 +193,6 @@ class GoBot: Bot {
     // some time later, this is a workaround until we can figure out how
     // to determine peer connection status and progress
     func sync(completion: @escaping SyncCompletion) {
-
-        //assert(Thread.isMainThread)
         guard self.bot.isRunning() else { completion(GoBotError.unexpectedFault("bot not started"), 0, 0); return }
         guard self._isSyncing == false else { completion(nil, 0, 0); return }
 
@@ -218,7 +211,6 @@ class GoBot: Bot {
     }
 
     func syncNotifications(completion: @escaping SyncCompletion) {
-        //assert(Thread.isMainThread)
         guard self.bot.isRunning() else { completion(GoBotError.unexpectedFault("bot not started"), 0, 0); return }
         guard self._isSyncing == false else { completion(nil, 0, 0); return }
 
@@ -298,7 +290,6 @@ class GoBot: Bot {
     // MARK: Invites
     
     func inviteRedeem(token: String, completion: @escaping ErrorCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             token.withGoString {
                 goStr in
@@ -317,7 +308,6 @@ class GoBot: Bot {
     private var lastPublishFireTime = DispatchTime.now()
 
     func publish(content: ContentCodable, completion: @escaping PublishCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             self.bot.publish(content) {
                 [weak self] key, error in
@@ -655,8 +645,6 @@ class GoBot: Bot {
     func data(for identifier: BlobIdentifier,
               completion: @escaping ((BlobIdentifier, Data?, Error?) -> Void))
     {
-        //Thread.assertIsMainThread()
-
         guard identifier.isValidIdentifier else {
             completion(identifier, nil, BotError.blobInvalidIdentifier)
             return
@@ -696,7 +684,6 @@ class GoBot: Bot {
     var about: About? { return self._about }
 
     func about(completion: @escaping AboutCompletion) {
-        //Thread.assertIsMainThread()
         guard let user = self._identity else {
             completion(nil, BotError.notLoggedIn)
             return
@@ -705,7 +692,6 @@ class GoBot: Bot {
     }
     
     func about(identity: Identity, completion: @escaping AboutCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let a = try self.database.getAbout(for: identity)
@@ -720,7 +706,6 @@ class GoBot: Bot {
     }
 
     func abouts(identities: Identities, completion: @escaping AboutsCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             var abouts: [About] = []
             for identity in identities {
@@ -759,7 +744,6 @@ class GoBot: Bot {
     }
 
     func follows(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        //Thread.assertIsMainThread()
         //this should be refactored, i gave up on being clever. - rabble
         if identity == self.identity {
             self.queue.async {
@@ -789,7 +773,6 @@ class GoBot: Bot {
     }
     
     func followedBy(identity: Identity, completion: @escaping ContactsCompletion) {
-        //Thread.assertIsMainThread()
         //this should be refactored, i gave up on being clever. - rabble
         if identity == self.identity {
             self.queue.async {
@@ -819,7 +802,6 @@ class GoBot: Bot {
     }
     
     func friends(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        //Thread.assertIsMainThread()
         if identity == self.identity {
             self.queue.async {
                 if self.friends.isEmpty {
@@ -846,7 +828,6 @@ class GoBot: Bot {
     }
     
     func blocks(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        //Thread.assertIsMainThread()
         if identity == self.identity {
             self.queue.async {
                 if self.blocks.isEmpty && self.anyBlocks  {
@@ -877,7 +858,6 @@ class GoBot: Bot {
     }
     
     func blockedBy(identity: FeedIdentifier, completion: @escaping ContactsCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let who = try self.database.blockedBy(feed: identity)
@@ -946,7 +926,6 @@ class GoBot: Bot {
     // MARK: Feeds
 
     func recent(newer than: Date, count: Int, completion: @escaping FeedCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.recentPosts(newer: than, limit: count)
@@ -958,7 +937,6 @@ class GoBot: Bot {
     }
     
     func recent(older than: Date, count: Int, wantPrivate: Bool, completion: @escaping FeedCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.recentPosts(older: than, limit: count)
@@ -971,7 +949,6 @@ class GoBot: Bot {
     
     // old recent
     func recent(completion: @escaping FeedCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.recentPosts(limit: 200)
@@ -984,7 +961,6 @@ class GoBot: Bot {
 
     func thread(keyValue: KeyValue, completion: @escaping ThreadCompletion) {
         assert(keyValue.value.content.isPost)
-        //Thread.assertIsMainThread()
         self.queue.async {
             if let rootKey = keyValue.value.content.post?.root {
                 do {
@@ -1005,7 +981,6 @@ class GoBot: Bot {
     }
 
     func thread(rootKey: MessageIdentifier, completion: @escaping ThreadCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             self.internalThread(rootKey: rootKey, completion: completion)
         }
@@ -1026,7 +1001,6 @@ class GoBot: Bot {
     }
 
     func mentions(completion: @escaping FeedCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let messages = try self.database.mentions(limit: 1000)
@@ -1039,7 +1013,6 @@ class GoBot: Bot {
 
     // TODO consider a different form that returns a tuple of arrays
     func notifications(completion: @escaping FeedCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 /* TODO:
@@ -1071,7 +1044,6 @@ class GoBot: Bot {
     }
 
     func feed(identity: Identity, completion: @escaping FeedCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let msgs = try self.database.feed(for: identity)
@@ -1085,7 +1057,6 @@ class GoBot: Bot {
     // MARK: Hashtags
 
     func hashtags(completion: @escaping HashtagsCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 var hashtags = try self.database.hashtags()
@@ -1098,7 +1069,6 @@ class GoBot: Bot {
     }
 
     func posts(with hashtag: Hashtag, completion: @escaping FeedCompletion) {
-        //Thread.assertIsMainThread()
         self.queue.async {
             do {
                 let keyValues = try self.database.messagesForHashtag(name: hashtag.name)

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -187,7 +187,7 @@ class ViewDatabase {
         try db.execute("PRAGMA journal_mode = WAL;")
         
         
-//        db.trace { print("\tSQL: \($0)") } // print all the statements
+        db.trace { print("\tSQL: \($0)") } // print all the statements
         
         if db.userVersion == 0 {
             let schemaV1url = Bundle.current.url(forResource: "ViewDatabaseSchema.sql", withExtension: nil)!


### PR DESCRIPTION
A bunch of the backend functions were waiting to get the main thread. This appears to been the cause  most of the delays in the app making it appear slow. This fixes it. It's worth double checking to see if this breaks things. The app feels tons faster. I've just commented out the assertIsMainThread for now. 