### PR TITLE
Disconnect peers before connecting to new ones, and connect more often

### DIFF
--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -67,13 +67,17 @@ protocol Bot {
     
     func knownPubs(completion: @escaping KnownPubsCompletion)
     
-    /// Retrieves a list of all pubs the current user has joined.
-    func pubs(queue: DispatchQueue, completion: @escaping (([Pub], Error?) -> Void))
+    /// Retrieves a list of all pubs the current user is currently a member of.
+    func joinedPubs(queue: DispatchQueue, completion: @escaping (([Pub], Error?) -> Void))
 
-    // Sync is the bot reaching out to remote peers and gathering the latest
-    // data from the network.  This only updates the local log and requires
-    // calling `refresh` to ensure the view database is updated.
     var isSyncing: Bool { get }
+    
+    /// Sync is the bot reaching out to remote peers and gathering the latest gossip from the network. This only
+    /// updates the local log and requires calling `refresh` to ensure the view database is updated.
+    /// - Parameters:
+    ///   - queue: the queue that `completion` will be called on.
+    ///   - peers: a list of peers to gossip with. Only a subset of this list will be used.
+    ///   - completion: a handler called with the result of the operation.
     func sync(queue: DispatchQueue, peers: [Peer], completion: @escaping SyncCompletion)
 
     // TODO: this is temporary until live-streaming is deployed on the pubs
@@ -294,7 +298,7 @@ extension Bot {
     }
     
     func pubs(completion: @escaping (([Pub], Error?) -> Void)) {
-        self.pubs(queue: .main, completion: completion)
+        self.joinedPubs(queue: .main, completion: completion)
     }
     
     func publish(content: ContentCodable, completion: @escaping PublishCompletion) {

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -60,13 +60,14 @@ protocol Bot {
 
     // MARK: Sync
     
-    // Ensure that these list of addresses are taken into consideration when establishing connections
+    /// Ensure that these list of addresses are taken into consideration when establishing connections
     func seedPubAddresses(addresses: [PubAddress],
                           queue: DispatchQueue,
                           completion: @escaping (Result<Void, Error>) -> Void)
     
     func knownPubs(completion: @escaping KnownPubsCompletion)
     
+    /// Retrieves a list of all pubs the current user has joined.
     func pubs(queue: DispatchQueue, completion: @escaping (([Pub], Error?) -> Void))
 
     // Sync is the bot reaching out to remote peers and gathering the latest

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -51,7 +51,7 @@ class SendMissionOperation: AsynchronousOperation {
         let queue = OperationQueue.current?.underlyingQueue ?? .global(qos: .background)
         
         Log.info("Retreiving all joined pubs from database.")
-        Bots.current.pubs(queue: queue) { (allJoinedPubs, error) in
+        Bots.current.joinedPubs(queue: queue) { (allJoinedPubs, error) in
             Log.optional(error)
             CrashReporting.shared.reportIfNeeded(error: error)
             

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 import Logger
 import CrashReporting
 
-/// Attempts connection to a Planetary's pub. It redeems invitation to these pubs if the user
+/// Starts and/or cycles connections to pub servers. It redeems invitations to the system pubs if the user
 /// didn't do it previously.
 class SendMissionOperation: AsynchronousOperation {
     
@@ -50,69 +50,56 @@ class SendMissionOperation: AsynchronousOperation {
         
         let queue = OperationQueue.current?.underlyingQueue ?? .global(qos: .background)
         
-        let knownStars = Set(Environment.Constellation.stars)
-        let knownStarsAddresses = knownStars.map { $0.address }
-        
-        Log.debug("Seeding known stars stars...")
-        Bots.current.seedPubAddresses(addresses: knownStarsAddresses, queue: queue) { [weak self, quality] result in
-            Log.debug("Retrieving list of available stars...")
-            Bots.current.pubs(queue: queue) { (pubs, error) in
-                Log.optional(error)
-                CrashReporting.shared.reportIfNeeded(error: error)
+        Log.info("Retreiving all joined pubs from database.")
+        Bots.current.pubs(queue: queue) { (allJoinedPubs, error) in
+            Log.optional(error)
+            CrashReporting.shared.reportIfNeeded(error: error)
+            
+            Log.info("Sending all joined pubs to bot (\(allJoinedPubs.count)).")
+            let stars = Set(Environment.Constellation.stars)
+            let allPubAddresses = stars.map { $0.address } + allJoinedPubs.map { $0.address }
+            
+            Bots.current.seedPubAddresses(addresses: allPubAddresses, queue: queue) { [weak self] result in
+                if case .failure(let error) = result {
+                    Log.optional(error)
+                    CrashReporting.shared.reportIfNeeded(error: error)
+                }
                 
-                if let error = error {
-                    Log.info("Couldn't get list of available stars. SendMissionOperation finished.")
-                    self?.result = .failure(error)
-                    self?.finish()
+                guard let self = self else {
                     return
                 }
                 
                 // Get the stars the users already redeemed an invite to
-                let joinedStars = knownStars.filter { star in
-                    pubs.contains { (pub) -> Bool in
+                let joinedStars = stars.filter { star in
+                    allJoinedPubs.contains { (pub) -> Bool in
                         pub.address.key == star.feed
                     }
                 }
                 
-                let starsToSync: Set<Star>
-                let redeemInviteOperations: [RedeemInviteOperation]
+                var starsToJoin = Set<Star>()
+                var redeemInviteOperations = [RedeemInviteOperation]()
                 
-                // Check if the current number of available stars is enough
+                // Join more stars if we haven't yet.
                 let numberOfMissingStars = SendMissionOperation.minNumberOfStars - joinedStars.count
                 if numberOfMissingStars > 0 {
-                    Log.debug("There are \(numberOfMissingStars) missing stars.")
+                    Log.debug("Joining \(numberOfMissingStars) stars to get to minimum.")
                     
                     // Let's take a random set of stars to reach the minimum and create Redeem Invite
                     // operations
-                    let missingStars = knownStars.subtracting(joinedStars)
+                    let missingStars = stars.subtracting(joinedStars)
                     let randomSampleOfStars = missingStars.randomSample(UInt(numberOfMissingStars))
                     redeemInviteOperations = randomSampleOfStars.map {
                         return RedeemInviteOperation(star: $0, shouldFollow: false)
                     }
                     
                     // Lets sync to available stars and newly redeemed stars
-                    starsToSync = joinedStars.union(missingStars)
-                } else {
-                    Log.debug("There are \(joinedStars.count) available stars.")
-                    
-                    // No need to redeem invite
-                    redeemInviteOperations = []
-                    
-                    // Just sync to the available stars
-                    starsToSync = joinedStars
+                    starsToJoin = missingStars
                 }
                 
-                let someNonStarPubs = pubs
-                    .filter { pub in
-                        !knownStars.contains(where: { $0.feed == pub.address.key })
-                    }
-                    .map { $0.toPeer() }
-                    .randomSample(2)
-                let someStars = starsToSync.randomSample(2).map { $0.toPeer() }
-                let peersToSync = someNonStarPubs + someStars
+                let peerPool = allJoinedPubs.map { $0.toPeer() } + starsToJoin.map { $0.toPeer() }
                 
-                let syncOperation = SyncOperation(peers: peersToSync)
-                switch quality {
+                let syncOperation = SyncOperation(peerPool: peerPool)
+                switch self.quality {
                 case .low:
                     syncOperation.notificationsOnly = true
                 case .high:
@@ -121,11 +108,11 @@ class SendMissionOperation: AsynchronousOperation {
                 redeemInviteOperations.forEach { syncOperation.addDependency($0) }
                 
                 let operations = redeemInviteOperations + [syncOperation]
-                self?.operationQueue.addOperations(operations, waitUntilFinished: true)
+                self.operationQueue.addOperations(operations, waitUntilFinished: true)
                 
                 Log.info("SendMissionOperation finished.")
-                self?.result = .success(())
-                self?.finish()
+                self.result = .success(())
+                self.finish()
             }
         }
     }

--- a/Source/Bot/Operations/SyncOperation.swift
+++ b/Source/Bot/Operations/SyncOperation.swift
@@ -11,12 +11,12 @@ import Logger
 import Analytics
 import CrashReporting
 
-/// Pokes the bot into doing a sync. Don't use this SyncOperation directly, use
+/// Tries to connect to the given peers to gossip with them. Don't use this SyncOperation directly, use
 /// SendMissionOperation instead.
 class SyncOperation: AsynchronousOperation {
     
-    /// List of available peers to establish connection
-    var peers: [Peer]
+    /// List of available peers to establish connection. Only a subset will be actually be connected to.
+    var peerPool: [Peer]
     
     /// If true, only will sync to one peer with no retries
     var notificationsOnly: Bool = false
@@ -26,8 +26,8 @@ class SyncOperation: AsynchronousOperation {
     
     private(set) var error: Error?
     
-    init(peers: [Peer]) {
-        self.peers = peers
+    init(peerPool: [Peer]) {
+        self.peerPool = peerPool
         super.init()
     }
      
@@ -46,7 +46,7 @@ class SyncOperation: AsynchronousOperation {
         
         let queue = OperationQueue.current?.underlyingQueue ?? DispatchQueue.global(qos: .background)
         if self.notificationsOnly {
-            Bots.current.syncNotifications(queue: queue, peers: peers) { [weak self] (error, timeInterval, newMessages) in
+            Bots.current.syncNotifications(queue: queue, peers: peerPool) { [weak self] (error, timeInterval, newMessages) in
                 Analytics.shared.trackBotDidSync(duration: timeInterval,
                                           numberOfMessages: newMessages)
                 Log.optional(error)
@@ -59,7 +59,7 @@ class SyncOperation: AsynchronousOperation {
                 self?.finish()
             }
         } else {
-            Bots.current.sync(queue: queue, peers: peers) { [weak self] (error, timeInterval, newMessages) in
+            Bots.current.sync(queue: queue, peers: peerPool) { [weak self] (error, timeInterval, newMessages) in
                 Analytics.shared.trackBotDidSync(duration: timeInterval,
                                           numberOfMessages: newMessages)
                 Log.optional(error)

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -47,7 +47,7 @@ class FakeBot: Bot {
         fatalError("TODO:knownPubs")
     }
     
-    func pubs(queue: DispatchQueue, completion: @escaping (([Pub], Error?) -> Void)) {
+    func joinedPubs(queue: DispatchQueue, completion: @escaping (([Pub], Error?) -> Void)) {
         queue.async {
             completion([], nil)
         }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -283,7 +283,7 @@ class GoBot: Bot {
          }
      }
     
-    func pubs(queue: DispatchQueue, completion: @escaping (([Pub], Error?) -> Void)) {
+    func joinedPubs(queue: DispatchQueue, completion: @escaping (([Pub], Error?) -> Void)) {
         userInitiatedQueue.async {
             do {
                 let pubs = try self.database.getRedeemedPubs()

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -333,6 +333,7 @@ class GoBot: Bot {
 
         utilityQueue.async {
             let before = self.repoNumberOfMessages()
+            self.bot.disconnectAll()
             self.bot.dialSomePeers(from: peers)
             let after = self.repoNumberOfMessages()
             let new = after - before

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -300,7 +300,7 @@ class GoBotInternal {
             Log.error("Failed to connect to healthy peers")
         }
         
-        // Also conncet to two random peers
+        // Also connect to two random peers
         let connectToRandom = self.dial(from: peers, atLeast: 2, tries: 10)
         if !connectToRandom {
             Log.error("Failed to connect to random peers")

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -279,14 +279,34 @@ class GoBotInternal {
     
     @discardableResult
     func dialSomePeers(from peers: [Peer]) -> Bool {
-        guard self.openConnections() < 3 else { return true } // only make connections if we dont have any
-        ssbConnectPeers(2)
         guard peers.count > 0 else {
-            Log.debug("User doesn't have redeemed pubs")
+            Log.debug("User doesn't have any redeemed pubs")
+            return false
+        }
+        
+        // only make connections if we dont have enough
+        guard self.openConnections() < 4 else {
             return true
         }
-        self.dial(from: peers, atLeast: 1, tries: 10)
-        return true
+        
+        // connect to two peers based on go-ssb's internal logic (reliability)
+        let disconnectSuccess = ssbDisconnectAllPeers()
+        if !disconnectSuccess {
+            Log.error("Failed to disconnect peers")
+        }
+        
+        let connectToHealthy = ssbConnectPeers(2)
+        if !connectToHealthy {
+            Log.error("Failed to connect to healthy peers")
+        }
+        
+        // Also conncet to two random peers
+        let connectToRandom = self.dial(from: peers, atLeast: 2, tries: 10)
+        if !connectToRandom {
+            Log.error("Failed to connect to random peers")
+        }
+        
+        return disconnectSuccess && connectToHealthy && connectToRandom
     }
     
     func dialOne(peer: Peer) -> Bool {

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -621,6 +621,10 @@ class ViewDatabase {
            .join(self.pubs, on: self.pubs[colMessageRef] == self.msgs[colMessageID])
             .where(self.msgs[colAuthorID] == currentUserID)
             .where(self.msgs[colMsgType] == "pub")
+            .join(authors, on: authors[colAuthor] == pubs[colKey])
+            .join(contacts, on: contacts[colContactID] == authors[colID])
+            .filter(contacts[colAuthorID] == currentUserID)
+            .filter(colContactState == 1)
 
         return try db.prepare(qry).map { row in
             let host = try row.get(colHost)

--- a/Source/Model/MissionControlCenter.swift
+++ b/Source/Model/MissionControlCenter.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 import Logger
 
-/// Manages sending missions to nearby stars
+/// Manages connections to other peers aka sending missions to nearby stars.
 class MissionControlCenter {
     
     /// State of a Mission Control Center object
@@ -34,12 +34,12 @@ class MissionControlCenter {
     
     /// Timer for the SendMissionOperation
     private lazy var sendMissionTimer: RepeatingTimer = {
-        RepeatingTimer(interval: 60) { [weak self] in self?.sendMissions() }
+        RepeatingTimer(interval: 30) { [weak self] in self?.sendMissions() }
     }()
     
     /// Timer for the RefreshOperation
     private lazy var refreshTimer: RepeatingTimer = {
-        RepeatingTimer(interval: 17) { [weak self] in self?.pokeRefresh() }
+        RepeatingTimer(interval: 14) { [weak self] in self?.pokeRefresh() }
     }()
     
     /// Background Task Identifier for the SendMissionOperation
@@ -55,9 +55,8 @@ class MissionControlCenter {
         }
         Log.info("Mission Control Center started operations")
         self.state = .started
-        self.sendMissionTimer.start(fireImmediately: false)
-        self.refreshTimer.start(fireImmediately: false)
-        self.sendMission()
+        self.sendMissionTimer.start(fireImmediately: true)
+        self.refreshTimer.start(fireImmediately: true)
     }
     
     /// Resumes Mission Control Center operations. It resumes timers and starts a new missions.
@@ -67,9 +66,8 @@ class MissionControlCenter {
         }
         Log.info("Mission Control Center resumed operations")
         self.state = .started
-        self.sendMissionTimer.start(fireImmediately: false)
-        self.refreshTimer.start(fireImmediately: false)
-        self.sendMission()
+        self.sendMissionTimer.start(fireImmediately: true)
+        self.refreshTimer.start(fireImmediately: true)
     }
     
     /// Pauses Mission Control Center operations. It pauses timers and cancels current missions.

--- a/Source/Model/Star.swift
+++ b/Source/Model/Star.swift
@@ -10,6 +10,8 @@ import Foundation
 import Logger
 import Network
 
+/// An object representing a Planetary owned SSB pub server, including connection information and an embedded
+/// invitation. AKA system pubs.
 struct Star {
     let invite: String
     


### PR DESCRIPTION
No ticket for this. It's partly trying to fix some connection issues @rabble was seeing in TestFlight, and partly an experiment based on our latest findings in go-ssb. Changes include:
- Run SendMissionOperation every 30 seconds instead of 60 seconds. 
- Disconnect from peers before connecting to new ones.
- Pass the full list of all joined pubs to `Bot.sync()`. I thought `Bot.sync()` would actually tell go-ssb to connect to all the peers we passed it, but it actually has its own algorithm to pick a subset of the passed peers.
- Updated the names of some things and added doc comments.