### PR TITLE
Add a job to compile GoSSB.xcframework on the CI server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,14 @@ name: CI
 on:
   pull_request
 jobs:
+  compile_go_ssb:
+    name: Build GoSSB.xcframework
+    runs-on: macOS-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Build
+      run: set -o pipefail && xcodebuild build -project GoSSB/GoSSB.xcodeproj -scheme GoSSB -destination "platform=iOS Simulator,name=iPhone 13,OS=15.2" | xcpretty
   unit_test:
     name : Unit Tests
     runs-on: macOS-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Build
-      run: set -o pipefail && xcodebuild build -project GoSSB/GoSSB.xcodeproj -scheme GoSSB -destination "platform=iOS Simulator,name=iPhone 13,OS=15.2" | xcpretty
+      run: set -o pipefail && xcodebuild build -project GoSSB/GoSSB.xcodeproj -scheme GoSSB -destination "platform=iOS Simulator,name=iPhone 13,OS=15.2"
   unit_test:
     name : Unit Tests
     runs-on: macOS-latest


### PR DESCRIPTION
@boreq this adds a Github Action to compile the Go code as part of our PR checks. I realized the Go wasn't actually being compiled in our current "Unit Tests" job, which is why the tests were passing on your other PR. Maybe this will help you test things on the `bump_version` branch. Feel free to click merge on this if you want to use it.