### PR TITLE
Fix localization of Errors enum

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -3290,13 +3290,15 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Source/Localization/*.swift",
+				"$(SRCROOT)/Source/Localization/ExportStrings.swift",
+				"$(SRCROOT)/Source/Localization/Localizable.swift",
+				"$(SRCROOT)/Source/Localization/Text.swift",
+				"$(SRCROOT)/Source/Localization/ExportStrings.sh",
 			);
 			name = "Generate Localized Strings";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/Source/Localization/*.lproj/Generated.strings",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Source/Bot/BotError.swift
+++ b/Source/Bot/BotError.swift
@@ -38,9 +38,9 @@ enum BotError: Error, LocalizedError {
         case .notLoggedIn:
             return "Not logged in"
         case .forkProtection:
-            return Text.Errors.cannotPublishBecauseRestoring.text
+            return Text.Error.cannotPublishBecauseRestoring.text
         case .invalidAppConfiguration:
-            return Text.Errors.invalidAppConfiguration.text
+            return Text.Error.invalidAppConfiguration.text
         }
     }
 }

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -22,7 +22,6 @@ extension Text {
             Text.Channel.self,
             Text.Post.self,
             Text.Report.self,
-            Text.Error.self
         ]
     }
 }
@@ -387,6 +386,8 @@ extension Text {
         case unexpected = "Something unexpected happened."
         case supportNotConfigured = "Support is not configured."
         case invitationRedemptionFailed = "Could not join {{ starName }}. Please try again or contact support."
+        case cannotPublishBecauseRestoring = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time."
+        case invalidAppConfiguration = "Invalid app configuration"
     }
 }
 
@@ -412,15 +413,5 @@ extension Text {
         case postReplied = "%@ replied to your post"
         case feedMentioned = "%@ mentioned you in a post"
         case messageLiked = "%@ liked your post"
-    }
-}
-
-// MARK: - Errors
-
-extension Text {
-    // There should be a better way to do this for enum errors
-    enum Errors: String, Localizable, CaseIterable {
-        case cannotPublishBecauseRestoring = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time."
-        case invalidAppConfiguration = "Invalid app configuration"
     }
 }

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "Gefährliches und mächtiges Debug-Menü";
 "Debug.debugFooter" = "Hier lassen wir dich in den Fuß schießen. Hier gelangen Sie an Ihren privaten Schlüssel, setzen Sie neue Schlüssel, lesen Sie Informationen über das Netzwerk, Pubs und alle möglichen Dinge. Vorsicht, was Sie in diesem Menü ändern, können Sie Dinge mit diesen Optionen zu brechen.";
 
-"Error.login" = "Die Peer-to-Peer-Engine konnte nicht gestartet werden. Bitte verwenden Sie Neustart, um zu reparieren und neu zu starten, oder verwenden Sie Ignore, um die Inhalte zu durchsuchen, die bereits auf Ihrem Gerät abgerufen werden.";
-"Error.unexpected" = "Etwas Unerwartetes ist passiert.";
-"Error.supportNotConfigured" = "Support ist nicht konfiguriert.";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "Kanal";
 "Channel.many" = "Kanäle";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ antwortete auf deinen Beitrag";
 "Report.feedMentioned" = "%@ hat dich in einem Beitrag erwähnt";
 "Report.messageLiked" = "%@ gefällt dein Beitrag";
-
-"Error.login" = "Die Peer-to-Peer-Engine konnte nicht gestartet werden. Bitte verwenden Sie Neustart, um zu reparieren und neu zu starten, oder verwenden Sie Ignore, um die Inhalte zu durchsuchen, die bereits auf Ihrem Gerät abgerufen werden.";
-"Error.unexpected" = "Etwas Unerwartetes ist passiert.";
-"Error.supportNotConfigured" = "Support ist nicht konfiguriert.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Esta es la parte en la que dejamos que te dispares en el pié. Acá es donde accedés a tu llave privada, configurás nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambiás en este menú, podés romper cosas con estas opciones.";
 
-"Error.login" = "El motor de par-a-par falló al arrancar. Por favor probá cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "hashtag";
 "Channel.many" = "hashtags";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ respondió";
 "Report.feedMentioned" = "%@ te mencionó en un un post";
 "Report.messageLiked" = "A %@ le gustó tu post";
-
-"Error.login" = "El motor de par-a-par falló al arrancar. Por favor probá cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Aquí es donde dejamos que te dispares en el pié. Aquí es donde accedes a tu llave privada, configuras nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambias en este menú, puedes romper cosas con estas opciones.";
 
-"Error.login" = "El motor de par-a-par falló en el inicio. Por favor prueba cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
-"Error.invitationRedemptionFailed" = "No se pudo unir a {{ starName }}. Por favor, inténtalo de nuevo o contacta con soporte.";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
+"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "etiqueta";
 "Channel.many" = "etiquetas";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ respondió";
 "Report.feedMentioned" = "%@ te mencionó en una publicación";
 "Report.messageLiked" = "A %@ le gustó tu publicación";
-
-"Error.login" = "El motor de par-a-par falló en el inicio. Por favor prueba cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
-"Error.invitationRedemptionFailed" = "No se pudo unir a {{ starName }}. Por favor, inténtalo de nuevo o contacta con soporte.";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Esta es la parte en la que dejamos que te dispares en el pié. Acá es donde accedés a tu llave privada, configurás nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambiás en este menú, podés romper cosas con estas opciones.";
 
-"Error.login" = "El motor de par-a-par falló al arrancar. Por favor probá cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
-"Error.invitationRedemptionFailed" = "No pudimos unirte a {{ starName }}. Por favor, intentá de vuelta o contactá con soporte.";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
+"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "hashtag";
 "Channel.many" = "hashtags";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ respondió";
 "Report.feedMentioned" = "%@ te mencionó en un un post";
 "Report.messageLiked" = "A %@ le gustó tu post";
-
-"Error.login" = "El motor de par-a-par falló al arrancar. Por favor probá cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
-"Error.invitationRedemptionFailed" = "No pudimos unirte a {{ starName }}. Por favor, intentá de vuelta o contactá con soporte.";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Aquí es donde dejamos que te dispares en el pié. Aquí es donde accedes a tu llave privada, configuras nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambias en este menú, puedes romper cosas con estas opciones.";
 
-"Error.login" = "El motor de par-a-par falló en el inicio. Por favor prueba cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "etiqueta";
 "Channel.many" = "etiquetas";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ respondió";
 "Report.feedMentioned" = "%@ te mencionó en una publicación";
 "Report.messageLiked" = "A %@ le gustó tu publicación";
-
-"Error.login" = "El motor de par-a-par falló en el inicio. Por favor prueba cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
-"Error.unexpected" = "Algo inesperado ocurrió.";
-"Error.supportNotConfigured" = "Soporte no está configurado.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "Niebezpieczne i potężne menu debugowania";
 "Debug.debugFooter" = "Tutaj pozwoliliśmy Ci strzelić sobie w stopę. Tutaj możesz uzyskać dostęp do swojego klucz prywatny, dodać nowe klucze, oraz zobaczyć informacje o sieci i pubach. Uważaj, co zmieniasz, bo możesz zepsuć.";
 
-"Error.login" = "Nie udało się uruchomić połączenia z siecią. Uruchom ponownie, aby spróbować naprawić tą sytuację, lub użyj opcji Ignoruj, aby przeglądać zawartość, która została już pobrana na Twoje urządzenie.";
-"Error.unexpected" = "Stało się coś nieoczekiwanego.";
-"Error.supportNotConfigured" = "Wsparcie techniczne nie jest dostępne.";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "kanał";
 "Channel.many" = "kanały";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ odpowiedział na Twój post";
 "Report.feedMentioned" = "%@ wspomniał o Tobie w poście";
 "Report.messageLiked" = "%@ polubił twój post";
-
-"Error.login" = "Nie udało się uruchomić połączenia z siecią. Uruchom ponownie, aby spróbować naprawić tą sytuację, lub użyj opcji Ignoruj, aby przeglądać zawartość, która została już pobrana na Twoje urządzenie.";
-"Error.unexpected" = "Stało się coś nieoczekiwanego.";
-"Error.supportNotConfigured" = "Wsparcie techniczne nie jest dostępne.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "Niebezpieczne i potężne menu debugowania";
 "Debug.debugFooter" = "Tutaj pozwoliliśmy Ci strzelić sobie w stopę. Tutaj możesz uzyskać dostęp do swojego klucz prywatny, dodać nowe klucze, oraz zobaczyć informacje o sieci i pubach. Uważaj, co zmieniasz, bo możesz zepsuć.";
 
-"Error.login" = "Nie udało się uruchomić połączenia z siecią. Uruchom ponownie, aby spróbować naprawić tą sytuację, lub użyj opcji Ignoruj, aby przeglądać zawartość, która została już pobrana na Twoje urządzenie.";
-"Error.unexpected" = "Stało się coś nieoczekiwanego.";
-"Error.supportNotConfigured" = "Wsparcie techniczne nie jest dostępne.";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "kanał";
 "Channel.many" = "kanały";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ odpowiedział na Twój post";
 "Report.feedMentioned" = "%@ wspomniał o Tobie w poście";
 "Report.messageLiked" = "%@ polubił twój post";
-
-"Error.login" = "Nie udało się uruchomić połączenia z siecią. Uruchom ponownie, aby spróbować naprawić tą sytuację, lub użyj opcji Ignoruj, aby przeglądać zawartość, która została już pobrana na Twoje urządzenie.";
-"Error.unexpected" = "Stało się coś nieoczekiwanego.";
-"Error.supportNotConfigured" = "Wsparcie techniczne nie jest dostępne.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -228,10 +228,12 @@
 "Debug.debugMenu" = "危险和强大的调试菜单";
 "Debug.debugFooter" = "这是我们让你在脚下开枪的地方。 这里是您在私钥上的地方，设置新的密钥，查看网络信息，Pub和所有类型的事情。 注意你在这个菜单中的更改，你可以用这些选项打破一切。";
 
-"Error.login" = "对等点引擎的对等点启动失败。 请使用重启来修复并重新启动它，或使用忽略来浏览已经获取到您设备的内容。";
-"Error.unexpected" = "发生了一些意外事件。";
-"Error.supportNotConfigured" = "支持未配置。";
+"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
+"Error.unexpected" = "Something unexpected happened.";
+"Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "频道";
 "Channel.many" = "频道";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ 回复了你的动态";
 "Report.feedMentioned" = "%@ 提到你的评论";
 "Report.messageLiked" = "%@ X点赞了你";
-
-"Error.login" = "对等点引擎的对等点启动失败。 请使用重启来修复并重新启动它，或使用忽略来浏览已经获取到您设备的内容。";
-"Error.unexpected" = "发生了一些意外事件。";
-"Error.supportNotConfigured" = "支持未配置。";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -232,6 +232,8 @@
 "Error.unexpected" = "Something unexpected happened.";
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
+"Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.invalidAppConfiguration" = "Invalid app configuration";
 
 "Channel.one" = "channel";
 "Channel.many" = "channels";
@@ -245,8 +247,3 @@
 "Report.postReplied" = "%@ replied to your post";
 "Report.feedMentioned" = "%@ mentioned you in a post";
 "Report.messageLiked" = "%@ liked your post";
-
-"Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
-"Error.unexpected" = "Something unexpected happened.";
-"Error.supportNotConfigured" = "Support is not configured.";
-"Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";


### PR DESCRIPTION
This fixes a bug where some of the error messages weren't being localized, and where our ExportStrings.sh script wasn't always running when it needed to (you can't use wildcards in Build Phase Input File lists, apparently).