### PR TITLE
Fix Onboarding start and end events

### DIFF
--- a/Source/Onboarding/Onboarding.swift
+++ b/Source/Onboarding/Onboarding.swift
@@ -86,8 +86,6 @@ class Onboarding {
         guard name.isValidName else { completion(nil, .invalidName); return }
         guard Bots.current.identity == nil else { completion(nil, .cannotOnboardWhileLoggedIn); return }
 
-        Analytics.shared.trackOnboardingStart()
-
         // create secret
         GoBot.shared.createSecret { secret, error in
             Log.optional(error)
@@ -168,7 +166,6 @@ class Onboarding {
         AppConfigurations.current.save()
 
         // mark as started
-        Analytics.shared.trackOnboardingEnd()
         Onboarding.set(status: .started, for: secret.identity)
     }
 

--- a/Source/Onboarding/Steps/DoneOnboardingStep.swift
+++ b/Source/Onboarding/Steps/DoneOnboardingStep.swift
@@ -105,6 +105,7 @@ class DoneOnboardingStep: OnboardingStep {
             DispatchQueue.main.async { [weak self] in
                 self?.view.lookReady()
                 Analytics.shared.trackOnboardingComplete(data.analyticsData)
+                Analytics.shared.trackOnboardingEnd()
                 self?.next()
             }
         }

--- a/Source/Onboarding/Steps/SplashOnboardingStep.swift
+++ b/Source/Onboarding/Steps/SplashOnboardingStep.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 import Support
+import Analytics
 
 class StartOnboardingStep: OnboardingStep {
 
@@ -34,6 +35,7 @@ class StartOnboardingStep: OnboardingStep {
 
     init() {
         super.init(.start)
+        Analytics.shared.trackOnboardingStart()
     }
 
     override func customizeView() {


### PR DESCRIPTION
Just something I noticed while looking at our analytics this morning. The start event and end events were both firing in the middle of onboarding, not at the start and end.