### PR TITLE
Fix showing alert if saving photo fails on AboutViewController

### DIFF
--- a/Source/App/AppController+Progress.swift
+++ b/Source/App/AppController+Progress.swift
@@ -18,7 +18,7 @@ extension AppController {
         SVProgressHUD.showSuccess(withStatus: text)
     }
     
-    func showProgress(after: TimeInterval = 1, statusText: String? = nil) {
+    func showProgress(after: TimeInterval = 0.3, statusText: String? = nil) {
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.setBackgroundColor(.appBackground)
         SVProgressHUD.setForegroundColor(UIColor.tint.default)

--- a/Source/Controller/AboutViewController.swift
+++ b/Source/Controller/AboutViewController.swift
@@ -178,12 +178,22 @@ class AboutViewController: ContentViewController {
         
         Analytics.shared.trackDidTapButton(buttonName: "update_avatar")
         self.imagePicker.present(from: sender, openCameraInSelfieMode: true) {
-            [unowned self] image in
-            guard let uiimage = image else {
+            [weak self] image in
+            guard let self = self,
+                  let uiimage = image else {
                 return
             }
-            self.publishProfilePhoto(uiimage) { [weak self] in
-                self?.imagePicker.dismiss()
+            self.imagePicker.dismiss {
+                AppController.shared.showProgress()
+                self.publishProfilePhoto(uiimage) { [weak self] error in
+                    AppController.shared.hideProgress()
+                    if let error = error {
+                        Log.optional(error)
+                        CrashReporting.shared.reportIfNeeded(error: error)
+                        self?.alert(error: error)
+                        return
+                    }
+                }
             }
         }
     }
@@ -237,47 +247,39 @@ class AboutViewController: ContentViewController {
         AppController.shared.choose(from: actions, sourceView: sender)
     }
 
-    private func publishProfilePhoto(_ uiimage: UIImage, completionHandler: @escaping () -> Void) {
-        // AppController.shared.showProgress()
-
+    private func publishProfilePhoto(_ uiimage: UIImage, completionHandler: @escaping (Error?) -> Void) {
         Bots.current.addBlob(jpegOf: uiimage, largestDimension: 1_000) { [weak self] image, error in
-            Log.optional(error)
-            CrashReporting.shared.reportIfNeeded(error: error)
             if let error = error {
-                AppController.shared.hideProgress()
-                self?.alert(error: error)
-            } else {
-                guard let about = self?.about?.mutatedCopy(image: image) else {
-                    // I don't see why this should ever happen
-                    // But will leave as it is
-                    let error = AppError.unexpected
-                    Log.optional(error)
-                    CrashReporting.shared.reportIfNeeded(error: error)
-                    AppController.shared.hideProgress()
+                completionHandler(error)
+                return
+            }
+            
+            guard let about = self?.about?.mutatedCopy(image: image) else {
+                // I don't see why this should ever happen
+                // But will leave as it is
+                let error = AppError.unexpected
+                completionHandler(error)
+                return
+            }
+            Bots.current.publish(content: about) { _, error in
+                if let error = error {
+                    completionHandler(error)
                     return
                 }
-                Bots.current.publish(content: about) { _, error in
-                    Log.optional(error)
-                    CrashReporting.shared.reportIfNeeded(error: error)
+                
+                Analytics.shared.trackDidUpdateAvatar()
+                Bots.current.about { (newAbout, error) in
                     if let error = error {
-                        AppController.shared.hideProgress()
-                        self?.alert(error: error)
-                    } else {
-                        Analytics.shared.trackDidUpdateAvatar()
-                        Bots.current.about { (newAbout, error) in
-                            Log.optional(error)
-                            CrashReporting.shared.reportIfNeeded(error: error)
-                            
-                            AppController.shared.hideProgress()
-                            
-                            if let newAbout = newAbout {
-                                NotificationCenter.default.post(Notification.didUpdateAbout(newAbout))
-                            }
-                            
-                            self?.aboutView.imageView.fade(to: uiimage)
-                            completionHandler()
-                        }
+                        completionHandler(error)
+                        return
                     }
+                    
+                    if let newAbout = newAbout {
+                        NotificationCenter.default.post(Notification.didUpdateAbout(newAbout))
+                    }
+                    
+                    self?.aboutView.imageView.fade(to: uiimage)
+                    completionHandler(nil)
                 }
             }
         }

--- a/Source/Controller/AboutViewController.swift
+++ b/Source/Controller/AboutViewController.swift
@@ -180,7 +180,7 @@ class AboutViewController: ContentViewController {
         self.imagePicker.present(from: sender, openCameraInSelfieMode: true) {
             [weak self] image in
             guard let self = self,
-                  let uiimage = image else {
+                let uiimage = image else {
                 return
             }
             self.imagePicker.dismiss {

--- a/Source/Controller/AboutViewController.swift
+++ b/Source/Controller/AboutViewController.swift
@@ -186,12 +186,14 @@ class AboutViewController: ContentViewController {
             self.imagePicker.dismiss {
                 AppController.shared.showProgress()
                 self.publishProfilePhoto(uiimage) { [weak self] error in
-                    AppController.shared.hideProgress()
-                    if let error = error {
-                        Log.optional(error)
-                        CrashReporting.shared.reportIfNeeded(error: error)
-                        self?.alert(error: error)
-                        return
+                    DispatchQueue.main.async {
+                        AppController.shared.hideProgress()
+                        if let error = error {
+                            Log.optional(error)
+                            CrashReporting.shared.reportIfNeeded(error: error)
+                            self?.alert(error: error)
+                            return
+                        }
                     }
                 }
             }
@@ -278,8 +280,10 @@ class AboutViewController: ContentViewController {
                         NotificationCenter.default.post(Notification.didUpdateAbout(newAbout))
                     }
                     
-                    self?.aboutView.imageView.fade(to: uiimage)
-                    completionHandler(nil)
+                    DispatchQueue.main.async {
+                        self?.aboutView.imageView.fade(to: uiimage)
+                        completionHandler(nil)
+                    }
                 }
             }
         }

--- a/Source/UI/ImagePicker.swift
+++ b/Source/UI/ImagePicker.swift
@@ -33,8 +33,8 @@ class ImagePicker: NSObject, UIImagePickerControllerDelegate, UINavigationContro
         self.promptForPhotoLibraryOrCamera(from: view)
     }
 
-    func dismiss() {
-        self.controller?.dismiss(animated: true, completion: nil)
+    func dismiss(completion: (() -> Void)? = nil) {
+        self.controller?.dismiss(animated: true, completion: completion)
     }
 
     // MARK: Prompting for source or to open Settings


### PR DESCRIPTION
This fixes a little bug I found while hunting down some blob issues. We were trying to present error alerts on top of the image picker which didn't work and the UI would freeze. I noticed it because I was getting forked feed protection errors when trying to set an image for my test profile. You may need to delete and reinstall the app in order to reproduce.

I also started showing a loading indicator again in this case. The code to show it was commented out for some reason. I also shortened the "grace" time for loading indicators because it felt really long.