### PR TITLE
Add swiftlint as a Planetary target build phase

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -1272,7 +1272,7 @@
 		53FCAFDD22051C88009E9E82 /* SecretViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecretViewController.swift; sourceTree = "<group>"; };
 		5B0D585327BEE1F1002F927D /* Secrets.release.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.release.plist; sourceTree = "<group>"; };
 		5B0D585827BEE4FC002F927D /* Secrets.debug.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.debug.plist; sourceTree = "<group>"; };
-		5B8DC4CD27FF8BB00007E73F /* swiftlint.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = swiftlint.sh; sourceTree = "<group>"; };
+		5B8DC4CD27FF8BB00007E73F /* swiftlint_diffonly.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = swiftlint_diffonly.sh; sourceTree = "<group>"; };
 		5B9A5EF727E8D1F1001D7CA3 /* CrashReporting+GoBot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashReporting+GoBot.swift"; sourceTree = "<group>"; };
 		5EA32E74C0DFF1EF8924773F /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		606DCE79703F49AE5AB530BD /* Pods-APITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-APITests/Pods-APITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1812,7 +1812,7 @@
 			children = (
 				0AD8D62D2408627000D87A95 /* go_install.sh */,
 				532751D5222A3EF60026500F /* increment_build.sh */,
-				5B8DC4CD27FF8BB00007E73F /* swiftlint.sh */,
+				5B8DC4CD27FF8BB00007E73F /* swiftlint_diffonly.sh */,
 			);
 			path = Scripts;
 			sourceTree = "<group>";
@@ -2830,7 +2830,7 @@
 			buildConfigurationList = 5344D83D21C4649A00704A34 /* Build configuration list for PBXNativeTarget "Planetary" */;
 			buildPhases = (
 				D4A56648BF87798DA8D53240 /* [CP] Check Pods Manifest.lock */,
-				5B8DC4CE27FF8C960007E73F /* Run swiftlint */,
+				5B8DC4CE27FF8C960007E73F /* Run swiftlint on modified files */,
 				8D9143FB230C6B670075BC8A /* Generate Localized Strings */,
 				5B0D584E27BAAE69002F927D /* Make Acknowledgments.plist */,
 				5B0D585727BEE41D002F927D /* Copy Secrets.plist */,
@@ -3224,7 +3224,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif [ $CONFIGURATION = \"Debug\" ]; then\ncp $SRCROOT/Resources/Secrets.debug.plist $CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist\nelse\ncp $SRCROOT/Resources/Secrets.release.plist $CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist\nfi\n";
 		};
-		5B8DC4CE27FF8C960007E73F /* Run swiftlint */ = {
+		5B8DC4CE27FF8C960007E73F /* Run swiftlint on modified files */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -3234,14 +3234,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Run swiftlint";
+			name = "Run swiftlint on modified files";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nsh $SRCROOT/Scripts/swiftlint.sh\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nsh $SRCROOT/Scripts/swiftlint_diffonly.sh\n";
 		};
 		7723EA9C2D57EFC61D5051B3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -1272,6 +1272,7 @@
 		53FCAFDD22051C88009E9E82 /* SecretViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecretViewController.swift; sourceTree = "<group>"; };
 		5B0D585327BEE1F1002F927D /* Secrets.release.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.release.plist; sourceTree = "<group>"; };
 		5B0D585827BEE4FC002F927D /* Secrets.debug.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.debug.plist; sourceTree = "<group>"; };
+		5B8DC4CD27FF8BB00007E73F /* swiftlint.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = swiftlint.sh; sourceTree = "<group>"; };
 		5B9A5EF727E8D1F1001D7CA3 /* CrashReporting+GoBot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashReporting+GoBot.swift"; sourceTree = "<group>"; };
 		5EA32E74C0DFF1EF8924773F /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		606DCE79703F49AE5AB530BD /* Pods-APITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-APITests/Pods-APITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1811,6 +1812,7 @@
 			children = (
 				0AD8D62D2408627000D87A95 /* go_install.sh */,
 				532751D5222A3EF60026500F /* increment_build.sh */,
+				5B8DC4CD27FF8BB00007E73F /* swiftlint.sh */,
 			);
 			path = Scripts;
 			sourceTree = "<group>";
