### PR TITLE
Don't fail when redeeming invite to a pub that already follows back

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,6 @@ jobs:
         VerseDirectoryAPIToken: nil
         VerseBlobToken: nil
     - name: Build
-      run: set -o pipefail && xcodebuild build-for-testing -workspace Planetary.xcworkspace -scheme UnitTests -destination "platform=iOS Simulator,name=iPhone 11,OS=13.5" | xcpretty
+      run: set -o pipefail && xcodebuild build-for-testing -workspace Planetary.xcworkspace -scheme UnitTests -destination "platform=iOS Simulator,name=iPhone 11,OS=13.6" | xcpretty
     - name: Test
-      run: set -o pipefail && xcodebuild test-without-building -workspace Planetary.xcworkspace -scheme UnitTests -destination "platform=iOS Simulator,name=iPhone 11,OS=13.5" | xcpretty
+      run: set -o pipefail && xcodebuild test-without-building -workspace Planetary.xcworkspace -scheme UnitTests -destination "platform=iOS Simulator,name=iPhone 11,OS=13.6" | xcpretty

--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -432,7 +432,7 @@ func ssbInviteAccept(token string) bool {
 	}
 
 	stamp := time.Now().Unix()
-	_, err = viewDB.Exec(`INSERT INTO addresses (about_id, address, redeemed) VALUES (?,?)`, peerID, tok.Address.String(), stamp)
+	_, err = viewDB.Exec(`INSERT INTO addresses (about_id, address, redeemed) VALUES (?,?,?)`, peerID, tok.Address.String(), stamp)
 	if err != nil {
 		retErr = errors.Wrap(err, "insert new pub into addresses failed")
 		return false

--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -413,7 +413,8 @@ func ssbInviteAccept(token string) bool {
 	ctx, cancel := context.WithCancel(longCtx)
 	err = invite.Redeem(ctx, tok, sbot.KeyPair.Id)
 	defer cancel()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "already following") {
+		// XXX: Don't fail immediatelly if the pub is already following our feed.
 		retErr = err
 		return false
 	}
@@ -430,7 +431,8 @@ func ssbInviteAccept(token string) bool {
 		return false
 	}
 
-	_, err = viewDB.Exec(`INSERT INTO addresses (about_id, address) VALUES (?,?)`, peerID, tok.Address.String())
+	stamp := time.Now().Unix()
+	_, err = viewDB.Exec(`INSERT INTO addresses (about_id, address, redeemed) VALUES (?,?)`, peerID, tok.Address.String(), stamp)
 	if err != nil {
 		retErr = errors.Wrap(err, "insert new pub into addresses failed")
 		return false

--- a/go-ssb-bindings/ctrl.go
+++ b/go-ssb-bindings/ctrl.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"runtime"
 	"time"
+    "strings"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"


### PR DESCRIPTION
It will prevent autofollow of planetary pubs from failing, by allowing the redeem
process to complete even if the pub's response will be the "already following" error.

Work in progress, tests may fail.