### PR TITLE
Synchronize access to Bot.statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] = 2022-03-30
+## [1.1.0] = 2022-04-04
 - Added several new community pubs #450
 - Rename the "User Directory" tab to "Your Network" #450
 - Redesigned "like" messages to be smaller #448

--- a/Shared/Debug/DebugTableViewCell.swift
+++ b/Shared/Debug/DebugTableViewCell.swift
@@ -9,13 +9,13 @@ struct DebugTableViewCellModel {
     // IMPORTANT!
     // Be sure to use [unowned self] if your closure uses 'self'
     // otherwise a retain cycle will be created.
-    var valueClosure: ((_ cell: UITableViewCell) -> Void)?
-    var actionClosure: ((_ cell: UITableViewCell) -> Void)?
+    var valueClosure: (@MainActor (_ cell: UITableViewCell) async -> Void)?
+    var actionClosure: (@MainActor (_ cell: UITableViewCell) async -> Void)?
 
     init(title: String? = nil,
          cellReuseIdentifier: String = DebugValueTableViewCell.className,
-         valueClosure: ((_ cell: UITableViewCell) -> Void)? = nil,
-         actionClosure: ((_ cell: UITableViewCell) -> Void)? = nil) {
+         valueClosure: ((_ cell: UITableViewCell) async -> Void)? = nil,
+         actionClosure: ((_ cell: UITableViewCell) async -> Void)? = nil) {
         self.title = title ?? ""
         self.cellReuseIdentifier = cellReuseIdentifier
         self.valueClosure = valueClosure

--- a/Shared/Debug/DebugTableViewController.swift
+++ b/Shared/Debug/DebugTableViewController.swift
@@ -61,7 +61,9 @@ class DebugTableViewController: UITableViewController {
         cell.textLabel?.textColor = UIColor.mainText
         cell.textLabel?.text = model.title
         cell.backgroundColor = UIColor.cardBackground
-        model.valueClosure?(cell)
+        Task {
+            await model.valueClosure?(cell)
+        }
         return cell
     }
 
@@ -71,8 +73,10 @@ class DebugTableViewController: UITableViewController {
 
         let model = self.settings[indexPath.section].cellModels[indexPath.row]
         if let cell = tableView.cellForRow(at: indexPath) {
-            model.actionClosure?(cell)
-            model.valueClosure?(cell)
+            Task {
+                await model.actionClosure?(cell)
+                await model.valueClosure?(cell)
+            }
         }
 
         tableView.deselectRow(at: indexPath, animated: true)

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -211,9 +211,6 @@ protocol Bot {
     
     func lastReceivedTimestam() throws -> Double
     
-    @available(*, deprecated)
-    var statistics: BotStatistics { get }
-    
     // MARK: Preloading
     
     func preloadFeed(at url: URL, completion: @escaping ErrorCompletion)

--- a/Source/Cache/BlobCache.swift
+++ b/Source/Cache/BlobCache.swift
@@ -441,7 +441,9 @@ class BlobCache: DictionaryCache {
         Task {
             guard let identifier = notification.blobIdentifier else { return }
             guard await self.requestManager.numberOfCompletions(for: identifier) > 1 else { return }
-            self.loadImage(for: identifier)
+            await MainActor.run {
+                self.loadImage(for: identifier)
+            }
         }
     }
 }

--- a/Source/Debug/DebugViewController.swift
+++ b/Source/Debug/DebugViewController.swift
@@ -460,7 +460,7 @@ class DebugViewController: DebugTableViewController {
     
     /// Allows the user to export the go-ssb log and SQLite database in a zip file. This function will zip up the files
     /// and present a share sheet as a popover on the given cell.
-    private func shareDatabase(cell: UITableViewCell) {
+    private func shareDatabase(cell: UITableViewCell) async {
         cell.showActivityIndicator()
 
         let presentShareSheet = { [weak self] (activityItems: [Any]) in
@@ -472,7 +472,7 @@ class DebugViewController: DebugTableViewController {
             }
         }
         
-        let databaseDirectory = URL(fileURLWithPath: Bots.current.statistics.repo.path).deletingLastPathComponent()
+        let databaseDirectory = URL(fileURLWithPath: await Bots.current.statistics().repo.path).deletingLastPathComponent()
         let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
         let url = temporaryDirectory.appendingPathComponent(UUID().uuidString)
         DispatchQueue.global(qos: .background).async { [weak self] in

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -73,6 +73,10 @@ class GoBot: Bot {
     
     /// A queue for operations that the user is waiting on like publishing a post, pull-to-refresh, etc.
     private let userInitiatedQueue: DispatchQueue
+    
+    /// A queue that should be used when fetching `statistics` from the bot, to work around some problems go-ssb
+    /// seems to be having where it locks when you call it from two threads.
+    private let statisticsQueue: DispatchQueue
  
     private let userDefaults: UserDefaults
     private var config: AppConfiguration?
@@ -98,6 +102,11 @@ class GoBot: Bot {
         self.userInitiatedQueue = DispatchQueue(label: "GoBot-userInitiated",
                                                 qos: .userInitiated,
                                                 attributes: .concurrent,
+                                                autoreleaseFrequency: .workItem,
+                                                target: nil)
+        self.statisticsQueue = DispatchQueue(label: "GoBot-statistics",
+                                                qos: .userInitiated,
+                                                attributes: [],
                                                 autoreleaseFrequency: .workItem,
                                                 target: nil)
         self.bot = GoBotInternal(self.userInitiatedQueue)
@@ -390,8 +399,10 @@ class GoBot: Bot {
                                     numberOfMessages: Int,
                                     completion: @escaping SyncCompletion) {
         self._isSyncing = false
-        self._statistics.lastSyncDate = Date()
-        self._statistics.lastSyncDuration = elapsed
+        statisticsQueue.sync {
+            self._statistics.lastSyncDate = Date()
+            self._statistics.lastSyncDuration = elapsed
+        }
         completion(nil, elapsed, numberOfMessages)
         NotificationCenter.default.post(name: .didSync, object: nil)
     }
@@ -438,8 +449,10 @@ class GoBot: Bot {
                                        error: Error?,
                                        completion: @escaping RefreshCompletion) {
         self._isRefreshing = false
-        self._statistics.lastRefreshDate = Date()
-        self._statistics.lastRefreshDuration = elapsed
+        statisticsQueue.sync {
+            self._statistics.lastRefreshDate = Date()
+            self._statistics.lastRefreshDuration = elapsed
+        }
         completion(error, elapsed)
         NotificationCenter.default.post(name: .didRefresh, object: nil)
     }
@@ -1289,44 +1302,12 @@ class GoBot: Bot {
 
     // MARK: Statistics
 
+    /// Any access to this variable should be done on `statisticsQueue`.
     private var _statistics = BotStatistics()
     
-    var statistics: BotStatistics {
-        let counts = try? self.bot.repoStatus()
-        let sequence = try? self.database.stats(table: .messagekeys)
-        
-        var ownMessages = -1
-        if let identity = self._identity, let omc = try? self.database.numberOfMessages(for: identity) {
-            ownMessages = omc
-        }
-        
-        var fc: Int = -1
-        if let feedCount = counts?.feeds { fc = Int(feedCount) }
-        var mc: Int = -1
-        if let msgs = counts?.messages { mc = Int(msgs) }
-        self._statistics.repo = RepoStatistics(path: self.bot.currentRepoPath,
-                                               feedCount: fc,
-                                               messageCount: mc,
-                                               numberOfPublishedMessages: ownMessages,
-                                               lastHash: counts?.lastHash ?? "")
-        
-        self.saveNumberOfPublishedMessages(from: self._statistics.repo)
-        
-        let connectionCount = self.bot.openConnections()
-        let openConnections = self.bot.openConnectionList()
-        
-        self._statistics.peer = PeerStatistics(count: openConnections.count,
-                                               connectionCount: connectionCount,
-                                               identities: openConnections,
-                                               open: openConnections)
-
-        self._statistics.db = DatabaseStatistics(lastReceivedMessage: sequence ?? -3)
-        
-        return self._statistics
-    }
     
     func statistics(queue: DispatchQueue, completion: @escaping StatisticsCompletion) {
-        self.utilityQueue.async {
+        statisticsQueue.async {
             let counts = try? self.bot.repoStatus()
             let sequence = try? self.database.stats(table: .messagekeys)
 

--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -63,7 +63,7 @@ class GoBotIntegrationTests: XCTestCase {
 
     /// Verifies that we can correctly refresh the `ViewDatabase` from the go-ssb log even after `publish` has copied
     /// some posts with a greater sequence number into `ViewDatabase` already.
-    func testRefreshGivenPublish() throws {
+    func testRefreshGivenPublish() async throws {
         // Arrange
         for i in 0..<10 {
             _ = sut.testingPublish(as: "alice", content: Post(text: "Alice \(i)"))
@@ -77,18 +77,19 @@ class GoBotIntegrationTests: XCTestCase {
             XCTAssertNil(error)
             postExpectation.fulfill()
         }
-        waitForExpectations(timeout: 10, handler: nil)
+        await waitForExpectations(timeout: 10, handler: nil)
         
         let refreshExpectation = self.expectation(description: "refresh completed")
         sut.refresh(load: .long, queue: .main) { error, _ in
             XCTAssertNil(error)
             refreshExpectation.fulfill()
         }
-        waitForExpectations(timeout: 10, handler: nil)
+        await waitForExpectations(timeout: 10, handler: nil)
         
         // Assert
-        XCTAssertEqual(sut.statistics.repo.messageCount, 11)
-        XCTAssertEqual(sut.statistics.repo.numberOfPublishedMessages, 1)
+        let statistics = await sut.statistics()
+        XCTAssertEqual(statistics.repo.messageCount, 11)
+        XCTAssertEqual(statistics.repo.numberOfPublishedMessages, 1)
         XCTAssertEqual(try sut.database.messageCount(), 11)
     }
     

--- a/UnitTests/GoBotOrderedTests.swift
+++ b/UnitTests/GoBotOrderedTests.swift
@@ -275,9 +275,10 @@ class GoBotOrderedTests: XCTestCase {
         XCTAssertEqual(publishedMessages.count, 0)
     }
 
-    func test101_ViewHasAboutSelf() {
+    func test101_ViewHasAboutSelf() async {
         let ex = self.expectation(description: "\(#function)")
-        XCTAssertEqual(GoBotOrderedTests.shared.statistics.repo.messageCount, 1 + publishManyCount + 1)
+        let statistics = await GoBotOrderedTests.shared.statistics()
+        XCTAssertEqual(statistics.repo.messageCount, 1 + publishManyCount + 1)
         GoBotOrderedTests.shared.about(identity: botTestsKey.identity) {
             about, err in
             XCTAssertNotNil(about)
@@ -288,7 +289,7 @@ class GoBotOrderedTests: XCTestCase {
         self.wait(for: [ex], timeout: 10)
     }
 
-    func test102_testuserAbouts() {
+    func test102_testuserAbouts() async {
         let nicks = ["alice", "barbara", "claire", "denise", "page"]
         for n in nicks {
             let abt = About(about: GoBotOrderedTests.pubkeys[n]!, name: n)
@@ -297,8 +298,9 @@ class GoBotOrderedTests: XCTestCase {
 
         GoBotOrderedTests.shared.testRefresh(self)
 
-        XCTAssertEqual(GoBotOrderedTests.shared.statistics.repo.feedCount, nicks.count + 1)
-        XCTAssertEqual(GoBotOrderedTests.shared.statistics.repo.messageCount, publishManyCount + 2 + nicks.count)
+        let statistics = await GoBotOrderedTests.shared.statistics()
+        XCTAssertEqual(statistics.repo.feedCount, nicks.count + 1)
+        XCTAssertEqual(statistics.repo.messageCount, publishManyCount + 2 + nicks.count)
 
         for n in nicks {
             let ex = self.expectation(description: "\(#function)")
@@ -315,7 +317,7 @@ class GoBotOrderedTests: XCTestCase {
 
     // MARK: contacts (follows / blocks)
 
-    func test110_testuserContacts() {
+    func test110_testuserContacts() async {
         // should have at least:
         // 1 friend (a<>b)
         // 1 follows only (a>c)
@@ -347,7 +349,8 @@ class GoBotOrderedTests: XCTestCase {
 
         let nFollows = 6
         let extra = 2 + 5 // abouts
-        XCTAssertEqual(GoBotOrderedTests.shared.statistics.repo.messageCount, publishManyCount + extra + nFollows)
+        let statistics = await GoBotOrderedTests.shared.statistics()
+        XCTAssertEqual(statistics.repo.messageCount, publishManyCount + extra + nFollows)
 
         for tc in whoFollowsWho {
             let ex = self.expectation(description: "\(#function) follow \(tc)")
@@ -387,8 +390,8 @@ class GoBotOrderedTests: XCTestCase {
     }
 
     // MARK: various safty checks
-    func test111_skip_unsupported_messages() {
-        let currentCount = GoBotOrderedTests.shared.statistics.db.lastReceivedMessage
+    func test111_skip_unsupported_messages() async {
+        let currentCount = await GoBotOrderedTests.shared.statistics().db.lastReceivedMessage
 
         let n = 6_000 // batch size is 5k TODO: find a way to tweek the batch-size in testing mode
         for i in 1...n {
@@ -415,8 +418,9 @@ class GoBotOrderedTests: XCTestCase {
         }
         self.wait(for: [ex], timeout: 10)
 
-        XCTAssertNotEqual(GoBotOrderedTests.shared.statistics.db.lastReceivedMessage, currentCount, "still at the old level")
-        XCTAssertGreaterThan(GoBotOrderedTests.shared.statistics.db.lastReceivedMessage, currentCount + n, "did not get all the messages")
+        let statistics = await GoBotOrderedTests.shared.statistics()
+        XCTAssertNotEqual(statistics.db.lastReceivedMessage, currentCount, "still at the old level")
+        XCTAssertGreaterThan(statistics.db.lastReceivedMessage, currentCount + n, "did not get all the messages")
 
         // make sure we got the supported message
         ex = self.expectation(description: "\(#function) 3")

--- a/UnitTests/GoBotReproductionHelper.swift
+++ b/UnitTests/GoBotReproductionHelper.swift
@@ -77,10 +77,11 @@ class API_GoBot: XCTestCase {
     }
     
     // check we loaded all the messages from the fixtures repo
-    func test02_replicateUpto() {
-        XCTAssertEqual(API_GoBot.bot.statistics.repo.feedCount, 200)
-        XCTAssertEqual(API_GoBot.bot.statistics.db.lastReceivedMessage, -1)
-        XCTAssertEqual(API_GoBot.bot.statistics.repo.messageCount, 6_700)
+    func test02_replicateUpto() async {
+        let statistics = await API_GoBot.bot.statistics()
+        XCTAssertEqual(statistics.repo.feedCount, 200)
+        XCTAssertEqual(statistics.db.lastReceivedMessage, -1)
+        XCTAssertEqual(statistics.repo.messageCount, 6_700)
         
         XCTAssertFalse(API_GoBot.bot.bot.repoFSCK(.Sequences))
     }
@@ -103,9 +104,10 @@ class API_GoBot: XCTestCase {
         self.wait(for: 10)
     }
 
-    func test04_same_msgs() {
-        XCTAssertEqual(API_GoBot.bot.statistics.db.lastReceivedMessage, 6_699)
-        XCTAssertEqual(API_GoBot.bot.statistics.repo.messageCount, 6_700)
+    func test04_same_msgs() async {
+        let statistics = await API_GoBot.bot.statistics()
+        XCTAssertEqual(statistics.db.lastReceivedMessage, 6_699)
+        XCTAssertEqual(statistics.repo.messageCount, 6_700)
         
         XCTAssertTrue(API_GoBot.bot.bot.repoFSCK(.Sequences))
     }
@@ -118,14 +120,15 @@ class API_GoBot: XCTestCase {
         self.wait()
     }
 
-    func test07_refresh() {
+    func test07_refresh() async {
         API_GoBot.bot.refresh(load: .short, queue: .main) {
             (err, _) in
             XCTAssertNil(err)
         }
         self.wait()
-        XCTAssertEqual(API_GoBot.bot.statistics.db.lastReceivedMessage, 6_699)
-        XCTAssertEqual(API_GoBot.bot.statistics.repo.messageCount, 6_700)
+        let statistics = await API_GoBot.bot.statistics()
+        XCTAssertEqual(statistics.db.lastReceivedMessage, 6_699)
+        XCTAssertEqual(statistics.repo.messageCount, 6_700)
     }
 
     func test900_logout() {


### PR DESCRIPTION
As I was doing final QA on 1.1.0 (316) today I noticed that replication was not happening at all on a fresh install of Planetary. As I investigated it seemed that go-ssb was locking internally when `Bot.statistics` was called from multiple threads simultaneously. This would put go-ssb into a state where it wouldn't do anything else until you force quit the app.

This PR synchronizes access to the `Bot._statistics` variable, ensuring that we never hit this bug in go-ssb. I also got a main thread assertion failure in the BlobCache and fixed that as well.