### PR TITLE
Add planetary:// as a URL scheme to open the app

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -23,6 +23,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.planetary.ios</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>planetary</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
This adds a simple URL scheme that will allow us to reliably open the app from other apps, like Userlytics.