### PR TITLE
Fix key import forking feeds

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -121,4 +121,5 @@ identifier_name:
     - key
     - pub
     - bot
+    - sut
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)

--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -682,6 +682,7 @@
 		C93FE9BB27D6C3F10013D4CF /* UIImage+Verse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E341FD224FF9EE002BB5F4 /* UIImage+Verse.swift */; };
 		C941A6E427ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
 		C941A6E527ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
+		C950B5512805CD6700D7059B /* JoinPlanetarySystemOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C950B5502805CD6600D7059B /* JoinPlanetarySystemOperation.swift */; };
 		C955CAB627D18367005146F2 /* Bundle+Current.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531A8A4F21FA622900D5C8C0 /* Bundle+Current.swift */; };
 		C955CAB727D18368005146F2 /* Bundle+Current.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531A8A4F21FA622900D5C8C0 /* Bundle+Current.swift */; };
 		C955CAB827D18368005146F2 /* Bundle+Current.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531A8A4F21FA622900D5C8C0 /* Bundle+Current.swift */; };
@@ -1318,6 +1319,7 @@
 		C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadedBlobService.swift; sourceTree = "<group>"; };
 		C9489999278CCC3A009BE021 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		C94BACFB279EFE0E00CC4743 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		C950B5502805CD6600D7059B /* JoinPlanetarySystemOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinPlanetarySystemOperation.swift; sourceTree = "<group>"; };
 		C9570F63278752D30095EFFF /* GoSSB.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoSSB.xcframework; path = GoSSB/Products/GoSSB.xcframework; sourceTree = "<group>"; };
 		C9570F652788E2280095EFFF /* Architecture */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Architecture; sourceTree = "<group>"; };
 		C95A131F2786279A00FFD52F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -1481,6 +1483,7 @@
 				0A1CA4C424E5D714006CAC43 /* FollowOperation.swift */,
 				0A1CA4C924EB2353006CAC43 /* SendMissionOperation.swift */,
 				0AAF8C4625C704B500FD8D0F /* UnfollowOperation.swift */,
+				C950B5502805CD6600D7059B /* JoinPlanetarySystemOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -3812,6 +3815,7 @@
 				0A64A83C247353CE009A5EBF /* VersePushAPI.swift in Sources */,
 				53EE01F42204F66200DFDF16 /* Secret.swift in Sources */,
 				53B4F5FF22B9E4F200027C6A /* Abouts.swift in Sources */,
+				C950B5512805CD6700D7059B /* JoinPlanetarySystemOperation.swift in Sources */,
 				2356500B2369C6CB00C3DBC0 /* DropContentRequest.swift in Sources */,
 				53211CC8227B60EE007FB785 /* ContactsViewControllers.swift in Sources */,
 				53033E9F2383322B004609F8 /* Onboarding+AppConfiguration.swift in Sources */,

