### PR TITLE
fixing amanda's request that we use ❤️&💔

### DIFF
--- a/Source/UI/PostCellView.swift
+++ b/Source/UI/PostCellView.swift
@@ -195,9 +195,9 @@ class PostCellView: KeyValueView {
         if let vote = keyValue.value.content.vote {
             let expression: String
             if vote.vote.value > 0 {
-                expression = "👍"
+                expression = "❤️"
             } else {
-                expression = "👎"
+                expression = "💔"
             }
             
             self.fullPostText = NSAttributedString(string: expression)


### PR DESCRIPTION
Our icon for liking is a heart, but we don't display it that way, instead we display thumbs up / down. So it's fixed, now we use ❤️&💔