### PR TITLE
Basic sentiment analysis

### DIFF
--- a/Source/Classification/SentimentAnalysis.swift
+++ b/Source/Classification/SentimentAnalysis.swift
@@ -1,0 +1,38 @@
+import NaturalLanguage
+
+/// Detect positive and negative message by tagging text with its sentiment score.
+
+public class SentimentAnalysis {
+
+    ///
+
+    public var message: String { return tagger.string }
+
+    ///
+
+    public let unit: NLTokenUnit
+
+    ///
+
+    private let tagger = NLTagger(tagSchemes: [.sentimentScore])
+
+    ///
+
+    public init(of message: String, being unit: NLTokenUnit) {
+        self.tagger.string = message
+        self.unit = unit
+    }
+
+    /// Get the sentiment score of the message.
+    ///
+    /// - Note: Supports 7 languages: English, French, Italian, German, Spanish, Portuguese, and Simplified Chinese.
+    ///
+    /// - Returns: The score as a floating-point number between -1 and 1, if possible to detect; otherwise `nil`.
+    ///
+
+    public var detectedScore: Float? {
+        let (score, _) = tagger.tag(at: message.startIndex, unit: unit, scheme: .sentimentScore)
+        return score?.rawValue
+    }
+
+}

--- a/UnitTests/SentimentAnalysisTests.swift
+++ b/UnitTests/SentimentAnalysisTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+class SentimentAnalysisTests: XCTestCase {
+
+    func test_positiveScore() {
+        let message = "It is always the simple that produces the marvelous."
+        // by Amelia E. Barr
+
+        let sentiment = SentimentAnalysis(of: message, being: .sentence)
+        XCAssertGreaterThan(sentiment.detectedScore, 0)
+    }
+
+    func test_negativeScore() {
+        let message = [
+            "You're going to pay a price for every bloody thing you do and everything you don't do."
+            "You don't get to choose to not pay a price."
+            "You get to choose which poison you're going to take."
+            "That's it."
+        ].joined(separator: " ")
+        // by Jordan B. Peterson
+
+        let sentiment = SentimentAnalysis(of: message, being: .paragraph)
+        XCAssertLowerThan(sentiment.detectedScore, 0)
+    }
+}


### PR DESCRIPTION
Work in Progress.

Using the Apple's Natural Language framework, we have access to the simple sentiment spectrum score. It's something.

@martindsq How would approach integrating it? Note, this thing is really fast, we could either do it in the background for all the messages, or on the fly (maybe also in the background), only for the messages to be displayed.

@Chardot Design ideas? What we have is a score between -1 and 1, representing either negative or positive interpretation. My first thought would be to squash it into ranges presented as sentiment emoji, or maybe some other kind of distinguished "sentiment" badges. Can't wait to see what are you gonna come up with ^w^.

Other considerations:

- We might want to let the users opt in/out for that feature.
- Displaying live sentiment while typing a message is also something we might wanna look into - as a way of helping people to become more aware of what they post.