--- a/Source/App/AppConfiguration.swift
+++ b/Source/App/AppConfiguration.swift
@@ -26,6 +26,10 @@ class AppConfiguration: NSObject, NSCoding {
     /// their feed has fully synced, which "forks" or breaks it forever.
     /// Should be kept up-to-date by the `Bot`.
     var numberOfPublishedMessages: Int = 0
+    
+    /// A bool indicating whether the user has opted to join the "Planetary System". Joining the Planetary System means
+    /// the system pubs will follow you automatically.
+    var joinedPlanetarySystem = false
 
     private var networkDidChange = false
     var network: NetworkKey? {
@@ -98,6 +102,9 @@ class AppConfiguration: NSObject, NSCoding {
         if aDecoder.containsValue(forKey: "numberOfPublishedMessages") {
             self.numberOfPublishedMessages = aDecoder.decodeInteger(forKey: "numberOfPublishedMessages")
         }
+        if aDecoder.containsValue(forKey: "joinedPlanetarySystem") {
+            self.joinedPlanetarySystem = aDecoder.decodeBool(forKey: "joinedPlanetarySystem")
+        }
     }
 
     func encode(with aCoder: NSCoder) {
@@ -106,6 +113,7 @@ class AppConfiguration: NSObject, NSCoding {
         if let network = self.network { aCoder.encode(network.data, forKey: "network") }
         if let bot = self.bot { aCoder.encode(bot.name, forKey: "bot") }
         aCoder.encode(numberOfPublishedMessages, forKey: "numberOfPublishedMessages")
+        aCoder.encode(joinedPlanetarySystem, forKey: "joinedPlanetarySystem")
     }
 
     override func isEqual(_ object: Any?) -> Bool {

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -37,7 +37,7 @@ enum RefreshLoad: Int32, CaseIterable {
 
 /// Abstract interface to any SSB bot implementation.
 /// - SeeAlso: `GoBot`
-protocol Bot {
+protocol Bot: AnyObject {
 
     // MARK: Name
     var name: String { get }
@@ -293,8 +293,20 @@ extension Bot {
         self.redeemInvitation(to: star, completionQueue: .main, completion: completion)
     }
     
-    func pubs(completion: @escaping (([Pub], Error?) -> Void)) {
+    func joinedPubs(completion: @escaping (([Pub], Error?) -> Void)) {
         self.joinedPubs(queue: .main, completion: completion)
+    }
+    
+    func joinedPubs() async throws -> [Pub] {
+        return try await withCheckedThrowingContinuation { continuation in
+            joinedPubs(queue: DispatchQueue.main) { result, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: result)
+            }
+        }
     }
     
     func publish(content: ContentCodable, completion: @escaping PublishCompletion) {

--- a/Source/Bot/Operations/JoinPlanetarySystemOperation.swift
+++ b/Source/Bot/Operations/JoinPlanetarySystemOperation.swift
@@ -34,8 +34,10 @@ class JoinPlanetarySystemOperation: AsynchronousOperation {
         }
         
         guard self.userDefaults.bool(forKey: "prevent_feed_from_forks") else {
-            Log.info("JoinPlanetarySystemOperation refusing to join Planetary system pubs because forked feed " +
-                " protection is turned off.")
+            Log.info(
+                "JoinPlanetarySystemOperation refusing to join Planetary system pubs because forked feed " +
+                " protection is turned off."
+            )
             self.finish()
             return
         }

--- a/Source/Bot/Operations/JoinPlanetarySystemOperation.swift
+++ b/Source/Bot/Operations/JoinPlanetarySystemOperation.swift
@@ -1,0 +1,78 @@
+//
+//  JoinPlanetarySystemOperation.swift
+//  Planetary
+//
+//  Created by Matthew Lorentz on 4/12/22.
+//  Copyright © 2022 Verse Communications Inc. All rights reserved.
+//
+
+import Foundation
+import Logger
+
+/// Joins the Planetary System pubs if the user has opted in.
+class JoinPlanetarySystemOperation: AsynchronousOperation {
+    
+    private var appConfiguration: AppConfiguration
+    
+    private var operationQueue: OperationQueue
+    
+    /// Minimum number of Planetary's pubs that should be followng the user for them to be considered in the system.
+    private static let minNumberOfStars = 3
+    
+    init(appConfiguration: AppConfiguration, operationQueue: OperationQueue) {
+        self.appConfiguration = appConfiguration
+        self.operationQueue = operationQueue
+    }
+    
+    override func main() {
+        guard let bot = appConfiguration.bot else {
+            Log.info("JoinPlanetarySystemOperation was given an AppConfiguration with no Bot.")
+            self.finish()
+            return
+        }
+        
+        Task {
+            guard appConfiguration.joinedPlanetarySystem else {
+                self.finish()
+                return
+            }
+                
+            do {
+                let allJoinedPubs = try await bot.joinedPubs()
+                let stars = Set(Environment.Constellation.stars)
+                let joinedStars = stars.filter { star in
+                    allJoinedPubs.contains { (pub) -> Bool in
+                        pub.address.key == star.feed
+                    }
+                }
+            
+                let numberOfMissingStars = Self.minNumberOfStars - joinedStars.count
+                if numberOfMissingStars > 0 {
+                    Log.debug("User needs to be followed by \(numberOfMissingStars) to be part of the Planetary System")
+                    
+                    // Let's take a random set of stars to reach the minimum and create Redeem Invite
+                    // operations
+                    let missingStars = stars.subtracting(joinedStars)
+                    let randomSampleOfStars = missingStars.randomSample(UInt(numberOfMissingStars))
+                    var redeemInviteOperations = [RedeemInviteOperation]()
+                    redeemInviteOperations = randomSampleOfStars.map {
+                        RedeemInviteOperation(star: $0, shouldFollow: false)
+                    }
+                    
+                    // Sync with stars after following
+                    let peerPool = randomSampleOfStars.map { $0.toPeer() }
+                    
+                    let syncOperation = SyncOperation(peerPool: peerPool)
+                    redeemInviteOperations.forEach { syncOperation.addDependency($0) }
+                    
+                    let operations = redeemInviteOperations + [syncOperation]
+                    self.operationQueue.addOperations(operations, waitUntilFinished: true)
+                }
+            } catch {
+                Log.optional(error)
+            }
+                
+            self.finish()
+        }
+    }
+}

--- a/Source/Bot/Operations/JoinPlanetarySystemOperation.swift
+++ b/Source/Bot/Operations/JoinPlanetarySystemOperation.swift
@@ -19,6 +19,8 @@ class JoinPlanetarySystemOperation: AsynchronousOperation {
     /// Minimum number of Planetary's pubs that should be followng the user for them to be considered in the system.
     private static let minNumberOfStars = 3
     
+    let userDefaults = UserDefaults.standard
+    
     init(appConfiguration: AppConfiguration, operationQueue: OperationQueue) {
         self.appConfiguration = appConfiguration
         self.operationQueue = operationQueue
@@ -31,12 +33,19 @@ class JoinPlanetarySystemOperation: AsynchronousOperation {
             return
         }
         
+        guard self.userDefaults.bool(forKey: "prevent_feed_from_forks") else {
+            Log.info("JoinPlanetarySystemOperation refusing to join Planetary system pubs because forked feed " +
+                " protection is turned off.")
+            self.finish()
+            return
+        }
+        
+        guard appConfiguration.joinedPlanetarySystem else {
+            self.finish()
+            return
+        }
+        
         Task {
-            guard appConfiguration.joinedPlanetarySystem else {
-                self.finish()
-                return
-            }
-                
             do {
                 let allJoinedPubs = try await bot.joinedPubs()
                 let stars = Set(Environment.Constellation.stars)

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -10,8 +10,8 @@ import Foundation
 import Logger
 import CrashReporting
 
-/// Starts and/or cycles connections to pub servers. It redeems invitations to the system pubs if the user
-/// didn't do it previously.
+/// Starts and/or cycles connections to pub servers. It also redeems invitations to the system pubs if the user
+/// has opted in.
 class SendMissionOperation: AsynchronousOperation {
     
     enum MissionQuality {
@@ -24,9 +24,6 @@ class SendMissionOperation: AsynchronousOperation {
     
     /// Result of the operation
     private(set) var result: Result<Void, Error> = .failure(AppError.unexpected)
-    
-    /// Minimum number of Planetary's pubs the users must have been invited to
-    private static let minNumberOfStars = 3
     
     /// Internal operation queue meant for executing other operations
     private let operationQueue = OperationQueue()
@@ -69,34 +66,9 @@ class SendMissionOperation: AsynchronousOperation {
                     return
                 }
                 
-                // Get the stars the users already redeemed an invite to
-                let joinedStars = stars.filter { star in
-                    allJoinedPubs.contains { (pub) -> Bool in
-                        pub.address.key == star.feed
-                    }
-                }
+                let joinPlanetarySystemOperation = JoinPlanetarySystemOperation(appConfiguration: AppConfiguration.current!, operationQueue: self.operationQueue)
                 
-                var starsToJoin = Set<Star>()
-                var redeemInviteOperations = [RedeemInviteOperation]()
-                
-                // Join more stars if we haven't yet.
-                let numberOfMissingStars = SendMissionOperation.minNumberOfStars - joinedStars.count
-                if numberOfMissingStars > 0 {
-                    Log.debug("Joining \(numberOfMissingStars) stars to get to minimum.")
-                    
-                    // Let's take a random set of stars to reach the minimum and create Redeem Invite
-                    // operations
-                    let missingStars = stars.subtracting(joinedStars)
-                    let randomSampleOfStars = missingStars.randomSample(UInt(numberOfMissingStars))
-                    redeemInviteOperations = randomSampleOfStars.map {
-                        RedeemInviteOperation(star: $0, shouldFollow: false)
-                    }
-                    
-                    // Lets sync to available stars and newly redeemed stars
-                    starsToJoin = missingStars
-                }
-                
-                let peerPool = allJoinedPubs.map { $0.toPeer() } + starsToJoin.map { $0.toPeer() }
+                let peerPool = allJoinedPubs.map { $0.toPeer() } + stars.map { $0.toPeer() }
                 
                 let syncOperation = SyncOperation(peerPool: peerPool)
                 switch self.quality {
@@ -105,9 +77,9 @@ class SendMissionOperation: AsynchronousOperation {
                 case .high:
                     syncOperation.notificationsOnly = false
                 }
-                redeemInviteOperations.forEach { syncOperation.addDependency($0) }
+                syncOperation.addDependency(joinPlanetarySystemOperation)
                 
-                let operations = redeemInviteOperations + [syncOperation]
+                let operations = [joinPlanetarySystemOperation, syncOperation]
                 self.operationQueue.addOperations(operations, waitUntilFinished: true)
                 
                 Log.info("SendMissionOperation finished.")

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -62,11 +62,14 @@ class SendMissionOperation: AsynchronousOperation {
                     CrashReporting.shared.reportIfNeeded(error: error)
                 }
                 
-                guard let self = self else {
+                guard let self = self, let appConfiguration = AppConfiguration.current else {
                     return
                 }
                 
-                let joinPlanetarySystemOperation = JoinPlanetarySystemOperation(appConfiguration: AppConfiguration.current!, operationQueue: self.operationQueue)
+                let joinPlanetarySystemOperation = JoinPlanetarySystemOperation(
+                    appConfiguration: appConfiguration,
+                    operationQueue: self.operationQueue
+                )
                 
                 let peerPool = allJoinedPubs.map { $0.toPeer() } + stars.map { $0.toPeer() }
                 

--- a/Source/Controller/ManagePubsViewController.swift
+++ b/Source/Controller/ManagePubsViewController.swift
@@ -33,7 +33,7 @@ class ManagePubsViewController: UITableViewController, KnownPubsTableViewDataSou
         self.dataSource.delegate = self
         self.tableView.dataSource = self.dataSource
         self.tableView.prefetchDataSource = self.dataSource
-        Bots.current.pubs { [weak self] (pubs, error) in
+        Bots.current.joinedPubs { [weak self] (pubs, error) in
             Log.optional(error)
             CrashReporting.shared.reportIfNeeded(error: error)
             if let error = error {

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -611,13 +611,9 @@ class ViewDatabase {
         }
 
         let qry = self.msgs
-           .join(self.pubs, on: self.pubs[colMessageRef] == self.msgs[colMessageID])
+            .join(self.pubs, on: self.pubs[colMessageRef] == self.msgs[colMessageID])
             .where(self.msgs[colAuthorID] == currentUserID)
             .where(self.msgs[colMsgType] == "pub")
-            .join(authors, on: authors[colAuthor] == pubs[colKey])
-            .join(contacts, on: contacts[colContactID] == authors[colID])
-            .filter(contacts[colAuthorID] == currentUserID)
-            .filter(colContactState == 1)
 
         return try db.prepare(qry).map { row in
             let host = try row.get(colHost)

--- a/Source/Onboarding/Onboarding.swift
+++ b/Source/Onboarding/Onboarding.swift
@@ -101,6 +101,8 @@ class Onboarding {
             // create app configuration with name and time stamp
             let configuration = AppConfiguration(with: secret)
             configuration.name = "\(name) (\(Date().shortDateTimeString))"
+            // We will add this as an option in the UI in the future #494
+            configuration.joinedPlanetarySystem = true
 
             // TODO https://app.asana.com/0/0/1134329918920789/f
             // TODO abstract GoBot network configuration

--- a/UnitTests/AppConfigurationTests.swift
+++ b/UnitTests/AppConfigurationTests.swift
@@ -9,23 +9,49 @@
 import KeychainSwift
 import XCTest
 
-extension XCTestCase {
-
-    func configuration() -> AppConfiguration {
-        let data = self.data(for: "Secret.json")
-        let secret = try? JSONDecoder().decode(Secret.self, from: data)
-        let configuration = AppConfiguration(with: secret!)
-        return configuration
-    }
-}
+// swiftlint:disable force_unwrapping implicitly_unwrapped_optional
 
 class AppConfigurationTests: XCTestCase {
+    
+    var secret: Secret!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        let data = self.data(for: "Secret.json")
+        secret = try! JSONDecoder().decode(Secret.self, from: data)
+    }
 
-    func test_archiving() {
-        let configuration = self.configuration()
-        let data = configuration.toData()
-        XCTAssertNotNil(data)
-        let configurationFromData = AppConfiguration.from(data!)
-        XCTAssertNotNil(configurationFromData)
+    func test_archiving() throws {
+        // Arrange
+        let configuration = AppConfiguration(with: secret)
+        configuration.name = "Test Configuration"
+        configuration.network = NetworkKey(base64: "123")
+        configuration.hmacKey = HMACKey(base64: "456")
+        configuration.bot = FakeBot()
+        configuration.numberOfPublishedMessages = 999
+        configuration.joinedPlanetarySystem = true
+        
+        // Act
+        let data = try XCTUnwrap(configuration.toData())
+        let configurationFromData = try XCTUnwrap(AppConfiguration.from(data))
+        
+        // Assert
+        XCTAssertEqual(configurationFromData.name, configuration.name)
+        XCTAssertEqual(configurationFromData.network, configuration.network)
+        XCTAssertEqual(configurationFromData.secret, configuration.secret)
+        XCTAssert(configurationFromData.bot === FakeBot.shared)
+        XCTAssertEqual(configurationFromData.hmacKey, configuration.hmacKey)
+        XCTAssertEqual(configurationFromData.numberOfPublishedMessages, configuration.numberOfPublishedMessages)
+        XCTAssertEqual(configurationFromData.joinedPlanetarySystem, configuration.joinedPlanetarySystem)
+    }
+    
+    func testDefaultNumberOfPublishedMessages() {
+        let sut = AppConfiguration(with: secret)
+        XCTAssertEqual(sut.numberOfPublishedMessages, 0)
+    }
+    
+    func testDefaultJoinedPlanetarySystem() {
+        let sut = AppConfiguration(with: secret)
+        XCTAssertEqual(sut.joinedPlanetarySystem, false)
     }
 }

--- a/UnitTests/AppConfigurationTests.swift
+++ b/UnitTests/AppConfigurationTests.swift
@@ -9,7 +9,7 @@
 import KeychainSwift
 import XCTest
 
-// swiftlint:disable implicitly_unwrapped_optional
+// swiftlint:disable implicitly_unwrapped_optional 
 
 class AppConfigurationTests: XCTestCase {
     
@@ -18,7 +18,7 @@ class AppConfigurationTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         let data = self.data(for: "Secret.json")
-        secret = try! JSONDecoder().decode(Secret.self, from: data)
+        secret = try JSONDecoder().decode(Secret.self, from: data)
     }
 
     func test_archiving() throws {

--- a/UnitTests/AppConfigurationTests.swift
+++ b/UnitTests/AppConfigurationTests.swift
@@ -9,7 +9,7 @@
 import KeychainSwift
 import XCTest
 
-// swiftlint:disable force_unwrapping implicitly_unwrapped_optional
+// swiftlint:disable implicitly_unwrapped_optional
 
 class AppConfigurationTests: XCTestCase {
     


### PR DESCRIPTION
#485 This prevents us from auto joining Planetary system pubs if the user has created their identity by adding their secret key in the debug menu. It does this by adding a new `joinedPlanetarySystem` flag to `AppConfiguration`. System pubs are only auto-joined if this flag is set, and it is only set during onboarding. Right now it is always set if the user creates their identity in the onboarding flow, but in the future it will be easy to add a toggle in the UI that is bound to the flag. This would let users opt out of having the Planetary pubs auto-follow them.

I also fixed a bug where we were redeeming invitations to the system pubs multiple times. It wasn't hurting anything but it did create a lot of noise.

Also I tweaked the sync algorithm so that the app will connect to the Planetary system pubs even if the user doesn't have any published pub messages, like in the case of a restore.