### PR TITLE
Fix crash in notifications' sync

### DIFF
--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -68,7 +68,7 @@ protocol Bot {
     func sync(queue: DispatchQueue, completion: @escaping SyncCompletion)
 
     // TODO: this is temporary until live-streaming is deployed on the pubs
-    func syncNotifications(completion: @escaping SyncCompletion)
+    func syncNotifications(queue: DispatchQueue, completion: @escaping SyncCompletion)
 
     // MARK: Refresh
 

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -174,8 +174,8 @@ class FakeBot: Bot {
         }
     }
     
-    func syncNotifications(completion: @escaping SyncCompletion) {
-        self.sync(queue: .main, completion: completion)
+    func syncNotifications(queue: DispatchQueue, completion: @escaping SyncCompletion) {
+        self.sync(queue: queue, completion: completion)
       }
 
     // MARK: Refresh


### PR DESCRIPTION
Problem: App crashes when receiving a notification in the background
because sync asserts that is being run in the main thread.

Solution: Remove the assertion and make syncNotifications work
similar to sync.