### PR TITLE
Add Markdown preview during post creation

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		1B5DB7D024AE5C8E008DCB81 /* FollowerTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5DB7CF24AE5C8E008DCB81 /* FollowerTableViewController.swift */; };
 		1B5DB7D224AE5F7F008DCB81 /* FollowingTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5DB7D124AE5F7E008DCB81 /* FollowingTableViewController.swift */; };
 		1BA1FECE2432805C00FBD5E5 /* Identity+Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA1FECD2432805C00FBD5E5 /* Identity+Link.swift */; };
+		1FFCEC6025646D12007BC13A /* PostTextEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFCEC5F25646D12007BC13A /* PostTextEditorView.swift */; };
 		230242892372C8870091BBCA /* NSNotification+Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B6A0D23728049008C248E /* NSNotification+Bot.swift */; };
 		2302428A2372C88C0091BBCA /* NSNotification+Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535B6A0D23728049008C248E /* NSNotification+Bot.swift */; };
 		230F4FD222F8729700F93B14 /* TestAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230F4FD122F8729700F93B14 /* TestAPI.swift */; };
@@ -865,6 +866,7 @@
 		1B5DB7CF24AE5C8E008DCB81 /* FollowerTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowerTableViewController.swift; sourceTree = "<group>"; };
 		1B5DB7D124AE5F7E008DCB81 /* FollowingTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowingTableViewController.swift; sourceTree = "<group>"; };
 		1BA1FECD2432805C00FBD5E5 /* Identity+Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Identity+Link.swift"; sourceTree = "<group>"; };
+		1FFCEC5F25646D12007BC13A /* PostTextEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTextEditorView.swift; sourceTree = "<group>"; };
 		205F056E32449189B64633F4 /* Pods-Planetary-UITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Planetary-UITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Planetary-UITests/Pods-Planetary-UITests.release.xcconfig"; sourceTree = "<group>"; };
 		230F4FD122F8729700F93B14 /* TestAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAPI.swift; sourceTree = "<group>"; };
 		231314CB2237ACDB0000C989 /* ViewDatabaseSchema.sql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ViewDatabaseSchema.sql; sourceTree = "<group>"; };
@@ -1917,6 +1919,7 @@
 				535754FC22694A4C002A6989 /* PostCellView.swift */,
 				8D8A7B18231995670087895B /* PostHeaderView.swift */,
 				531B92C322CEAD25005D5255 /* PostReplyView.swift */,
+				1FFCEC5F25646D12007BC13A /* PostTextEditorView.swift */,
 				539FD4CA22C586CC005A4DF2 /* ReplyTextView.swift */,
 				536255D723AB16E8001007D0 /* SnowView.swift */,
 				8DD985D12329B94600FA2F1A /* ThreadInteractionView.swift */,
@@ -3168,6 +3171,7 @@
 				0ACE919E243D734B00EFB4E9 /* BotError+LocalizedError.swift in Sources */,
 				533F4051225E9E010060B4B9 /* DebugUIViewController.swift in Sources */,
 				53AD3FD92270FF33005228F9 /* UITableView+TableHeaderView.swift in Sources */,
+				1FFCEC6025646D12007BC13A /* PostTextEditorView.swift in Sources */,
 				533EDBEB2385F8B6008B3565 /* DictionaryCache.swift in Sources */,
 				535754F42268E248002A6989 /* ContentType.swift in Sources */,
 				0A674A29253F3C4400698CF7 /* Draft.swift in Sources */,

