### PR TITLE
Work around pub invitation lock

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -565,7 +565,7 @@
 		5396A6232244356600C57A4B /* Layout+ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A6222244356600C57A4B /* Layout+ContentView.swift */; };
 		5396A6252244358A00C57A4B /* UIView+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A6242244358A00C57A4B /* UIView+Layout.swift */; };
 		5396A62722444A1500C57A4B /* BotViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62622444A1500C57A4B /* BotViewController.swift */; };
-		5396A62922444D9D00C57A4B /* UIViewController+Confirm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62822444D9D00C57A4B /* UIViewController+Confirm.swift */; };
+		5396A62922444D9D00C57A4B /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62822444D9D00C57A4B /* UIViewController+Alert.swift */; };
 		5396A62B22445BE900C57A4B /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62A22445BE900C57A4B /* AppConfiguration.swift */; };
 		5396A62F2245A50300C57A4B /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62E2245A50300C57A4B /* LaunchViewController.swift */; };
 		5396A631224823DD00C57A4B /* FeatureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A630224823DD00C57A4B /* FeatureViewController.swift */; };
@@ -1135,7 +1135,7 @@
 		5396A6222244356600C57A4B /* Layout+ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Layout+ContentView.swift"; sourceTree = "<group>"; };
 		5396A6242244358A00C57A4B /* UIView+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Layout.swift"; sourceTree = "<group>"; };
 		5396A62622444A1500C57A4B /* BotViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotViewController.swift; sourceTree = "<group>"; };
-		5396A62822444D9D00C57A4B /* UIViewController+Confirm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Confirm.swift"; sourceTree = "<group>"; };
+		5396A62822444D9D00C57A4B /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		5396A62A22445BE900C57A4B /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		5396A62E2245A50300C57A4B /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		5396A630224823DD00C57A4B /* FeatureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureViewController.swift; sourceTree = "<group>"; };
@@ -2105,7 +2105,7 @@
 				531749962370EED800F4C381 /* UIView+Superview.swift */,
 				531749942370EC7700F4C381 /* UIView+UIImage.swift */,
 				539208B3235A8413000A20C1 /* UIViewController+ApplicationWillEnterForeground.swift */,
-				5396A62822444D9D00C57A4B /* UIViewController+Confirm.swift */,
+				5396A62822444D9D00C57A4B /* UIViewController+Alert.swift */,
 				53E341FF225000D4002BB5F4 /* UIViewController+Keyboard.swift */,
 				8D74DE002335601F003C284B /* UIViewController+NavigationItems.swift */,
 				535B6A092372360F008C248E /* UIViewController+TopViewController.swift */,
@@ -3434,7 +3434,7 @@
 				531EC40C230F6B9E001A25AD /* DebugPostsViewController.swift in Sources */,
 				0A65A62E244DEB65004C48C8 /* SupportService.swift in Sources */,
 				530F01AE22DEAE86007EBAE2 /* DoneOnboardingStep.swift in Sources */,
-				5396A62922444D9D00C57A4B /* UIViewController+Confirm.swift in Sources */,
+				5396A62922444D9D00C57A4B /* UIViewController+Alert.swift in Sources */,
 				8DE093DC234651E1009E505D /* FollowButton.swift in Sources */,
 				539246E022A9CCBF00D01EEC /* Person.swift in Sources */,
 				53C422B721C476B000A314AD /* DebugTableViewController.swift in Sources */,

--- a/Shared/Extensions/UIViewController+Alert.swift
+++ b/Shared/Extensions/UIViewController+Alert.swift
@@ -16,7 +16,7 @@ extension UIViewController {
                                            message: error.localizedDescription,
                                            preferredStyle: .alert)
         controller.view.tintColor = UIColor.tint.system
