### PR TITLE
Fixed numberOfPublishedMessages being incorrect after a secret key im…

### DIFF
--- a/Planetary.xcodeproj/xcshareddata/xcbaselines/5308168421C46A52005C48ED.xcbaseline/188BAB62-50E9-4AEA-A97C-F3B7599AC7F7.plist
+++ b/Planetary.xcodeproj/xcshareddata/xcbaselines/5308168421C46A52005C48ED.xcbaseline/188BAB62-50E9-4AEA-A97C-F3B7599AC7F7.plist
@@ -56,7 +56,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>2.180000</real>
+					<real>0.477000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Source/App/AppConfiguration+Keychain.swift
+++ b/Source/App/AppConfiguration+Keychain.swift
@@ -16,6 +16,7 @@ extension AppConfiguration {
 
     func apply() {
         Keychain.configuration = self
+        AppConfigurations.add(self)
     }
 
     func unapply() {
@@ -34,8 +35,11 @@ extension AppConfigurations {
     }
 
     static func add(_ configuration: AppConfiguration) {
-        if let _ = Keychain.configurations.firstIndex(of: configuration) { return }
-        Keychain.configurations += [configuration]
+        if let existingIndex = Keychain.configurations.firstIndex(where: {configuration.identity == $0.identity}) {
+            Keychain.configurations[existingIndex] = configuration
+        } else {
+            Keychain.configurations += [configuration]
+        }
     }
 
     static func delete(_ configuration: AppConfiguration) {

--- a/Source/App/AppController+Progress.swift
+++ b/Source/App/AppController+Progress.swift
@@ -18,7 +18,7 @@ extension AppController {
         SVProgressHUD.showSuccess(withStatus: text)
     }
     
-    func showProgress(after: TimeInterval = 1, statusText: String? = nil) {
+    @MainActor func showProgress(after: TimeInterval = 1, statusText: String? = nil) {
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.setBackgroundColor(.appBackground)
         SVProgressHUD.setForegroundColor(UIColor.tint.default)
@@ -26,11 +26,11 @@ extension AppController {
         SVProgressHUD.show(withStatus: statusText)
     }
 
-    func updateProgress(perc: Float64, status: String? = nil) {
+    @MainActor func updateProgress(perc: Float64, status: String? = nil) {
         SVProgressHUD.showProgress(Float(perc), status: status)
     }
     
-    func hideProgress(completion: (() -> Void)? = nil) {
+    @MainActor func hideProgress(completion: (() -> Void)? = nil) {
         SVProgressHUD.dismiss { completion?() }
     }
 }

--- a/Source/App/AppDelegate+Repair.swift
+++ b/Source/App/AppDelegate+Repair.swift
@@ -26,7 +26,7 @@ extension AppDelegate {
 
         // repair onboarding status' for all identities
         for configuration in configurations {
-            guard let identity = configuration.identity else { continue }
+            let identity = configuration.identity
             let status = Onboarding.status(for: identity)
             Onboarding.set(status: status, for: identity)
         }

--- a/Source/Bot/Bot+AppConfiguration.swift
+++ b/Source/Bot/Bot+AppConfiguration.swift
@@ -17,7 +17,6 @@ extension Bot {
                completion: @escaping ((Bool) -> Void)) {
         guard configuration.canLaunch else { completion(false); return }
         guard configuration.network != nil else { completion(false); return }
-        guard configuration.secret != nil else { completion(false); return }
 
         Bots.current.login(config: configuration) { error in
             let loggedIn = ((error as? BotError) == .alreadyLoggedIn) || error == nil

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -20,7 +20,11 @@ typealias PaginatedCompletion = ((PaginatedKeyValueDataProxy, Error?) -> Void)
 typealias HashtagCompletion = ((Hashtag?, Error?) -> Void)
 typealias HashtagsCompletion = (([Hashtag], Error?) -> Void)
 typealias PublishCompletion = ((MessageIdentifier, Error?) -> Void)
-typealias RefreshCompletion = ((Error?, TimeInterval) -> Void)
+
+/// - Error: an error if the refresh failed
+/// - TimeInterval: the amount of time the refresh took
+/// - Bool: True if the view database is fully up to date with the backing store.
+typealias RefreshCompletion = ((Error?, TimeInterval, Bool) -> Void)
 typealias SecretCompletion = ((Secret?, Error?) -> Void)
 typealias SyncCompletion = ((Error?, TimeInterval, Int) -> Void)
 typealias ThreadCompletion = ((KeyValue?, PaginatedKeyValueDataProxy, Error?) -> Void)
@@ -237,10 +241,17 @@ extension Bot {
         self.sync(queue: .main, peers: peers, completion: completion)
     }
     
-    func refresh(load: RefreshLoad, queue: DispatchQueue = .main) async -> (Error?, TimeInterval) {
-        await withCheckedContinuation { continuation in
-            refresh(load: load, queue: queue) { result1, result2 in
-                continuation.resume(returning: (result1, result2))
+    @discardableResult func refresh(
+        load: RefreshLoad,
+        queue: DispatchQueue = .main
+    ) async throws -> (TimeInterval, Bool) {
+        try await withCheckedThrowingContinuation { continuation in
+            refresh(load: load, queue: queue) { error, result2, result3 in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: (result2, result3))
+                }
             }
         }
     }

--- a/Source/Bot/Operations/LoginOperation.swift
+++ b/Source/Bot/Operations/LoginOperation.swift
@@ -25,8 +25,7 @@ class LoginOperation: AsynchronousOperation {
             return
         }
         
-        // Unwrapping this values is safe because canLaunch() verify them
-        let identity = configuration.identity!
+        let identity = configuration.identity
         
         if let loggedInIdentity = Bots.current.identity, loggedInIdentity == identity {
             self.success = true

--- a/Source/Bot/Operations/RefreshOperation.swift
+++ b/Source/Bot/Operations/RefreshOperation.swift
@@ -33,7 +33,7 @@ class RefreshOperation: AsynchronousOperation {
         }
         
         let queue = OperationQueue.current?.underlyingQueue ?? DispatchQueue.global(qos: .background)
-        Bots.current.refresh(load: refreshLoad, queue: queue) { [weak self, refreshLoad] (error, timeInterval) in
+        Bots.current.refresh(load: refreshLoad, queue: queue) { [weak self, refreshLoad] (error, timeInterval, _) in
             Analytics.shared.trackBotDidRefresh(load: refreshLoad.rawValue,
                                                 duration: timeInterval,
                                                 error: error)

--- a/Source/Controller/LaunchViewController.swift
+++ b/Source/Controller/LaunchViewController.swift
@@ -56,17 +56,15 @@ class LaunchViewController: UIViewController {
 
         // if configuration and is required then onboard
         if let configuration = AppConfiguration.current,
-            let identity = configuration.identity,
-            Onboarding.status(for: identity) == .started {
+           Onboarding.status(for: configuration.identity) == .started {
             self.launchIntoOnboarding(status: .started)
             return
         }
 
         // if configuration and not started then already onboarded
         if let configuration = AppConfiguration.current,
-            let identity = configuration.identity,
-            Onboarding.status(for: identity) == .notStarted {
-            Onboarding.set(status: .completed, for: identity)
+           Onboarding.status(for: configuration.identity) == .notStarted {
+            Onboarding.set(status: .completed, for: configuration.identity)
         }
 
         // otherwise there is a configuration and onboarding has been completed
@@ -84,8 +82,8 @@ class LaunchViewController: UIViewController {
         Log.info("Launching with configuration '\(configuration.name)'")
 
         // note that hmac key can be nil to switch it off
+        let secret = configuration.secret 
         guard let network = configuration.network else { return }
-        guard let secret = configuration.secret else { return }
         guard let bot = configuration.bot else { return }
         
         bot.login(config: configuration) { error in

--- a/Source/Debug/AppConfigurationViewController.swift
+++ b/Source/Debug/AppConfigurationViewController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import Logger
 
 // TODO https://app.asana.com/0/914798787098068/1122607002060947/f
 // TODO deprecate identity manager
@@ -120,7 +121,7 @@ class AppConfigurationViewController: DebugTableViewController {
                                              cellReuseIdentifier: DebugValueTableViewCell.className,
                                              valueClosure: {
                 [unowned self] cell in
-                cell.detailTextLabel?.text = Onboarding.status(for: self.configuration.identity!).rawValue
+            cell.detailTextLabel?.text = Onboarding.status(for: self.configuration.identity).rawValue
             },
                                              actionClosure: nil)]
 
@@ -174,6 +175,7 @@ class AppConfigurationViewController: DebugTableViewController {
                                     fullySynced = finished
                                 } catch {
                                     self.alert(error: error)
+                                    return
                                 }
                             }
                             let statistics = await bot.statistics()
@@ -182,6 +184,10 @@ class AppConfigurationViewController: DebugTableViewController {
                             UserDefaults.standard.set(false, forKey: "prevent_feed_from_forks")
                             UserDefaults.standard.synchronize()
                             self.tableView.reloadData()
+                            Log.info(
+                                "User reset number of published messages " +
+                                "to \(self.configuration.numberOfPublishedMessages)"
+                            )
                             AppController.shared.hideProgress()
                         }
                     }
@@ -215,7 +221,7 @@ class AppConfigurationViewController: DebugTableViewController {
                 [unowned self] cell in
                 cell.textLabel?.isEnabled = self.canEditConfiguration
                 cell.textLabel?.numberOfLines = 1
-                guard let secret = self.configuration.secret ?? self.secret else { return }
+                let secret = self.configuration.secret 
                 cell.textLabel?.text = secret.jsonStringUnescaped()
             },
                                              actionClosure: {

--- a/Source/Debug/BotViewController.swift
+++ b/Source/Debug/BotViewController.swift
@@ -120,7 +120,7 @@ class BotViewController: DebugTableViewController {
                 [unowned self] cell in
                 cell.showActivityIndicator()
                 self.bot.refresh(load: .long, queue: .main) {
-                    [weak self] _, _ in
+                    [weak self] _, _, _ in
                     cell.hideActivityIndicator()
                     self?.updateSettings()
                 }

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -219,7 +219,7 @@ class FakeBot: Bot {
     func refresh(load: RefreshLoad, queue: DispatchQueue, completion: @escaping RefreshCompletion) {
         self._statistics.lastRefreshDate = Date()
         queue.async {
-            completion(nil, 0)
+            completion(nil, 0, false)
         }
     }
 

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -182,7 +182,7 @@ class FakeBot: Bot {
 
     func login(queue: DispatchQueue, config: AppConfiguration, completion: @escaping ErrorCompletion) {
         self._network = config.network?.string
-        self._identity = config.secret?.identity
+        self._identity = config.secret.identity
         queue.async {
             completion(nil)
         }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -145,12 +145,12 @@ class GoBot: Bot {
         config: AppConfiguration,
         completion: @escaping ErrorCompletion
     ) {
-        guard let secret = config.secret,
-            let network = config.network else {
-                  queue.async { completion(BotError.invalidAppConfiguration) }
-                  return
-              }
+        guard let network = config.network else {
+            queue.async { completion(BotError.invalidAppConfiguration) }
+            return
+        }
 
+        let secret = config.secret
         guard self._identity == nil else {
             if secret.identity == self._identity {
                 queue.async { completion(nil) }

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable line_length
+// swiftlint:disable line_length identifier_name nesting
 
 // provide the types of any new Localizable enums
 // in order to automatically export their strings to the localization files
@@ -376,6 +376,10 @@ extension Text {
         case debugTitle = "Hacker Mode"
         case debugMenu = "Dangerous and powerful debug menu"
         case debugFooter = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options."
+        case resetForkedFeedProtection = "Reset Forked Feed Protection"
+        case resetForkedFeedProtectionDescription = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?"
+        case reset = "Reset"
+        case noBotConfigured = "No bot configured."
     }
 }
 

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker-Modus";
 "Debug.debugMenu" = "Gefährliches und mächtiges Debug-Menü";
 "Debug.debugFooter" = "Hier lassen wir dich in den Fuß schießen. Hier gelangen Sie an Ihren privaten Schlüssel, setzen Sie neue Schlüssel, lesen Sie Informationen über das Netzwerk, Pubs und alle möglichen Dinge. Vorsicht, was Sie in diesem Menü ändern, können Sie Dinge mit diesen Optionen zu brechen.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "Die Peer-to-Peer-Engine konnte nicht gestartet werden. Bitte verwenden Sie Neustart, um zu reparieren und neu zu starten, oder verwenden Sie Ignore, um die Inhalte zu durchsuchen, die bereits auf Ihrem Gerät abgerufen werden.";
 "Error.unexpected" = "Etwas Unerwartetes ist passiert.";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Modo Hacker";
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Esta es la parte en la que dejamos que te dispares en el pié. Acá es donde accedés a tu llave privada, configurás nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambiás en este menú, podés romper cosas con estas opciones.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Modo Hacker";
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Aquí es donde dejamos que te dispares en el pié. Aquí es donde accedes a tu llave privada, configuras nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambias en este menú, puedes romper cosas con estas opciones.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "El motor de par-a-par falló en el inicio. Por favor prueba cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
 "Error.unexpected" = "Algo inesperado ocurrió.";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Modo Hacker";
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Esta es la parte en la que dejamos que te dispares en el pié. Acá es donde accedés a tu llave privada, configurás nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambiás en este menú, podés romper cosas con estas opciones.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "El motor de par-a-par falló al arrancar. Por favor probá cerrando e iniciando la aplicación una y otra vez para ver si eso lo arregla.";
 "Error.unexpected" = "Algo inesperado ocurrió.";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Modo Hacker";
 "Debug.debugMenu" = "Menú de desarrollo poderoso y peligroso";
 "Debug.debugFooter" = "Aquí es donde dejamos que te dispares en el pié. Aquí es donde accedes a tu llave privada, configuras nuevas llaves, ves información sobre la red, sobre los pubs, y todo tipo de cosas. Cuidado con lo que cambias en este menú, puedes romper cosas con estas opciones.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Tryb Zaawansowany";
 "Debug.debugMenu" = "Niebezpieczne i potężne menu debugowania";
 "Debug.debugFooter" = "Tutaj pozwoliliśmy Ci strzelić sobie w stopę. Tutaj możesz uzyskać dostęp do swojego klucz prywatny, dodać nowe klucze, oraz zobaczyć informacje o sieci i pubach. Uważaj, co zmieniasz, bo możesz zepsuć.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "Nie udało się uruchomić połączenia z siecią. Uruchom ponownie, aby spróbować naprawić tą sytuację, lub użyj opcji Ignoruj, aby przeglądać zawartość, która została już pobrana na Twoje urządzenie.";
 "Error.unexpected" = "Stało się coś nieoczekiwanego.";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Tryb Zaawansowany";
 "Debug.debugMenu" = "Niebezpieczne i potężne menu debugowania";
 "Debug.debugFooter" = "Tutaj pozwoliliśmy Ci strzelić sobie w stopę. Tutaj możesz uzyskać dostęp do swojego klucz prywatny, dodać nowe klucze, oraz zobaczyć informacje o sieci i pubach. Uważaj, co zmieniasz, bo możesz zepsuć.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "黑客模式";
 "Debug.debugMenu" = "危险和强大的调试菜单";
 "Debug.debugFooter" = "这是我们让你在脚下开枪的地方。 这里是您在私钥上的地方，设置新的密钥，查看网络信息，Pub和所有类型的事情。 注意你在这个菜单中的更改，你可以用这些选项打破一切。";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "对等点引擎的对等点启动失败。 请使用重启来修复并重新启动它，或使用忽略来浏览已经获取到您设备的内容。";
 "Error.unexpected" = "发生了一些意外事件。";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -227,6 +227,10 @@
 "Debug.debugTitle" = "Hacker Mode";
 "Debug.debugMenu" = "Dangerous and powerful debug menu";
 "Debug.debugFooter" = "This is where we let you shoot yourself in the foot. Here is where you get at your private key, set new keys, see information about the network, pub's, and all sorts of things. Careful what you change in this menu, you can break things with these options.";
+"Debug.resetForkedFeedProtection" = "Reset Forked Feed Protection";
+"Debug.resetForkedFeedProtectionDescription" = "This will reset the number of published messages associated with your identity to the number currently in your database. It will also turn forked feed protection on if it is off. You should only do this if you are sure all of your published messages are on this device. Are you sure?";
+"Debug.reset" = "Reset";
+"Debug.noBotConfigured" = "No bot configured.";
 
 "Error.login" = "The peer to peer engine failed to start. Please use Restart to repair and restart it or use Ignore to browse the content that is already fetched to your device.";
 "Error.unexpected" = "Something unexpected happened.";

--- a/Source/Onboarding/Onboarding+AppConfiguration.swift
+++ b/Source/Onboarding/Onboarding+AppConfiguration.swift
@@ -12,11 +12,10 @@ extension Onboarding.Context {
 
     init?(from configuration: AppConfiguration) {
 
-        guard let identity = configuration.identity else { return nil }
         guard let network = configuration.network else { return nil }
         guard let bot = configuration.bot else { return nil }
 
-        self.identity = identity
+        self.identity = configuration.secret.identity
         self.network = network
         self.signingKey = configuration.hmacKey
         self.bot = bot

--- a/UnitTests/GoBotOrderedTests.swift
+++ b/UnitTests/GoBotOrderedTests.swift
@@ -341,7 +341,7 @@ class GoBotOrderedTests: XCTestCase {
 
         let ex = self.expectation(description: "\(#function) refresh")
         GoBotOrderedTests.shared.refresh(load: .short, queue: .main) {
-            err, _ in
+            err, _, _ in
             XCTAssertNil(err, "refresh error!")
             ex.fulfill()
         }
@@ -416,7 +416,7 @@ class GoBotOrderedTests: XCTestCase {
 
         var ex = self.expectation(description: "\(#function) 1")
         GoBotOrderedTests.shared.refresh(load: .short, queue: .main) {
-            err, _ in
+            err, _, _ in
             XCTAssertNil(err, "refresh error!")
             ex.fulfill()
         }
@@ -425,7 +425,7 @@ class GoBotOrderedTests: XCTestCase {
         // need two refresh calls to consume the whole batch
         ex = self.expectation(description: "\(#function) 2")
         GoBotOrderedTests.shared.refresh(load: .short, queue: .main) {
-            err, _ in
+            err, _, _ in
             XCTAssertNil(err, "refresh error!")
             ex.fulfill()
         }

--- a/UnitTests/GoBotReproductionHelper.swift
+++ b/UnitTests/GoBotReproductionHelper.swift
@@ -89,7 +89,7 @@ class API_GoBot: XCTestCase {
     // make sure view db is uptodate with gosbot repo
     func test03_refresh() {
         API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, took) in
+            (err, took, _) in
             XCTAssertNil(err)
             print("ref1:\(took)")
         }
@@ -97,7 +97,7 @@ class API_GoBot: XCTestCase {
         
         // TODO: retrigger refesh after repair sync
         API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, took) in
+            (err, took, _) in
             XCTAssertNil(err)
             print("ref2:\(took)")
         }
@@ -114,7 +114,7 @@ class API_GoBot: XCTestCase {
 
     func test05_refresh() {
         API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, _) in
+            (err, _, _) in
             XCTAssertNil(err)
         }
         self.wait()
@@ -122,7 +122,7 @@ class API_GoBot: XCTestCase {
 
     func test07_refresh() async {
         API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, _) in
+            (err, _, _) in
             XCTAssertNil(err)
         }
         self.wait()

--- a/UnitTests/Test Helpers/GoBotTestExtensions.swift
+++ b/UnitTests/Test Helpers/GoBotTestExtensions.swift
@@ -23,7 +23,7 @@ extension GoBot {
 
         let refreshExpectation = tc.expectation(description: "Refresh")
         self.refresh(load: .short, queue: .main) {
-            error, _ in
+            error, _, _ in
             XCTAssertNil(error, "view refresh failed")
             refreshExpectation.fulfill()
         }

--- a/UnitTests/Test Helpers/KeyValueFixtures.swift
+++ b/UnitTests/Test Helpers/KeyValueFixtures.swift
@@ -14,6 +14,7 @@ struct KeyValueFixtures {
     
     static func keyValue(
         key: MessageIdentifier = "TestPostId=.ed25519",
+        timestamp: Float64 = 2_684_029_486_000, // 2055
         receivedTimestamp: Float64 = 2_684_029_486_000, // 2055
         receivedSeq: Int64 = 0, // largest in example feed is 77
         author: Identity) -> KeyValue {
@@ -26,7 +27,7 @@ struct KeyValueFixtures {
                 previous: nil,
                 sequence: 0,
                 signature: Identifier("signature"),
-                timestamp: 2_684_029_486_000 // 2055
+                timestamp: timestamp
             ),
             timestamp: receivedTimestamp,
             receivedSeq: receivedSeq,


### PR DESCRIPTION
This does three things:
- Adds a button in the debug menu to reset the `numberOfPublishedMessages` stored in the keychain. This is useful to recover from situations/bugs where Planetary thinks you have published more messages than you actually have (#489)
- Updates our forked feed protection to handle restoring from an imported key (which is possible now, after #495)
- Fixes a bug where `AppConfigurations.current` (plural) would not be updated when `AppConfiguration.current` was updated. So basically `AppConfigurations.current` was only being updated when a new configuration was added or deleted, not when one was updated.