--- a/Source/Controller/NewPostViewController.swift
+++ b/Source/Controller/NewPostViewController.swift
@@ -86,6 +86,7 @@ class NewPostViewController: ContentViewController {
     private func addActions() {
         self.buttonsView.photoButton.addTarget(self, action: #selector(photoButtonTouchUpInside), for: .touchUpInside)
 
+        self.buttonsView.previewButton.action = didPressPreviewButton
         self.buttonsView.postButton.action = didPressPostButton
     }
 
@@ -96,6 +97,12 @@ class NewPostViewController: ContentViewController {
             if let image = image { self?.galleryView.add(image) }
             self?.imagePicker.dismiss()
         }
+    }
+
+    func didPressPreviewButton() {
+        Analytics.shared.trackDidTapButton(buttonName: "preview")
+        self.textView.previewActive = !self.textView.previewActive
+        self.buttonsView.previewButton.isSelected = self.textView.previewActive
     }
 
     func didPressPostButton() {
@@ -144,12 +151,14 @@ class NewPostViewController: ContentViewController {
         AppController.shared.showProgress()
         self.buttonsView.photoButton.isEnabled = false
         self.buttonsView.postButton.isEnabled = false
+        self.buttonsView.previewButton.isEnabled = false
     }
 
     private func lookReady() {
         AppController.shared.hideProgress()
         self.buttonsView.photoButton.isEnabled = true
         self.buttonsView.postButton.isEnabled = true
+        self.buttonsView.previewButton.isEnabled = true
     }   
 }
 

--- a/Source/Controller/NewPostViewController.swift
+++ b/Source/Controller/NewPostViewController.swift
@@ -85,8 +85,7 @@ class NewPostViewController: ContentViewController {
 
     private func addActions() {
         self.buttonsView.photoButton.addTarget(self, action: #selector(photoButtonTouchUpInside), for: .touchUpInside)
-
-        self.buttonsView.previewButton.action = didPressPreviewButton
+        self.buttonsView.previewToggle.addTarget(self, action: #selector(previewToggled), for: .valueChanged)
         self.buttonsView.postButton.action = didPressPostButton
     }
 
@@ -99,10 +98,9 @@ class NewPostViewController: ContentViewController {
         }
     }
 
-    func didPressPreviewButton() {
+    @objc private func previewToggled() {
         Analytics.shared.trackDidTapButton(buttonName: "preview")
-        self.textView.previewActive = !self.textView.previewActive
-        self.buttonsView.previewButton.isSelected = self.textView.previewActive
+        self.textView.previewActive = self.buttonsView.previewToggle.isOn
     }
 
     func didPressPostButton() {

--- a/Source/Controller/NewPostViewController.swift
+++ b/Source/Controller/NewPostViewController.swift
@@ -149,14 +149,14 @@ class NewPostViewController: ContentViewController {
         AppController.shared.showProgress()
         self.buttonsView.photoButton.isEnabled = false
         self.buttonsView.postButton.isEnabled = false
-        self.buttonsView.previewButton.isEnabled = false
+        self.buttonsView.previewToggle.isEnabled = false
     }
 
     private func lookReady() {
         AppController.shared.hideProgress()
         self.buttonsView.photoButton.isEnabled = true
         self.buttonsView.postButton.isEnabled = true
-        self.buttonsView.previewButton.isEnabled = true
+        self.buttonsView.previewToggle.isEnabled = true
     }   
 }
 

--- a/Source/Controller/NewPostViewController.swift
+++ b/Source/Controller/NewPostViewController.swift
@@ -72,7 +72,7 @@ class NewPostViewController: ContentViewController {
     override func constrainSubviews() {
         super.constrainSubviews()
 
-        Layout.fillTop(of: self.contentView, with: self.textView, insets: UIEdgeInsets.default)
+        Layout.fillTop(of: self.contentView, with: self.textView)
 
         Layout.fillSouth(of: self.textView, with: self.galleryView)
 

--- a/Source/Controller/ThreadViewController.swift
+++ b/Source/Controller/ThreadViewController.swift
@@ -112,7 +112,7 @@ class ThreadViewController: ContentViewController {
         view.photoButton.addTarget(self, action: #selector(photoButtonTouchUpInside), for: .touchUpInside)
         view.postButton.setText(.postReply)
         view.postButton.action = didPressPostButton
-        view.previewButton.action = didPressPreviewButton
+        view.previewToggle.addTarget(self, action: #selector(didPressPreviewToggle), for: .valueChanged)
         view.backgroundColor = .cardBackground
         return view
     }()
@@ -347,10 +347,9 @@ class ThreadViewController: ContentViewController {
         }
     }
     
-    func didPressPreviewButton() {
+    @objc func didPressPreviewToggle() {
         Analytics.shared.trackDidTapButton(buttonName: "preview")
-        self.replyTextView.previewActive = !self.replyTextView.previewActive
-        self.buttonsView.previewButton.isSelected = self.replyTextView.previewActive
+        self.replyTextView.previewActive = self.buttonsView.previewToggle.isOn
         self.buttonsView.maximize(duration: 0)
     }
     

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -152,7 +152,7 @@ enum Text: String, Localizable, CaseIterable {
     case pasteAddress = "Token"
     
     case refresh = "Refresh"
-    case markdownSupported = "Markdown supported"
+    case markdownSupported = "Markdown preview"
 }
 
 // MARK:- ImagePicker

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -66,6 +66,7 @@ enum Text: String, Localizable, CaseIterable {
     case loadingUpdates = "Planetary is searching for updates\non the peer to peer decentralized web."
 
     case post = "Post"
+    case preview = "Preview"
     case newPost = "New Post"
     case deletePost = "Delete this post"
     case editPost = "Edit this post"

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -34,6 +34,7 @@
 "Text.analyticsMessage" = "We would like to capture anonymized data about your use of the app - and crash reports when something goes wrong - so we can make the application better.";
 "Text.loadingUpdates" = "Planetary is searching for updates\non the peer to peer decentralized web.";
 "Text.post" = "Post";
+"Text.preview" = "Preview";
 "Text.newPost" = "New Post";
 "Text.deletePost" = "Delete this post";
 "Text.editPost" = "Edit this post";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -101,7 +101,7 @@
 "Text.refresh" = "Refresh";
 "Text.markdownSupported" = "Markdown preview";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each others content or be able to contact each other.";
+"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";
 "Blocking.blockedUsers" = "Blocked Users";
 "Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
@@ -144,7 +144,7 @@
 "Onboarding.chooseProfileImage" = "Choose a\nprofile image";
 "Onboarding.changePhoto" = "Change photo";
 "Onboarding.confirmPhoto" = "Yes, that's good!";
-"Onboarding.startOver" = "Start-Over";
+"Onboarding.startOver" = "Start Over";
 "Onboarding.contactsHint" = "We one-way encrypt this data so we can never access it directly.";
 "Onboarding.connect" = "Connect away!";
 "Onboarding.notNow" = "Not now";
@@ -156,8 +156,8 @@
 "Onboarding.earlyAccess" = "This app is at an early stage. We've been focusing our time on the foundations, so there are gaps and rough bits in the UI. Bear with us!";
 "Onboarding.iUnderstand" = "Yes, I understand";
 "Onboarding.somethingWentWrong" = "Oh no! Something went wrong!";
-"Onboarding.errorRetryMessage" = "This is not your fault, we messed something up. You can try again or start-over, and please come and tell one of us about it.";
-"Onboarding.resumeRetryMessage" = "This is not your fault, we messed something up. If some cases, it may mean your device cannot reach the network, and trying again later might help.";
+"Onboarding.errorRetryMessage" = "This is not your fault, we messed something up. You can try again or start over, and please come and tell one of us about it.";
+"Onboarding.resumeRetryMessage" = "This is not your fault, we messed something up. In some cases, it may mean your device cannot reach the network, and trying again later might help.";
 "Onboarding.backupHint" = "Planetary does not use passwords - you have a secret key that you need to keep safe. If you can, you should back it up. Note: this feature is still a work in progress.";
 "Onboarding.backUp" = "Yes, back up my identity";
 "Onboarding.bioHint" = "Don't worry too much about what you say, you can change it later.";
@@ -213,7 +213,7 @@
 
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
-"Debug.debugFooter" = "This is where we let you shot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";
@@ -227,7 +227,7 @@
 "Post.many" = "posts";
 
 "Report.somebody" = "Somebody";
-"Report.feedFollowed" = "%@ is started following you";
+"Report.feedFollowed" = "%@ started following you";
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -99,7 +99,7 @@
 "Text.redeemInvitation" = "Redeem an invitation";
 "Text.pasteAddress" = "Token";
 "Text.refresh" = "Refresh";
-"Text.markdownSupported" = "Markdown supported";
+"Text.markdownSupported" = "Markdown preview";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each others content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/UI/PostButtonsView.swift
+++ b/Source/UI/PostButtonsView.swift
@@ -82,6 +82,7 @@ class PostButtonsView: UIView {
         UIView.animate(withDuration: duration) {
             self.photoButton.alpha = 0
             self.postButton.alpha = 0
+            self.previewButton.alpha = 0
             self.markdownNoticeLabel.alpha = 0
             self.heightConstraint?.constant = 0
         }
@@ -91,6 +92,7 @@ class PostButtonsView: UIView {
         UIView.animate(withDuration: duration) {
             self.photoButton.alpha = 1
             self.postButton.alpha = 1
+            self.previewButton.alpha = 1
             self.markdownNoticeLabel.alpha = 1
             self.heightConstraint?.constant = Self.viewHeight
         }

--- a/Source/UI/PostButtonsView.swift
+++ b/Source/UI/PostButtonsView.swift
@@ -29,6 +29,14 @@ class PostButtonsView: UIView {
         return label
     }()
 
+    let previewButton: PillButton = {
+        let button = PillButton()
+        button.setTitle(.preview)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .medium)
+        button.height = 32
+        return button
+    }()
+
     let postButton: PillButton = {
         let button = PillButton()
         button.setTitle(.post)
@@ -53,14 +61,15 @@ class PostButtonsView: UIView {
         self.photoButton.pinLeftToSuperview(constant: Layout.horizontalSpacing)
         self.photoButton.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
         self.photoButton.constrainSize(to: size)
-        
-        self.addSubview(self.markdownNoticeLabel)
-        self.markdownNoticeLabel.leadingAnchor.constraint(equalTo: self.photoButton.trailingAnchor, constant: 8).isActive = true
-        self.markdownNoticeLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
 
         self.addSubview(self.postButton)
         self.postButton.pinRightToSuperview(constant: -Layout.horizontalSpacing)
         self.postButton.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+
+        self.addSubview(self.previewButton)
+        self.previewButton.trailingAnchor.constraint(equalTo: self.postButton.leadingAnchor,
+                                                     constant: -Layout.horizontalSpacing).isActive = true
+        self.previewButton.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
     }
 
     // MARK: Animations

--- a/Source/UI/PostButtonsView.swift
+++ b/Source/UI/PostButtonsView.swift
@@ -33,6 +33,7 @@ class PostButtonsView: UIView {
         let toggle = UISwitch()
         toggle.translatesAutoresizingMaskIntoConstraints = false
         toggle.tintColor = UIColor.tint.default
+        toggle.onTintColor = UIColor.tint.default
         return toggle
     }()
 

--- a/Source/UI/PostButtonsView.swift
+++ b/Source/UI/PostButtonsView.swift
@@ -82,7 +82,7 @@ class PostButtonsView: UIView {
         UIView.animate(withDuration: duration) {
             self.photoButton.alpha = 0
             self.postButton.alpha = 0
-            self.previewButton.alpha = 0
+            self.previewToggle.alpha = 0
             self.markdownNoticeLabel.alpha = 0
             self.heightConstraint?.constant = 0
         }
@@ -92,7 +92,7 @@ class PostButtonsView: UIView {
         UIView.animate(withDuration: duration) {
             self.photoButton.alpha = 1
             self.postButton.alpha = 1
-            self.previewButton.alpha = 1
+            self.previewToggle.alpha = 1
             self.markdownNoticeLabel.alpha = 1
             self.heightConstraint?.constant = Self.viewHeight
         }

--- a/Source/UI/PostButtonsView.swift
+++ b/Source/UI/PostButtonsView.swift
@@ -29,12 +29,11 @@ class PostButtonsView: UIView {
         return label
     }()
 
-    let previewButton: PillButton = {
-        let button = PillButton()
-        button.setTitle(.preview)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .medium)
-        button.height = 32
-        return button
+    let previewToggle: UISwitch = {
+        let toggle = UISwitch()
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+        toggle.tintColor = UIColor.tint.default
+        return toggle
     }()
 
     let postButton: PillButton = {
@@ -66,10 +65,15 @@ class PostButtonsView: UIView {
         self.postButton.pinRightToSuperview(constant: -Layout.horizontalSpacing)
         self.postButton.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
 
-        self.addSubview(self.previewButton)
-        self.previewButton.trailingAnchor.constraint(equalTo: self.postButton.leadingAnchor,
+        self.addSubview(self.previewToggle)
+        self.previewToggle.trailingAnchor.constraint(equalTo: self.postButton.leadingAnchor,
                                                      constant: -Layout.horizontalSpacing).isActive = true
-        self.previewButton.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+        self.previewToggle.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+
+        self.addSubview(self.markdownNoticeLabel)
+        self.markdownNoticeLabel.trailingAnchor.constraint(equalTo: self.previewToggle.leadingAnchor,
+                                                           constant: -Layout.horizontalSpacing).isActive = true
+        self.markdownNoticeLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
     }
 
     // MARK: Animations

--- a/Source/UI/PostReplyView.swift
+++ b/Source/UI/PostReplyView.swift
@@ -24,7 +24,7 @@ class PostReplyView: KeyValueView {
     let replyTextView: ReplyTextView = {
         let view = ReplyTextView(topSpacing: 0, bottomSpacing: Layout.verticalSpacing)
         view.button.isUserInteractionEnabled = false
-        view.textView.isUserInteractionEnabled = false
+        view.isUserInteractionEnabled = false
         view.topSeparator.isHidden = true
         view.addGestureRecognizer(view.tapGesture.recognizer)
         view.isSkeletonable = true

--- a/Source/UI/PostTextEditorView.swift
+++ b/Source/UI/PostTextEditorView.swift
@@ -1,0 +1,106 @@
+//
+//  MarkdownTextView.swift
+//  Planetary
+//
+//  Created by Marcel Kummer on 17.11.20.
+//  Copyright © 2020 Marcel Kummer. All rights reserved.
+//
+
+import Foundation
+import Down
+import UIKit
+
+class PostTextEditorView: UIView {
+    private let font = UIFont.systemFont(ofSize: 19, weight: .regular)
+    private lazy var fontAttribute = [NSAttributedString.Key.font: self.font]
+
+    private let mentionDelegate = MentionTextViewDelegate(font: UIFont.verse.newPost,
+                                                          color: UIColor.text.default)
+
+    private lazy var textView: UITextView = {
+        let view = UITextView.forPostsAndReplies()
+        view.backgroundColor = .cardBackground
+        view.delegate = self.mentionDelegate
+        view.font = font
+        view.textColor = UIColor.text.default
+        return view
+    }()
+
+    private lazy var menu: AboutsMenu = {
+        let view = AboutsMenu()
+        view.bottomSeparator.isHidden = true
+        return view
+    }()
+
+    // This property holds the Markdown source "code" *only* while the rendered preview is shown. This way it also implicitly tells if the preview is currently active.
+    private var sourceBuffer: NSAttributedString?
+
+    var attributedText: NSAttributedString {
+        get {
+            return sourceBuffer ?? textView.attributedText
+        }
+
+        set {
+            textView.attributedText = newValue
+            sourceBuffer = nil
+        }
+    }
+
+    var previewActive: Bool {
+        get {
+            return sourceBuffer != nil
+        }
+
+        set {
+            if newValue {
+                textView.isEditable = false
+                sourceBuffer = textView.attributedText
+                textView.attributedText = sourceBuffer!.string.decodeMarkdown()
+            } else {
+                textView.attributedText = sourceBuffer
+                sourceBuffer = nil
+                textView.isEditable = true
+            }
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+
+        useAutoLayout()
+        backgroundColor = .appBackground
+
+        addSubview(textView)
+        textView.pinTopToSuperview()
+        textView.pinBottomToSuperviewBottom()
+        textView.pinLeftToSuperview()
+        textView.pinRightToSuperview()
+
+        addSubview(menu)
+        menu.pinBottomToSuperviewBottom()
+        menu.constrainWidth(to: self)
+
+        addActions()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func addActions() {
+        mentionDelegate.didChangeMention = { [unowned self] string in
+            self.menu.filter(by: string)
+        }
+
+        menu.didSelectAbout = { [unowned self] about in
+            guard let range = self.mentionDelegate.mentionRange else { return }
+            self.textView.replaceText(in: range, with: about.mention, attributes: self.fontAttribute)
+            self.mentionDelegate.clear()
+            self.menu.hide()
+        }
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        return textView.becomeFirstResponder()
+    }
+}

--- a/Source/UI/PostTextEditorView.swift
+++ b/Source/UI/PostTextEditorView.swift
@@ -116,22 +116,22 @@ class PostTextEditorView: UIView {
     }
 
     private func animateToPreview() {
-        UIView.animate(withDuration: 0.25, animations: {
+        UIView.animate(withDuration: 0.2, animations: {
             self.sourceTextView.alpha = 0
         },
         completion: { (_) in
-            UIView.animate(withDuration: 0.25) {
+            UIView.animate(withDuration: 0.2) {
                 self.renderedTextView.alpha = 1
             }
         })
     }
 
     private func animateToSourceView() {
-        UIView.animate(withDuration: 0.25, animations: {
+        UIView.animate(withDuration: 0.2, animations: {
             self.renderedTextView.alpha = 0
         },
         completion: { (_) in
-            UIView.animate(withDuration: 0.25) {
+            UIView.animate(withDuration: 0.2) {
                 self.sourceTextView.alpha = 1
             }
         })

--- a/Source/UI/PostTextEditorView.swift
+++ b/Source/UI/PostTextEditorView.swift
@@ -34,6 +34,7 @@ class PostTextEditorView: UIView {
         view.textColor = UIColor.text.default
         view.alpha = 0
         view.contentInset = UIEdgeInsets.default
+        view.isEditable = false
         return view
     }()
 

--- a/Source/UI/PostTextEditorView.swift
+++ b/Source/UI/PostTextEditorView.swift
@@ -19,10 +19,11 @@ class PostTextEditorView: UIView {
 
     private lazy var sourceTextView: UITextView = {
         let view = UITextView.forPostsAndReplies()
-        view.backgroundColor = .cardBackground
+        view.backgroundColor = .appBackground
         view.delegate = self.mentionDelegate
         view.font = font
         view.textColor = UIColor.text.default
+        view.contentInset = UIEdgeInsets.default
         return view
     }()
 
@@ -32,6 +33,7 @@ class PostTextEditorView: UIView {
         view.font = font
         view.textColor = UIColor.text.default
         view.alpha = 0
+        view.contentInset = UIEdgeInsets.default
         return view
     }()
 


### PR DESCRIPTION
Here comes basic Markdown previewing. I moved stuff around as I saw fit - there are a few things I would like your opinion on:
- The mention delegate needs direct access to the `UITextView`, therefore I integrated it into `PostEditorTextView`. I'd rather kept it outside for better separation but pulling it out seems too involved.
- The `PillButton` looks almost disabled to me when `isSelected = false`. However I wanted to visually differentiate the preview button from the post button. Not quite happy with the current setup, do you have better ideas?
- I haven't come up with a nice way to communicate the Markdown capability now that the "Markdown supported" label is gone. Having "Preview Markdown" as the button caption is way too long already, not even thinking about a German translation. Then again, using an SF Symbols-powered button isn't too telling either.