### PR TITLE
Fix SQLite write locking

### DIFF
--- a/Planetary.xcodeproj/xcshareddata/xcbaselines/5308168421C46A52005C48ED.xcbaseline/188BAB62-50E9-4AEA-A97C-F3B7599AC7F7.plist
+++ b/Planetary.xcodeproj/xcshareddata/xcbaselines/5308168421C46A52005C48ED.xcbaseline/188BAB62-50E9-4AEA-A97C-F3B7599AC7F7.plist
@@ -34,9 +34,11 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.208039</real>
+					<real>0.208000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>25.000000</real>
 				</dict>
 			</dict>
 			<key>testGetFollows()</key>

--- a/Planetary.xcodeproj/xcshareddata/xcbaselines/5308168421C46A52005C48ED.xcbaseline/188BAB62-50E9-4AEA-A97C-F3B7599AC7F7.plist
+++ b/Planetary.xcodeproj/xcshareddata/xcbaselines/5308168421C46A52005C48ED.xcbaseline/188BAB62-50E9-4AEA-A97C-F3B7599AC7F7.plist
@@ -56,7 +56,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>2.090000</real>
+					<real>2.180000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Planetary.xcodeproj/xcshareddata/xcschemes/Planetary.xcscheme
+++ b/Planetary.xcodeproj/xcshareddata/xcschemes/Planetary.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5344D82A21C4649700704A34"
+            BuildableName = "Planetary.app"
+            BlueprintName = "Planetary"
+            ReferencedContainer = "container:Planetary.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
#305 This removes the `db.transaction` wrapper in `ViewDatabase.fillMessages()`. While wrapping our writes to SQLite in a transaction gives a small (~6%) speed boost to the write operations, it creates an exclusive lock on the database, preventing any other reads or writes from taking place. By inserting rows individually instead of in a transaction, we allow readers to read from the database in between insertions. This is important when we are copying over large amounts of data from go-ssb, as a big write transaction can take more than 10 seconds. And it fits with our general strategy of using [SQLite as a cache layer](https://github.com/planetary-social/planetary-ios/blob/master/Architecture/0004-use-sqlite-as-a-cache.md) and optimizing it for read performance.