-        
+
         let cancelAction = UIAlertAction(title: Text.cancel.text,
                                          style: .cancel) { _ in
                                             controller.dismiss(animated: true)
@@ -30,10 +30,9 @@ extension UIViewController {
                title: String? = nil,
                message: String,
                cancelTitle: String = Text.cancel.text,
-               cancelClosure: (() -> Void)? = nil)
-    {
-        let cancel = UIAlertAction(title: cancelTitle, style: .cancel) {
-            _ in
+               cancelClosure: (() -> Void)? = nil) {
+        
+        let cancel = UIAlertAction(title: cancelTitle, style: .cancel) { _ in
             cancelClosure?()
         }
 
@@ -47,17 +46,14 @@ extension UIViewController {
                  cancelTitle: String = Text.cancel.text,
                  cancelClosure: (() -> Void)? = nil,
                  confirmTitle: String = Text.ok.text,
-                 confirmClosure: @escaping (() -> Void))
-    {
+                 confirmClosure: @escaping (() -> Void)) {
+        
         let confirm = UIAlertAction(title: confirmTitle,
-                                    style: isDestructive ? .destructive : .default)
-        {
-            _ in
+                                    style: isDestructive ? .destructive : .default) { _ in
             confirmClosure()
         }
 
-        let cancel = UIAlertAction(title: cancelTitle, style: .cancel) {
-            _ in
+        let cancel = UIAlertAction(title: cancelTitle, style: .cancel) { _ in
             cancelClosure?()
         }
 

--- a/Shared/Extensions/UIViewController+Alert.swift
+++ b/Shared/Extensions/UIViewController+Alert.swift
@@ -1,5 +1,5 @@
 //
-//  UIViewController+Confirm.swift
+//  UIViewController+Alert.swift
 //  FBTT
 //
 //  Created by Christoph on 3/21/19.

--- a/Source/App/AppController+URL.swift
+++ b/Source/App/AppController+URL.swift
@@ -91,8 +91,6 @@ extension AppController {
                         self?.hideProgress()
                     }
                 case .failure(let error):
-                    Log.optional(error)
-                    CrashReporting.shared.reportIfNeeded(error: error)
                     DispatchQueue.main.async {
                         self?.hideProgress()
                         self?.alert(error: error)

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -94,7 +94,7 @@ protocol Bot {
 
     // Redeem uses the invite information and accepts it.
     // It adds the pub behind the address to the connection sheduling table and follows it.
-    func inviteRedeem(queue: DispatchQueue, token: String, completion: @escaping ErrorCompletion)
+    func redeemInvitation(to: Star, completionQueue: DispatchQueue, completion: @escaping ErrorCompletion)
 
     // MARK: Publish
 
@@ -246,8 +246,8 @@ extension Bot {
         self.about(queue: .main, identity: identity, completion: completion)
     }
     
-    func inviteRedeem(token: String, completion: @escaping ErrorCompletion) {
-        self.inviteRedeem(queue: .main, token: token, completion: completion)
+    func redeemInvitation(to star: Star, completion: @escaping ErrorCompletion) {
+        self.redeemInvitation(to: star, completionQueue: .main, completion: completion)
     }
     
     func pubs(completion: @escaping (([Pub], Error?) -> Void)) {

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -242,7 +242,6 @@ extension Bot {
         self.reports(queue: .main, completion: completion)
     }
     
-    // TODO: add function to get about for a given feed
     func about(identity: Identity, completion:  @escaping AboutCompletion) {
         self.about(queue: .main, identity: identity, completion: completion)
     }

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -242,6 +242,7 @@ extension Bot {
         self.reports(queue: .main, completion: completion)
     }
     
+    // TODO: add function to get about for a given feed
     func about(identity: Identity, completion:  @escaping AboutCompletion) {
         self.about(queue: .main, identity: identity, completion: completion)
     }

--- a/Source/Bot/Operations/RedeemInviteOperation.swift
+++ b/Source/Bot/Operations/RedeemInviteOperation.swift
@@ -41,8 +41,8 @@ class RedeemInviteOperation: AsynchronousOperation {
                 CrashReporting.shared.reportIfNeeded(error: error)
                 
                 // Construct a better error message before returning
-                Bots.current.about(identity: self.star.feed.id) { about, error in
-                    let starName = about?.nameOrIdentity ?? self.star.feed.id
+                Bots.current.about(identity: self.star.feed) { about, error in
+                    let starName = about?.name ?? self.star.feed
                     let localizedMessage = Text.Error.invitationRedemptionFailed.text(["starName": starName])
                     let userError = NSError(
                         domain: String(describing: type(of: self)),

--- a/Source/Bot/Operations/RedeemInviteOperation.swift
+++ b/Source/Bot/Operations/RedeemInviteOperation.swift
@@ -37,7 +37,7 @@ class RedeemInviteOperation: AsynchronousOperation {
         }
         Log.debug("Redeeming invite to star \(self.star.feed)...")
         let queue = OperationQueue.current?.underlyingQueue ?? DispatchQueue.global(qos: .background)
-        Bots.current.inviteRedeem(queue: queue, token: self.star.invite) { [weak self, star, shouldFollow] (error) in
+        Bots.current.redeemInvitation(to: star, completionQueue: queue) { [weak self, star, shouldFollow] (error) in
             Log.optional(error)
             CrashReporting.shared.reportIfNeeded(error: error)
             if let error = error {

--- a/Source/Bot/Operations/RedeemInviteOperation.swift
+++ b/Source/Bot/Operations/RedeemInviteOperation.swift
@@ -29,7 +29,7 @@ class RedeemInviteOperation: AsynchronousOperation {
     override func main() {
         Log.info("RedeemInviteOperation started.")
         
-        redeemInvitation() { result in
+        redeemInvitation { result in
             
             switch result {
             case .success:
@@ -41,7 +41,7 @@ class RedeemInviteOperation: AsynchronousOperation {
                 CrashReporting.shared.reportIfNeeded(error: error)
                 
                 // Construct a better error message before returning
-                Bots.current.about(identity: self.star.feed) { about, error in
+                Bots.current.about(identity: self.star.feed) { about, _ in
                     let starName = about?.name ?? self.star.feed
                     let localizedMessage = Text.Error.invitationRedemptionFailed.text(["starName": starName])
                     let userError = NSError(
@@ -57,7 +57,7 @@ class RedeemInviteOperation: AsynchronousOperation {
         }
     }
         
-    private func redeemInvitation(completion: @escaping (Result<Void, Error>) -> ()) {
+    private func redeemInvitation(completion: @escaping (Result<Void, Error>) -> Void) {
         
         let configuredIdentity = AppConfiguration.current?.identity
         let loggedInIdentity = Bots.current.identity

--- a/Source/Controller/RedeemInviteViewController.swift
+++ b/Source/Controller/RedeemInviteViewController.swift
@@ -106,8 +106,6 @@ class RedeemInviteViewController: UIViewController, Saveable, SaveableDelegate, 
                     }
                 }
             case .failure(let error):
-                Log.optional(error)
-                CrashReporting.shared.reportIfNeeded(error: error)
                 DispatchQueue.main.async {
                     AppController.shared.hideProgress()
                     self?.alert(error: error)

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -49,8 +49,8 @@ class FakeBot: Bot {
             completion([], nil)
         }
     }
-    func inviteRedeem(queue: DispatchQueue, token: String, completion: @escaping ErrorCompletion) {
-        queue.async{ completion(nil) }
+    func redeemInvitation(to: Star, completionQueue: DispatchQueue, completion: @escaping ErrorCompletion) {
+        completionQueue.async{ completion(nil) }
     }
     
     func thread(rootKey: MessageIdentifier, completion: @escaping ThreadCompletion) {

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -50,7 +50,7 @@ class FakeBot: Bot {
         }
     }
     func redeemInvitation(to: Star, completionQueue: DispatchQueue, completion: @escaping ErrorCompletion) {
-        completionQueue.async{ completion(nil) }
+        completionQueue.async { completion(nil) }
     }
     
     func thread(rootKey: MessageIdentifier, completion: @escaping ThreadCompletion) {

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -864,6 +864,7 @@ class ViewDatabase {
         return nil
     }
     
+    /// The `id` parameter appears to be treated as a message ID. This won't work if you pass in a feed/author ID.
     func getAbout(for id: Identifier) throws -> About? {
         guard let db = self.openDB else {
             throw ViewDatabaseError.notOpen

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -864,7 +864,6 @@ class ViewDatabase {
         return nil
     }
     
-    /// The `id` parameter appears to be treated as a message ID. This won't work if you pass in a feed/author ID.
     func getAbout(for id: Identifier) throws -> About? {
         guard let db = self.openDB else {
             throw ViewDatabaseError.notOpen

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -22,7 +22,7 @@ extension Text {
     }
 }
 
-// MARK:- Generic
+// MARK: - Generic
 
 enum Text: String, Localizable, CaseIterable {
 
@@ -157,7 +157,7 @@ enum Text: String, Localizable, CaseIterable {
     case markdownSupported = "Markdown preview"
 }
 
-// MARK:- ImagePicker
+// MARK: - ImagePicker
 
 extension Text {
 
@@ -172,7 +172,7 @@ extension Text {
     }
 }
 
-// MARK:- New post
+// MARK: - New post
 
 extension Text {
 
@@ -182,7 +182,7 @@ extension Text {
     }
 }
 
-// MARK:- Offboarding
+// MARK: - Offboarding
 
 extension Text {
 
@@ -199,7 +199,7 @@ extension Text {
     }
 }
 
-// MARK:- Onboarding
+// MARK: - Onboarding
 
 extension Text {
 
@@ -281,7 +281,7 @@ extension Text {
     }
 }
 
-// MARK:- Manage Pubs
+// MARK: - Manage Pubs
 
 extension Text {
 
@@ -296,7 +296,7 @@ extension Text {
     }
 }
 
-// MARK:- Preview
+// MARK: - Preview
 
 extension Text {
 
@@ -306,7 +306,7 @@ extension Text {
     }
 }
 
-// MARK:- Public Web Hosting
+// MARK: - Public Web Hosting
 
 extension Text {
 
@@ -317,7 +317,7 @@ extension Text {
     }
 }
 
-// MARK:- Push
+// MARK: - Push
 
 extension Text {
 
@@ -329,7 +329,7 @@ extension Text {
     }
 }
 
-// MARK:- Report
+// MARK: - Report
 
 extension Text {
 
@@ -342,7 +342,7 @@ extension Text {
     }
 }
 
-// MARK:- Block
+// MARK: - Block
 
 extension Text {
 
@@ -371,6 +371,7 @@ extension Text {
         case login = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device."
         case unexpected = "Something unexpected happened."
         case supportNotConfigured = "Support is not configured."
+        case invitationRedemptionFailed = "Could not join community: {{ starName }}. Please try again or contact support."
     }
 }
 

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -371,7 +371,7 @@ extension Text {
         case login = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device."
         case unexpected = "Something unexpected happened."
         case supportNotConfigured = "Support is not configured."
-        case invitationRedemptionFailed = "Could not join community: {{ starName }}. Please try again or contact support."
+        case invitationRedemptionFailed = "Could not join {{ starName }}. Please try again or contact support."
     }
 }
 

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -220,7 +220,7 @@
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join community: {{ starName }}. Please try again or contact support.";
+"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -220,6 +220,7 @@
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
+"Error.invitationRedemptionFailed" = "Could not join community: {{ starName }}. Please try again or contact support.";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";

--- a/Source/Model/About.swift
+++ b/Source/Model/About.swift
@@ -13,7 +13,7 @@ import Foundation
 /// Identifier.  A good example is the hashtag feature.  A Tag model is
 /// published to generate a Identifier, but without a name.  So, an About
 /// is published referencing the tag identifier and supplying a name.
-struct About: ContentCodable {
+struct About: ContentCodable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case about

--- a/Source/Model/Identifier.swift
+++ b/Source/Model/Identifier.swift
@@ -63,7 +63,7 @@ extension Identifier {
         else                                                { return .unsupported }
     }
 
-    // the base64 number between the sigil, marker, and algorithm
+    /// the base64 number between the sigil, marker, and algorithm
     var id: String {
         let components = self.components(separatedBy: ".")
         guard components.count == 2 else { return Identifier.unsupported }

--- a/Source/Model/Star.swift
+++ b/Source/Model/Star.swift
@@ -61,6 +61,8 @@ struct Star {
         return Pub(type: .pub, address: self.address)
     }
     
+    /// Checks whether we can establish a TCP connection to the star. This is only necessary to work around a bug
+    /// in go-ssb and can probably go away after #301 is solved.
     func testConnection(completion: @escaping (Bool) -> Void) {
         guard let port = NWEndpoint.Port(rawValue: UInt16(port)) else {
             completion(false)

--- a/Source/UI/Buttons/FollowButton.swift
+++ b/Source/UI/Buttons/FollowButton.swift
@@ -74,8 +74,6 @@ class FollowButton: PillButton {
                             self.onUpdate?(shouldFollow)
                         }
                     case .failure(let error):
-                        Log.optional(error)
-                        CrashReporting.shared.reportIfNeeded(error: error)
                         DispatchQueue.main.async {
                             AppController.shared.hideProgress()
                             self.isEnabled = true

--- a/UnitTests/ViewDatabaseTests.swift
+++ b/UnitTests/ViewDatabaseTests.swift
@@ -631,6 +631,21 @@ class ViewDatabaseTests: XCTestCase {
         // Assert
         XCTAssertEqual(try vdb.messageCount(), messageCount + 1)
     }
+    
+    func testGetAboutForIDGivenUserID() throws {
+        // Arrange
+        let id = try XCTUnwrap(fixture.identities.first) // userOne
+        let expectedAbout = About(about: id, name: "userOne", description: nil, imageLink: nil, publicWebHosting: nil)
+        
+        // Act
+        let about = try vdb.getAbout(for: id)
+        
+        // Assert
+        XCTAssertEqual(about?.identity, expectedAbout.identity)
+        XCTAssertEqual(about?.name, expectedAbout.name)
+        XCTAssertEqual(about?.description, expectedAbout.description)
+        XCTAssertEqual(about?.publicWebHosting, expectedAbout.publicWebHosting)
+    }
 }
 
 class ViewDatabasePreloadTest: XCTestCase {


### PR DESCRIPTION
#272 this prevents go-ssb from locking for 70 seconds on a bad pub TCP connection by trying our to make our own TCP connection to pubs first. I also did some refactoring to show a nicer error message when pub invitation redemption fails.