### PR TITLE
Accept all peer connections

### DIFF
--- a/GoSSB/Sources/api-ios.go
+++ b/GoSSB/Sources/api-ios.go
@@ -308,6 +308,7 @@ func ssbBotInit(config string, notifyBlobReceivedFn uintptr, notifyNewBearerToke
 			return countconn.WrapConn(level.Debug(log), c), nil
 		}),
 		mksbot.DisableEBT(true),
+		mksbot.WithPublicAuthorizer(newAcceptAllAuthorizer()),
 	}
 
 	if hmacSignKey != "" {
@@ -367,5 +368,16 @@ func (e emitter) EmitBlob(n ssb.BlobStoreNotification) error {
 }
 
 func (e emitter) Close() error {
+	return nil
+}
+
+type acceptAllAuthorizer struct {
+}
+
+func newAcceptAllAuthorizer() *acceptAllAuthorizer {
+	return &acceptAllAuthorizer{}
+}
+
+func (a acceptAllAuthorizer) Authorize(remote refs.FeedRef) error {
 	return nil
 }


### PR DESCRIPTION
A while ago a mechanism which tries to filter accepted connections was
introduced in go-ssb. By defaut this mechanism accepts connections based on the
follow graph. This may make sense if go-ssb acts as a pub but makes little
sense if go-ssb runs on a phone as your social media profile node. After all as
a user I want people to connect to me and get my messages. My profile is
public.

On top of all of that the feature doesn't seem to work correctly. Even after I
followed my Patchwork identity the connections from/to Patchwork were still
being rejected.

This sets an authorizer which accepts all peer connections to mitigate this
problem.

Fixes #431.