### PR TITLE
Fixed numberOfLines for secret text label in debug menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - Fixed invitation to three.planetary.pub
 - Added Russian and Ukrainian language pubs to the community pub list #474
+- Fixed secret key JSON overflowing its text box in the debug settings #493 @cappster
 
 ## [1.1.0] = 2022-04-04
 - Added several new community pubs #450

--- a/Source/Debug/AppConfigurationViewController.swift
+++ b/Source/Debug/AppConfigurationViewController.swift
@@ -165,7 +165,7 @@ class AppConfigurationViewController: DebugTableViewController {
                                              valueClosure: {
                 [unowned self] cell in
                 cell.textLabel?.isEnabled = self.canEditConfiguration
-                cell.textLabel?.numberOfLines = 0
+                cell.textLabel?.numberOfLines = 1
                 guard let secret = self.configuration.secret ?? self.secret else { return }
                 cell.textLabel?.text = secret.jsonStringUnescaped()
             },


### PR DESCRIPTION
I've found a problem that a secret in the configuration menu is shown wrong. You could see it on this screenshot:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/7153094/162970639-71657b4a-0916-4bc8-8fd7-07a3668678a8.png">

So i've fixed it by changing a numberOfLines property. Now it looks like this:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/7153094/162970685-cd1ed53f-f752-4c1a-a803-79a68c985175.png">
