### PR TITLE
send app logs on unhandled crashes

### DIFF
--- a/CrashReporting/Sources/Domain/Services/CrashReportingServiceAdapter.swift
+++ b/CrashReporting/Sources/Domain/Services/CrashReportingServiceAdapter.swift
@@ -11,9 +11,11 @@ import Logger
 class CrashReportingServiceAdapter: CrashReportingService {
 
     var apiService: APIService
+    var logger: LogProtocol
 
-    init(_ apiService: APIService) {
+    init(_ apiService: APIService, logger: LogProtocol = Log.shared) {
         self.apiService = apiService
+        self.logger = logger
     }
 
     func identify(identity: Identity) {
@@ -25,19 +27,19 @@ class CrashReportingServiceAdapter: CrashReportingService {
     }
 
     func record(_ message: String) {
-        Log.debug(message)
+        logger.debug(message)
         apiService.record(message)
     }
 
     func report(error: Error, metadata: [AnyHashable: Any]? = nil, botLog: String?) {
-        Log.error(error.localizedDescription)
+        logger.error(error.localizedDescription)
         var appLog: String?
-        if let logUrls = Log.fileUrls.first {
+        if let logUrls = logger.fileUrls.first {
             do {
                 let data = try Data(contentsOf: logUrls)
                 appLog = String(data: data, encoding: .utf8)
             } catch {
-                Log.optional(error)
+                logger.optional(error, nil)
             }
         }
         apiService.report(error: error, metadata: metadata, appLog: appLog, botLog: botLog)

--- a/Logger/Sources/Delivery/Log.swift
+++ b/Logger/Sources/Delivery/Log.swift
@@ -41,6 +41,10 @@ public class Log: LogProtocol {
         service.debug(string)
     }
 
+    public func error(_ string: String) {
+        service.unexpected(string, nil)
+    }
+
     public func unexpected(_ reason: Reason, _ detail: String?) {
         service.unexpected(reason.rawValue, detail)
     }
@@ -103,6 +107,6 @@ public extension Log {
 
     /// Log a ERROR message
     static func error(_ message: String) {
-        shared.service.unexpected(message, nil)
+        shared.error(message)
     }
 }

--- a/Logger/Sources/Delivery/Models/LogProtocol.swift
+++ b/Logger/Sources/Delivery/Models/LogProtocol.swift
@@ -26,6 +26,9 @@ public protocol LogProtocol {
     func debug(_ string: String)
 
     /// Log a ERROR message
+    func error(_ string: String)
+
+    /// Log a ERROR message
     ///
     /// Convencience function that categorize common errors that the app can handle
     func unexpected(_ reason: Reason, _ detail: String?)


### PR DESCRIPTION
Closes #507
It sends the app logs every time we send an event to bugsnag. It takes care to not overwrite the log if it was already appended before.