### PR TITLE
Fix beta1 migration tests

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -676,6 +676,7 @@
 		C93FE9BB27D6C3F10013D4CF /* UIImage+Verse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E341FD224FF9EE002BB5F4 /* UIImage+Verse.swift */; };
 		C941A6E427ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
 		C941A6E527ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
+		C943A12C2818900500E1AF96 /* Beta1MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9724B0B28089499000EBCCD /* Beta1MigrationTests.swift */; };
 		C949E96E28119B47006C5F18 /* ProgressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C949E96D28119B47006C5F18 /* ProgressButton.swift */; };
 		C949E96F28119B47006C5F18 /* ProgressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C949E96D28119B47006C5F18 /* ProgressButton.swift */; };
 		C949E9712811A8AF006C5F18 /* VerticallyCenteringScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C949E9702811A8AF006C5F18 /* VerticallyCenteringScrollView.swift */; };
@@ -3830,6 +3831,7 @@
 				0A64A84024735520009A5EBF /* NullPushAPI.swift in Sources */,
 				23EF5AAA249D177F00469977 /* BlockedAPI.swift in Sources */,
 				53E26C5E23045D34009240B2 /* Data+Person.swift in Sources */,
+				C943A12C2818900500E1AF96 /* Beta1MigrationTests.swift in Sources */,
 				23C7A47922748E8700F02311 /* URL+Identifier.swift in Sources */,
 				C9724B932809EA18000EBCCD /* SmallPostHeaderView.swift in Sources */,
 				C9724B452809D502000EBCCD /* RefreshOperation.swift in Sources */,

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -50,7 +50,7 @@ protocol Bot: AnyObject {
     // MARK: AppLifecycle
     init(userDefaults: UserDefaults, preloadedPubService: PreloadedPubService?)
     func suspend()
-    func exit()
+    func exit() async
     func dropDatabase(for configuration: AppConfiguration) async throws
     
     // MARK: Logs

--- a/Source/Bot/Operations/ExitOperation.swift
+++ b/Source/Bot/Operations/ExitOperation.swift
@@ -25,9 +25,10 @@ class ExitOperation: AsynchronousOperation {
             return
         }
         
-        Bots.current.exit()
-        
-        Log.info("ExitOperation finished.")
-        self.finish()
+        Task {
+            await Bots.current.exit()
+            Log.info("ExitOperation finished.")
+            self.finish()
+        }
     }
 }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -122,11 +122,11 @@ class GoBot: Bot {
         }
     }
 
