### PR TITLE
hotfix duplication

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -1614,12 +1614,12 @@
 				2334D04421F7786600AB28E2 /* GoBotInternal.swift */,
 				531D0A1221EACC0A008E40A8 /* GoBotViewController.swift */,
 				233A8F89220138F600CE01CE /* ViewDatabase.swift */,
+				236761582450681800A97140 /* ViewDatabase+Pagination.swift */,
 				231314CB2237ACDB0000C989 /* ViewDatabaseSchema.sql */,
 				0ACE91A1243D740C00EFB4E9 /* GoBotError.swift */,
 				0ACE91A5243D742700EFB4E9 /* GoBotError+LocalizedError.swift */,
 				0ACE91A9243D74A900EFB4E9 /* ViewDatabaseError.swift */,
 				0ACE91AD243D74D200EFB4E9 /* ViewDatabaseError+LocalizedError.swift */,
-				236761582450681800A97140 /* ViewDatabase+Pagination.swift */,
 			);
 			path = GoBot;
 			sourceTree = "<group>";

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -966,6 +966,7 @@ class ViewDatabase {
             .filter(colMsgType == ContentType.post.rawValue || colMsgType == ContentType.vote.rawValue )
             .filter(colRoot == msgID)
             .filter(colHidden == false)
+            .order(colClaimedAt.asc)
         
         // making this a two-pass query until i can figure out how to dynamlicly join based on type
 

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1603,7 +1603,7 @@ class ViewDatabase {
                     ))
                 } else {
                     do {
-                        try db.run(self.msgs.insert(or: .replace,
+                        try db.run(self.msgs.insert(
                             colRXseq <- lastRxSeq,
                             colMessageID <- msgKeyID,
                             colAuthorID <- authorID,
@@ -1612,6 +1612,17 @@ class ViewDatabase {
                             colReceivedAt <- msg.timestamp,
                             colClaimedAt <- claimed
                         ))
+                    } catch Result.error(let errMsg, let errCode, _) {
+                        // this is _just_ hear because of a fetch-duplication bug in go-ssb
+                        // the constraints on the table are for uniquness:
+                        // 1) message key/id
+                        // 2) (author,sequence no)
+                        // while (1) always means duplicate message (2) can also mean fork
+                        // the problem is, SQLITE can throw (1) or (2) and we cant keep them apart here...
+                        if errCode == SQLITE_CONSTRAINT {
+                            continue // ignore this message and go to the next
+                        }
+                        throw GoBotError.unexpectedFault("ViewDB/INSERT message error \(errCode): \(errMsg)")
                     } catch {
                         throw error
                     }

--- a/UnitTests/FeedFill.swift
+++ b/UnitTests/FeedFill.swift
@@ -64,7 +64,7 @@ class ViewDatabaseTest: XCTestCase {
     
     var tmpURL :URL = URL(string: "unset")!
     var vdb = ViewDatabase()
-    let expMsgCount = 82
+    let expMsgCount = 81
 
     override func setUp() {
         let data = self.data(for: "Feed_example.json")
@@ -90,7 +90,8 @@ class ViewDatabaseTest: XCTestCase {
             // get test messages from JSON
             let msgs = try JSONDecoder().decode([KeyValue].self, from: data)
             XCTAssertNotNil(msgs)
-            XCTAssertEqual(msgs.count, expMsgCount)
+            // +1 to fake-cause the duplication bug
+            XCTAssertEqual(msgs.count, expMsgCount+1)
             
             // put them all in
             try vdb.fillMessages(msgs: msgs)
@@ -107,7 +108,7 @@ class ViewDatabaseTest: XCTestCase {
         do {
             // find them all
             let stats = try self.vdb.stats()
-            XCTAssertEqual(stats[.messages], expMsgCount-8) // 8 tag messaes from old test data (TODO better test data creation)
+            XCTAssertEqual(stats[.messages], expMsgCount-8) // 8 tag messages from old test data (TODO better test data creation)
             XCTAssertEqual(stats[.authors], 6)
             XCTAssertEqual(stats[.abouts], 6)
             XCTAssertEqual(stats[.abouts], stats[.authors]) // authors with missing abouts will not be shown

--- a/UnitTests/FeedFill.swift
+++ b/UnitTests/FeedFill.swift
@@ -64,7 +64,7 @@ class ViewDatabaseTest: XCTestCase {
     
     var tmpURL :URL = URL(string: "unset")!
     var vdb = ViewDatabase()
-    let expMsgCount = 81
+    let expMsgCount = 82
 
     override func setUp() {
         let data = self.data(for: "Feed_example.json")

--- a/UnitTests/Feed_example.json
+++ b/UnitTests/Feed_example.json
@@ -1625,5 +1625,26 @@
     },
     "timestamp": 1568971583834,
     "ReceiveLogSeq": 80
+  },
+  {
+    "key": "%DZ764OpJ08EBTN191nxs5WdtWnY4/I4Q+Humk50sdBI=.sha256",
+    "value": {
+      "previous": "%PfX2TNch9Z1/WR0nHV7V0lf164XOElOanjn3KG3Dets=.sha256",
+      "sequence": 13,
+      "author": "@3cEmxKx9ScNK8Pd1yz0qh5A2URzIbL7+VvpjfETU050=.ed25519",
+      "timestamp": 1568971583833,
+      "hash": "sha256",
+      "content": {
+        "hashtags": [
+          "extag2",
+          "extag3"
+        ],
+        "text": "hashtags test post 2",
+        "type": "post"
+      },
+      "signature": "PmMrRQgBtYpAbUOZxWOF6bs29GLxarpqLtwSeToLn6g1GjP+yxUGwXiPS+1ULYlZa2kIuv6C4Jn8Cg2yPFAdAQ==.sig.ed25519"
+    },
+    "timestamp": 1568971583835,
+    "ReceiveLogSeq": 81
   }
 ]

--- a/UnitTests/GoBotTests.swift
+++ b/UnitTests/GoBotTests.swift
@@ -673,7 +673,7 @@ class GoBotTests: XCTestCase {
         let orangePixel = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==",
                                options: .ignoreUnknownCharacters)!
         ex = self.expectation(description: "Store blob")
-        GoBotTests.shared.store(data: orangePixel, for: ref) { (error) in
+        GoBotTests.shared.store(data: orangePixel, for: ref) { _, error in
             XCTAssertNil(error)
             ex.fulfill()
         }


### PR DESCRIPTION
This reverts PR #117. Just replacing it in the messages table meant that
the the more specialzed messages (viewdb L1631 ff) were still inserted.