@@ -2828,6 +2830,7 @@
 			buildConfigurationList = 5344D83D21C4649A00704A34 /* Build configuration list for PBXNativeTarget "Planetary" */;
 			buildPhases = (
 				D4A56648BF87798DA8D53240 /* [CP] Check Pods Manifest.lock */,
+				5B8DC4CE27FF8C960007E73F /* Run swiftlint */,
 				8D9143FB230C6B670075BC8A /* Generate Localized Strings */,
 				5B0D584E27BAAE69002F927D /* Make Acknowledgments.plist */,
 				5B0D585727BEE41D002F927D /* Copy Secrets.plist */,
@@ -3220,6 +3223,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif [ $CONFIGURATION = \"Debug\" ]; then\ncp $SRCROOT/Resources/Secrets.debug.plist $CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist\nelse\ncp $SRCROOT/Resources/Secrets.release.plist $CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist\nfi\n";
+		};
+		5B8DC4CE27FF8C960007E73F /* Run swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run swiftlint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nsh $SRCROOT/Scripts/swiftlint.sh\n";
 		};
 		7723EA9C2D57EFC61D5051B3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Scripts/swiftlint.sh
+++ b/Scripts/swiftlint.sh
@@ -1,0 +1,28 @@
+# Run SwiftLint
+START_DATE=$(date +"%s")
+
+SWIFT_LINT=/opt/homebrew/bin/swiftlint
+
+# Run SwiftLint for given filename
+run_swiftlint() {
+    local filename="${1}"
+    if [[ "${filename##*.}" == "swift" ]]; then
+        ${SWIFT_LINT} autocorrect --path "${filename}"
+        ${SWIFT_LINT} lint --lenient --path "${filename}"
+    fi
+}
+
+if [[ -e "${SWIFT_LINT}" ]]; then
+    echo "SwiftLint version: $(${SWIFT_LINT} version)"
+    # Run for both staged and unstaged files
+    git diff --name-only | while read filename; do run_swiftlint "${filename}"; done
+    git diff --cached --name-only | while read filename; do run_swiftlint "${filename}"; done
+else
+    echo "${SWIFT_LINT} is not installed."
+    exit 0
+fi
+
+END_DATE=$(date +"%s")
+
+DIFF=$(($END_DATE - $START_DATE))
+echo "SwiftLint took $(($DIFF / 60)) minutes and $(($DIFF % 60)) seconds to complete."

--- a/Scripts/swiftlint_diffonly.sh
+++ b/Scripts/swiftlint_diffonly.sh
@@ -1,4 +1,8 @@
-# Run SwiftLint
+#!/bin/sh
+
+# Script to run swiftlint on modified files (staged or unstaged) using git diff
+# Source: https://github.com/realm/SwiftLint/issues/413
+
 START_DATE=$(date +"%s")
 
 SWIFT_LINT=/opt/homebrew/bin/swiftlint
@@ -24,5 +28,5 @@ fi
 
 END_DATE=$(date +"%s")
 
-DIFF=$(($END_DATE - $START_DATE))
-echo "SwiftLint took $(($DIFF / 60)) minutes and $(($DIFF % 60)) seconds to complete."
+DIFF=$((END_DATE - START_DATE))
+echo "SwiftLint took $((DIFF / 60)) minutes and $((DIFF % 60)) seconds to complete."


### PR DESCRIPTION
This PR adds a "Run swiftlint" in the main target that executes SwiftLint just in the modified files as documented in https://github.com/realm/SwiftLint/issues/413.

The script itself is in Scripts/swiftlint.sh just in case we want to run SwiftLint from the console as well, or from a pre-commit hook. 

It doesn't fail if SwiftLint is not installed, but it doesn't succeed if SwiftLint was not installed using HomeBrew. I think both of us use brew so it won't be a problem for now, but we might need to change the SWIFT_LINT=/opt/homebrew/bin/swiftlint part in the future.