-    func exit() {
-        userInitiatedQueue.async {
+    func exit() async {
+        _ = await Task(priority: .userInitiated) {
             self.bot.disconnectAll()
             self.database.close()
-        }
+        }.result
     }
     
     func dropDatabase(for configuration: AppConfiguration) async throws {

--- a/UnitTests/Beta1MigrationTests.swift
+++ b/UnitTests/Beta1MigrationTests.swift
@@ -44,7 +44,7 @@ class Beta1MigrationTests: XCTestCase {
         try await super.tearDown()
         userDefaults.removeSuite(named: userDefaultsSuite)
 
-        mockBot.exit()
+        await mockBot.exit()
         do {
             try await mockBot.logout()
         } catch {
@@ -58,10 +58,6 @@ class Beta1MigrationTests: XCTestCase {
     
     /// Verifies that the proper user defaults keys are set after the migration
     func testUserDefaultsSetAfterMigration() async throws {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("This test is expected to fail until #514 is implemented", options: options)
-        
         // Arrange
         // Sanity checks
         XCTAssertEqual(self.userDefaults.bool(forKey: "PerformedBeta1Migration"), false)
@@ -81,10 +77,6 @@ class Beta1MigrationTests: XCTestCase {
     
     /// Verifies that the proper user defaults keys are set when a user creates a new profile
     func testUserDefaultsSetAfterNewAccountCreation() async throws {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("This test is expected to fail until #514 is implemented", options: options)
-        
         // Act
         try await mockBot.login(config: appConfig)
         
@@ -94,10 +86,6 @@ class Beta1MigrationTests: XCTestCase {
     }
     
     func testMigrationDoesntRunTwiceForDifferentProfiles() async throws {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("This test is expected to fail until #514 is implemented", options: options)
-        
         // Arrange
         // swiftlint:disable line_length indentation_width
         let bobSecret = Secret(from: """
@@ -176,10 +164,6 @@ class Beta1MigrationTests: XCTestCase {
     
     /// Verifies that the LaunchViewController starts the migration for a user with an old go-ssb database.
     func testLaunchViewControllerTriggersMigration() async throws {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("This test is expected to fail until #514 is implemented", options: options)
-        
         // Arrange
         Onboarding.set(status: .completed, for: appConfig.identity)
         let sut = await LaunchViewController(
@@ -203,10 +187,6 @@ class Beta1MigrationTests: XCTestCase {
     /// Verifies that the LaunchViewController doees not start the migration on a fresh install of the app, when there
     /// is no AppConfiguration in the keychain.
     func testLaunchViewControllerDoesNotTriggerMigrationOnFreshInstall() throws {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("This test is expected to fail until #514 is implemented", options: options)
-        
         // Arrange
         let mockData = try XCTUnwrap("mockDatabase".data(using: .utf8))
         let databaseURL = try XCTUnwrap(URL(fileURLWithPath: testPath.appending("/mockDatabase")))
@@ -234,10 +214,6 @@ class Beta1MigrationTests: XCTestCase {
     /// Verifies that the LaunchViewController doees not start the migration on an AppConfiguration that has been
     /// created but hasn't started Onboarding yet.
     func testLaunchViewControllerDoesNotTriggerMigrationOnFreshAccount() throws {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("This test is expected to fail until #514 is implemented", options: options)
-        
         // Arrange
         Onboarding.set(status: .notStarted, for: appConfig.identity)
         let mockData = try XCTUnwrap("mockDatabase".data(using: .utf8))
@@ -266,10 +242,6 @@ class Beta1MigrationTests: XCTestCase {
     /// Verifies that the LaunchViewController doees not start the migration on an AppConfiguration that has started
     /// onboarding but hasn't completed it yet.
     func testLaunchViewControllerDoesNotTriggerMigrationOnAccountRestore() throws {
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("This test is expected to fail until #514 is implemented", options: options)
-        
         Onboarding.set(status: .started, for: appConfig.identity)
         let mockData = try XCTUnwrap("mockDatabase".data(using: .utf8))
         let databaseURL = try XCTUnwrap(URL(fileURLWithPath: testPath.appending("/mockDatabase")))

--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -63,7 +63,7 @@ class GoBotIntegrationTests: XCTestCase {
                 throw error
             }
         }
-        sut.exit()
+        await sut.exit()
         do {
             try fm.removeItem(atPath: workingDirectory)
         } catch {
@@ -231,27 +231,13 @@ class GoBotIntegrationTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 
-    func testLoginLogoutLoop() {
-        continueAfterFailure = false
-        
-        for i in 1...100 {
-            var ex = self.expectation(description: "login \(i)")
-            sut.login(config: appConfig) {
-                error in
-                XCTAssertNil(error)
-                ex.fulfill()
-            }
-            self.wait(for: [ex], timeout: 10)
+    func testLoginLogoutLoop() async throws {
+        try await sut.login(config: appConfig)
 
-            ex = self.expectation(description: "logout \(i)")
-            sut.exit()
-            sut.logout() {
-                error in
-                XCTAssertNil(error)
-                ex.fulfill()
-            }
-            self.wait(for: [ex], timeout: 10)
-        }
+        await sut.exit()
+        try await sut.logout()
+        
+        try await sut.login(config: appConfig)
     }
 
     // MARK: - Forked Feed Protection

--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -230,7 +230,30 @@ class GoBotIntegrationTests: XCTestCase {
         
         waitForExpectations(timeout: 10)
     }
-    
+
+    func testLoginLogoutLoop() {
+        continueAfterFailure = false
+        
+        for i in 1...100 {
+            var ex = self.expectation(description: "login \(i)")
+            sut.login(config: appConfig) {
+                error in
+                XCTAssertNil(error)
+                ex.fulfill()
+            }
+            self.wait(for: [ex], timeout: 10)
+
+            ex = self.expectation(description: "logout \(i)")
+            sut.exit()
+            sut.logout() {
+                error in
+                XCTAssertNil(error)
+                ex.fulfill()
+            }
+            self.wait(for: [ex], timeout: 10)
+        }
+    }
+
     // MARK: - Forked Feed Protection
     
     /// Verifies that the GoBot checks the `"prevent_feed_from_forks"` settings and avoids publishing when the number

--- a/UnitTests/GoBotOrderedTests.swift
+++ b/UnitTests/GoBotOrderedTests.swift
@@ -202,41 +202,6 @@ class GoBotOrderedTests: XCTestCase {
         self.wait(for: [exStats], timeout: 10)
     }
 
-//    Commenting text as after block work makes the following tests to not work properly
-//    Possibly race issues.
-
-//    func test009_login_status_logout_loop() {
-//        for it in 1...20 {
-//            var ex = self.expectation(description: "login \(it)")
-//            GoBotTests.shared.login(network: botTestNetwork, hmacKey: botTestHMAC, secret: botTestsKey) {
-//                error in
-//                XCTAssertNil(error)
-//                ex.fulfill()
-//            }
-//            self.wait(for: [ex], timeout: 10)
-//
-//            // trigger ssbBotStatus
-//            // TODO: this maybe should be a loop on a seperate thread to simulate the peer widget
-//            XCTAssertEqual(GoBotTests.shared.statistics.peer.count, 0, "\(it): conn count not zero")
-//
-//            ex = self.expectation(description: "logout \(it)")
-//            GoBotTests.shared.logout() {
-//                error in
-//                XCTAssertNil(error)
-//                ex.fulfill()
-//            }
-//            self.wait(for: [ex], timeout: 10)
-//        }
-//        // start again
-//        let ex = self.expectation(description: "final login")
-//        GoBotTests.shared.login(network: botTestNetwork, hmacKey: botTestHMAC, secret: botTestsKey) {
-//            error in
-//            XCTAssertNil(error)
-//            ex.fulfill()
-//        }
-//        self.wait(for: [ex], timeout: 10)
-//    }
-
     // MARK: abouts
     func test051_postAboutSelf() {
         let ex = self.expectation(description: "\(#function)")


### PR DESCRIPTION
#514 The problem here was that we weren't waiting for the calls in `Bot.exit()` to finish executing before logging in again. I made it `async` and now things seem to work.