### PR TITLE
Send GoBot logs

### DIFF
--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -47,6 +47,9 @@ protocol Bot {
     func suspend()
     func exit()
     
+    // MARK: Logs
+    var logFileUrls: [URL] { get }
+    
     // MARK: Identity
 
     var identity: Identity? { get }

--- a/Source/CrashReporting/BugsnagCrashReporting.swift
+++ b/Source/CrashReporting/BugsnagCrashReporting.swift
@@ -41,7 +41,14 @@ class BugsnagCrashReporting: CrashReportingService {
         guard configured else {
             return
         }
-        Bugsnag.notifyError(NSError(domain: "com.planetary.social", code: 408, userInfo: nil))
+        Bugsnag.notifyError(NSError(domain: "com.planetary.social", code: 408, userInfo: nil)) { report in
+            if let log = Log.fileUrls.first, let data = try? Data(contentsOf: log), let string = String(data: data, encoding: .utf8) {
+                report.addMetadata(["app": string], toTabWithName: "logs")
+            }
+            if let log = Bots.current.logFileUrls.first, let data = try? Data(contentsOf: log), let string = String(data: data, encoding: .utf8) {
+                report.addMetadata(["bot": string], toTabWithName: "logs")
+            }
+        }
     }
     
     func record(_ message: String) {
@@ -55,7 +62,14 @@ class BugsnagCrashReporting: CrashReportingService {
         guard configured, let error = error else {
             return
         }
-        Bugsnag.notifyError(error)
+        Bugsnag.notifyError(error) { report in
+            if let log = Log.fileUrls.first, let data = try? Data(contentsOf: log), let string = String(data: data, encoding: .utf8) {
+                report.addMetadata(["app": string], toTabWithName: "logs")
+            }
+            if let log = Bots.current.logFileUrls.first, let data = try? Data(contentsOf: log), let string = String(data: data, encoding: .utf8) {
+                report.addMetadata(["bot": string], toTabWithName: "logs")
+            }
+        }
     }
 
     func reportIfNeeded(error: Error?, metadata: [AnyHashable: Any]) {
@@ -64,6 +78,12 @@ class BugsnagCrashReporting: CrashReportingService {
         }
         Bugsnag.notifyError(error) { report in
             report.addMetadata(metadata, toTabWithName: "metadata")
+            if let log = Log.fileUrls.first, let data = try? Data(contentsOf: log), let string = String(data: data, encoding: .utf8) {
+                report.addMetadata(["app": string], toTabWithName: "logs")
+            }
+            if let log = Bots.current.logFileUrls.first, let data = try? Data(contentsOf: log), let string = String(data: data, encoding: .utf8) {
+                report.addMetadata(["bot": string], toTabWithName: "logs")
+            }
         }
     }
     

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -120,6 +120,7 @@ class FakeBot: Bot {
 
     let name = "FakeBot"
     let version = "1.0"
+    let logFileUrls: [URL] = []
     
     // MARK: Login
     private var _network: String?

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -35,6 +35,26 @@ class GoBot: Bot {
 
     private var _identity: Identity? = nil
     var identity: Identity? { return self._identity }
+    
+    var logFileUrls: [URL] {
+        let url = URL(fileURLWithPath: self.bot.currentRepoPath.appending("/debug"))
+        guard let urls = try? FileManager.default.contentsOfDirectory(at: url,
+                                                                      includingPropertiesForKeys: [URLResourceKey.creationDateKey],
+                                                                      options: .skipsHiddenFiles) else {
+                                                                        return []
+        }
+        return urls.sorted { (lhs, rhs) -> Bool in
+            let lhsCreationDate = try? lhs.resourceValues(forKeys: [.creationDateKey]).creationDate
+            let rhsCreationDate = try? rhs.resourceValues(forKeys: [.creationDateKey]).creationDate
+            if let lhsCreationDate = lhsCreationDate, let rhsCreationDate = rhsCreationDate {
+                return lhsCreationDate.compare(rhsCreationDate) == .orderedAscending
+            } else if lhsCreationDate == nil {
+                return false
+            } else {
+                return true
+            }
+        }
+    }
 
     private let queue: DispatchQueue
 

--- a/Source/Support/ZendeskSupport.swift
+++ b/Source/Support/ZendeskSupport.swift
@@ -60,6 +60,14 @@ class ZendeskSupport: SupportService {
         let reporter = reporter ?? Identity.notLoggedIn
         let config = RequestUiConfiguration()
         config.tags = tags + [reporter]
+        var attachments = [RequestAttachment]()
+        if let log = Log.fileUrls.first, let data = try? Data(contentsOf: log) {
+            attachments.append(RequestAttachment(filename: log.lastPathComponent, data: data, fileType: .plain))
+        }
+        if let log = Bots.current.logFileUrls.first, let data = try? Data(contentsOf: log) {
+            attachments.append(RequestAttachment(filename: log.lastPathComponent, data: data, fileType: .plain))
+        }
+        config.fileAttachments = attachments
         return RequestUi.buildRequestList(with: [config])
     }
     
@@ -167,9 +175,13 @@ extension ZendeskSupport {
     private func _newTicketViewController(from reporter: Identity? = nil,
                                           subject: SupportSubject = .bugReport,
                                           attachments: [RequestAttachment] = [],
-                                          tags: [String] = []) -> UIViewController? {
-        guard configured else {
-            return nil
+                                          tags: [String] = []) -> UIViewController {
+        var attachments = attachments
+        if let log = Log.fileUrls.first, let data = try? Data(contentsOf: log) {
+            attachments.append(RequestAttachment(filename: log.lastPathComponent, data: data, fileType: .plain))
+        }
+        if let log = Bots.current.logFileUrls.first, let data = try? Data(contentsOf: log) {
+            attachments.append(RequestAttachment(filename: log.lastPathComponent, data: data, fileType: .plain))
         }
         let reporter = reporter ?? Identity.notLoggedIn
         let config = RequestUiConfiguration()


### PR DESCRIPTION
Problem: GoBot logs are not used.

Solution: Attach GoBot logs to Share logs in Debug, to Bugsnag crash reports
and to Zendesk tickets.