### PR TITLE
Fix issue when mentioning a profile with an emoji

### DIFF
--- a/Source/Model/Mention+NSAttributedString.swift
+++ b/Source/Model/Mention+NSAttributedString.swift
@@ -57,7 +57,7 @@ extension NSMutableAttributedString {
     convenience init(from mention: Mention) {
         let name = mention.name ?? ""
         self.init(string: name)
-        let range = NSRange(location: 0, length: name.count)
+        let range = NSRange(location: 0, length: name.utf16.count)
         self.addAttribute(NSAttributedString.Key.link, value: mention.link, range: range)
     }
 

--- a/UnitTests/AttributedStringTests.swift
+++ b/UnitTests/AttributedStringTests.swift
@@ -37,6 +37,14 @@ class AttributedStringTests: XCTestCase {
         XCTAssertTrue(markdown == "this is a test [identity](identity)")
     }
 
+    func test_mentionWithEmojiAttributedStringToMarkdown() {
+        let string = NSMutableAttributedString(string: "this is a test ")
+        let mention = Mention(link: "identity", name: "identity 🪲")
+        string.append(mention.attributedString)
+        let markdown = string.markdown
+        XCTAssertTrue(markdown == "this is a test [identity 🪲](identity)")
+    }
+
     func test_hashtagToAttributedString() {
         let hashtag = Hashtag.named("channel")
         let string = hashtag.attributedString

--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -225,7 +225,7 @@ class GoBotIntegrationTests: XCTestCase {
         XCTAssertNotNil(ref)
     }
 
-    /// Verifies that the GoBOt can publish a message with a mention whose name has an emoji
+    /// Verifies that the GoBot can publish a message with a mention whose name has an emoji
     func testPublishWithAMentionWithEmoji() async throws {
         // Arrange
         let mention = Mention(

--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -184,6 +184,73 @@ class GoBotIntegrationTests: XCTestCase {
         XCTAssertEqual(appConfig.numberOfPublishedMessages, 1)
         XCTAssertNotNil(ref)
     }
+
+    /// Verifies that the GoBot can publish a message with an emoji
+    func testPublishAnEmoji() async throws {
+        // Arrange
+        let testPost = Post(text: "🪲")
+        AppConfiguration.current?.numberOfPublishedMessages = 0
+
+        // Act
+        let ref = try await sut.publish(content: testPost)
+
+        // Assert
+        XCTAssertEqual(appConfig.numberOfPublishedMessages, 1)
+        XCTAssertNotNil(ref)
+    }
+
+    /// Verifies that the GoBOt can publish a message with a mention
+    func testPublishWithAMention() async throws {
+        // Arrange
+        let mention = Mention(
+            link: Identity("@j8jAl6Qs54VKIVQ5Jlja+Y3EQ/OCS6u85xGsNUGgb/g=.ed25519"),
+            name: "Martin Dutra",
+            metadata: nil
+        )
+        let testPost = Post(
+            blobs: nil,
+            branches: nil,
+            hashtags: nil,
+            mentions: [mention],
+            root: nil,
+            text: "Be yourself; everyone else is already taken"
+        )
+        AppConfiguration.current?.numberOfPublishedMessages = 0
+
+        // Act
+        let ref = try await sut.publish(content: testPost)
+
+        // Assert
+        XCTAssertEqual(appConfig.numberOfPublishedMessages, 1)
+        XCTAssertNotNil(ref)
+    }
+
+    /// Verifies that the GoBOt can publish a message with a mention whose name has an emoji
+    func testPublishWithAMentionWithEmoji() async throws {
+        // Arrange
+        let mention = Mention(
+            link: Identity("@j8jAl6Qs54VKIVQ5Jlja+Y3EQ/OCS6u85xGsNUGgb/g=.ed25519"),
+            name: "Martin Dutra 🪲",
+            metadata: nil
+        )
+        let testPost = Post(
+            blobs: nil,
+            branches: nil,
+            hashtags: nil,
+            mentions: [mention],
+            root: nil,
+            text: "Be yourself; everyone else is already taken"
+        )
+        let test = mention.attributedString
+        AppConfiguration.current?.numberOfPublishedMessages = 0
+
+        // Act
+        let ref = try await sut.publish(content: testPost)
+
+        // Assert
+        XCTAssertEqual(appConfig.numberOfPublishedMessages, 1)
+        XCTAssertNotNil(ref)
+    }
     
     /// Verifies that the statitistics() function updates the number of published messages in the AppConfiguration.
     func testStatisticsFunctionSetsNumberOfPublishedMessages() async throws {


### PR DESCRIPTION
Closes #327
Converting a Mention to a NSAttributedString wasn't done properly. Check accepted answer [here](https://stackoverflow.com/questions/56470728/swift-nsattributedstring-emojis).