### PR TITLE
Tweak insets on new post editor to prevent content running off screen 

### DIFF
--- a/Shared/Layout/UIEdgeInsets+Layout.swift
+++ b/Shared/Layout/UIEdgeInsets+Layout.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 extension UIEdgeInsets {
-    static let `default` =          UIEdgeInsets(top: Layout.verticalSpacing, left: Layout.horizontalSpacing, bottom: -Layout.verticalSpacing, right: -Layout.horizontalSpacing)
+    static let `default` =          UIEdgeInsets(top: Layout.verticalSpacing, left: Layout.horizontalSpacing, bottom: Layout.verticalSpacing, right: Layout.horizontalSpacing)
     static let leftBottomRight =    UIEdgeInsets(top: 0, left: Layout.horizontalSpacing, bottom: -Layout.verticalSpacing, right: -Layout.horizontalSpacing)
     static let leftRight =          UIEdgeInsets(top: 0, left: Layout.horizontalSpacing, bottom: 0, right: -Layout.horizontalSpacing)
     static let topOnly =            UIEdgeInsets(top: Layout.verticalSpacing, left: 0, bottom: 0, right: 0)

--- a/Source/UI/PostTextEditorView.swift
+++ b/Source/UI/PostTextEditorView.swift
@@ -23,7 +23,7 @@ class PostTextEditorView: UIView {
         view.delegate = self.mentionDelegate
         view.font = font
         view.textColor = UIColor.text.default
-        view.contentInset = UIEdgeInsets.default
+        view.textContainerInset = UIEdgeInsets.default
         return view
     }()
 
@@ -33,7 +33,7 @@ class PostTextEditorView: UIView {
         view.font = font
         view.textColor = UIColor.text.default
         view.alpha = 0
-        view.contentInset = UIEdgeInsets.default
+        view.textContainerInset = UIEdgeInsets.default
         view.isEditable = false
         return view
     }()


### PR DESCRIPTION
I think this addresses #202. (and potentially #209, but there's not much detail there.)

Content is currently being cut off on the right and bottom edges of the new post view. 

I think that's because `UIEdgeInsets.default` had negative values set for `right` and `bottom`. I solved this by modifying that `.default` itself, as this is the only place that it's being used. (Well, it's also used once in `addSpacerView()`, but that only grabs the `UIEdgeInsets.default.top` value, which remains unchanged.) If there's any other plans for using that default, this change can be done elsewhere. :) 

The second thing is switching from `contentInset` to `textContainerInset` on the UITextView. Without this switch, it gets all bouncy and crazy without the negative margins when text is modified. But I *think* that's the correct usage anyways. 

## Before:

| scrolled to top  | scrolled to bottom |
| --------  | -------- |
| ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 17 53](https://user-images.githubusercontent.com/1018145/107464519-59cca080-6b15-11eb-9abb-b5c2ac8580bd.png) | ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 17 58](https://user-images.githubusercontent.com/1018145/107464531-5fc28180-6b15-11eb-9fbf-7e92760a7c18.png) | 
| ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 18 01](https://user-images.githubusercontent.com/1018145/107464467-330e6a00-6b15-11eb-988f-6f4f36c4a7f8.png) | ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 18 04](https://user-images.githubusercontent.com/1018145/107464478-399ce180-6b15-11eb-9195-49e9b6cea39c.png) | 

## After (this PR branch):

| scrolled to top  | scrolled to bottom |
| --------  | -------- |
| ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 16 29](https://user-images.githubusercontent.com/1018145/107464002-2ccbbe00-6b14-11eb-90cb-fddbb9727444.png) | ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 16 39](https://user-images.githubusercontent.com/1018145/107464019-37865300-6b14-11eb-82ea-ceeaf90589e7.png) | 
| ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 16 32](https://user-images.githubusercontent.com/1018145/107464035-3fde8e00-6b14-11eb-8dbc-5e5feacc4405.png) | ![Simulator Screen Shot - iPhone 12 - 2021-02-09 at 20 16 35](https://user-images.githubusercontent.com/1018145/107464042-44a34200-6b14-11eb-9e18-9689fbe82802.png) | 