### PR TITLE
refactor mentions to use a single polymorphic table instead of two

### DIFF
--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -979,7 +979,7 @@ class GoBot: Bot {
                 let mentions = try self.database.mentions(limit: 50)
                 all.append(contentsOf: mentions)
 
-                let contacts: [KeyValue] = try self.database.followedBy(feed: self._identity!, limit: 50)
+                let contacts: [KeyValue] = try self.database.followedBy(feed: self._identity!, limit: 100)
                 all.append(contentsOf: contacts)
 
                 let sorted = all.sortedByDateDescending()

--- a/Source/GoBot/ViewDatabaseSchema.sql
+++ b/Source/GoBot/ViewDatabaseSchema.sql
@@ -197,6 +197,23 @@ CREATE TABLE branches (
     FOREIGN KEY ( branch )      REFERENCES messages( "msg_id" )
 );
 
+-- unified mentions
+CREATE TABLE mentions (
+msg_ref              integer not null,
+feed_id              integer,
+name                 text,
+link_id              integer,
+type                 integer not null,
+link                 text,
+FOREIGN KEY ( msg_ref ) REFERENCES messages( "msg_id" ),
+FOREIGN KEY ( feed_id ) REFERENCES authors( "id" )
+FOREIGN KEY ( link_id ) REFERENCES messages( "msg_id" )
+);
+CREATE INDEX mentions_refs on mentions (msg_ref);
+CREATE INDEX mentions_author on mentions (feed_id);
+
+
+
 
 -- posts can mention people
 CREATE TABLE mention_feed (

--- a/Source/Model/Mention.swift
+++ b/Source/Model/Mention.swift
@@ -36,7 +36,7 @@ struct Mention: Codable {
 //        self.type = nil
 //    }
     
-    init(link: Identifier, name: String? = nil , metadata: Blob.Metadata? = nil) {
+    init(link: Identifier, name: String? = nil, type: Int? = nil, metadata: Blob.Metadata? = nil) {
         self.link = link
         self.name = name
 


### PR DESCRIPTION
We're doing silly stuff with mentions and there is no reason why we need them in two tables in the database if we have them as a single model in swift and a single thing in ssb logs. 