### PR TITLE
Add retry when blobWant fails

### DIFF
--- a/Source/Cache/BlobCache.swift
+++ b/Source/Cache/BlobCache.swift
@@ -370,7 +370,10 @@ class BlobCache: DictionaryCache {
         
         /// The number of seconds that should be waited before the next retry
         func retryDelay(for identifier: BlobIdentifier) -> Int {
+            // this is the only way I could find to convert Decimal to Int
+            // swiftlint:disable legacy_objc_type
             NSDecimalNumber(decimal: pow(Decimal(retries[identifier] ?? 0), 2)).intValue
+            // swiftlint:enable legacy_objc_type
         }
         
         func didRetry(identifier: BlobIdentifier) {


### PR DESCRIPTION
I noticed that sometimes fetching a blob from go-ssb fails with a message about "failing to pour to a closed sink". I think this happens when go-ssb tries to ask a peer for a blob but the peer has closed the connection on their end. This adds a simple exponential backoff retry algorithm to retry fetching the blob. 