### PR TITLE
Fix inset misalignment from scrollToTop on UICollectionView

### DIFF
--- a/Source/Extension/UICollectionView+Verse.swift
+++ b/Source/Extension/UICollectionView+Verse.swift
@@ -11,7 +11,7 @@ import UIKit
 extension UICollectionView {
     
     func scrollToTop(animated: Bool = true) {
-        let point = CGPoint(x: 0, y: -self.contentInset.top)
+        let point = CGPoint(x: -self.contentInset.left, y: -self.contentInset.top)
         DispatchQueue.main.async {
             self.setContentOffset(point, animated: animated)
         }


### PR DESCRIPTION
Currently, if you tap the tab bar icon for the Discover page (when already on that view) to trigger a scroll to the top, the left margin gets messed up.

Looks like `scrollToTop()` was setting the content offset to `0` despite it being set to `5` on the view itself. This uses the defined value from the collectionView instead, as it already did for the y offset. 

Screen recording of bug:
https://user-images.githubusercontent.com/1018145/107459081-3f40fa00-6b0a-11eb-8c66-041496e3a133.mov

