### PR TITLE
Better migration dismissal

### DIFF
--- a/Analytics/Sources/Delivery/Analytics+Statistics.swift
+++ b/Analytics/Sources/Delivery/Analytics+Statistics.swift
@@ -38,9 +38,11 @@ public extension Analytics {
 
     struct DatabaseStatistics {
         public var lastReceivedMessage: Int
+        public var messageCount: Int
 
-        public init(lastReceivedMessage: Int) {
+        public init(lastReceivedMessage: Int, messageCount: Int) {
             self.lastReceivedMessage = lastReceivedMessage
+            self.messageCount = messageCount
         }
     }
 
@@ -67,7 +69,7 @@ public extension Analytics {
 
         if let repo = statistics.repo {
             params["Feed Count"] = repo.feedCount
-            params["Message Count"] = repo.messageCount
+            params["Repo Message Count"] = repo.messageCount
             params["Published Message Count"] = repo.numberOfPublishedMessages
             params["Last Hash"] = repo.lastHash
         }
@@ -75,6 +77,7 @@ public extension Analytics {
         if let database = statistics.database {
             let lastRxSeq = database.lastReceivedMessage
             params["Last Received Message"] = lastRxSeq
+            params["Database Message Count"] = database.messageCount
 
             if let repo = statistics.repo {
                 let diff = repo.messageCount - 1 - lastRxSeq

--- a/Analytics/Tests/Delivery/AnalyticsTests.swift
+++ b/Analytics/Tests/Delivery/AnalyticsTests.swift
@@ -276,7 +276,7 @@ final class AnalyticsTests: XCTestCase {
     func testTrackStatistics() {
         let now = Date.init(timeIntervalSinceNow: 0)
         var statistics = Analytics.Statistics(lastSyncDate: now, lastRefreshDate: now)
-        statistics.database = Analytics.DatabaseStatistics(lastReceivedMessage: 1)
+        statistics.database = Analytics.DatabaseStatistics(lastReceivedMessage: 1, messageCount: 1)
         statistics.repo = Analytics.RepoStatistics(feedCount: 1,
                                                    messageCount: 2,
                                                    numberOfPublishedMessages: 3,

--- a/Source/Bot/BotStatistics.swift
+++ b/Source/Bot/BotStatistics.swift
@@ -42,7 +42,10 @@ extension BotStatistics {
         }
 
         if db.lastReceivedMessage != -3 {
-            statistics.database = Analytics.DatabaseStatistics(lastReceivedMessage: db.lastReceivedMessage)
+            statistics.database = Analytics.DatabaseStatistics(
+                lastReceivedMessage: db.lastReceivedMessage,
+                messageCount: db.messageCount
+            )
         }
 
         statistics.peer = Analytics.PeerStatistics(peers: peer.count,
@@ -85,9 +88,12 @@ struct RepoStatistics: Equatable {
 struct DatabaseStatistics: Equatable {
 
     let lastReceivedMessage: Int
+    
+    let messageCount: Int
 
-    init(lastReceivedMessage: Int = -2) {
+    init(lastReceivedMessage: Int = -2, messageCount: Int = 0) {
         self.lastReceivedMessage = lastReceivedMessage
+        self.messageCount = messageCount
     }
 }
 

--- a/Source/Controller/Beta1MigrationCoordinator.swift
+++ b/Source/Controller/Beta1MigrationCoordinator.swift
@@ -41,6 +41,9 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
     /// A number between 0 and 1.0 representing the progress of the migration.
     @Published var progress: Float = 0
     
+    /// A flag that is used to show a confirmation alert before dismissing the migration screen early.
+    @Published var shouldConfirmDismissal = false
+    
     /// A block that can be called to dismiss the migration view.
     private var dismissHandler: () -> Void
     
@@ -172,7 +175,15 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
     
     // MARK: Handle User Interation
     
-    func buttonPressed() {
+    func confirmDismissal() {
+        guard progress <= 0.995 else {
+            return
+        }
+        
+        shouldConfirmDismissal = true
+    }
+    
+    func dismissPressed() {
         Log.info("User dismissed Beta1MigrationView with progress: \(progress)")
         var syncedMessages = -1
         do {

--- a/Source/Controller/Beta1MigrationCoordinator.swift
+++ b/Source/Controller/Beta1MigrationCoordinator.swift
@@ -54,6 +54,8 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
     
     private var appConfiguration: AppConfiguration
     
+    private var appController: AppController
+    
     // MARK: - Public Interface
     
     /// Checks if the migration has already run then drops GoBot database and presents migration UI if it hasn't.
@@ -79,6 +81,7 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
         
         let coordinator = Beta1MigrationCoordinator(
             appConfiguration: appConfiguration,
+            appController: appController,
             userDefaults: userDefaults,
             dismissHandler: {
                 Task { await appController.dismiss(animated: true) }
@@ -109,10 +112,12 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
     
     private init(
         appConfiguration: AppConfiguration,
+        appController: AppController,
         userDefaults: UserDefaults,
         dismissHandler: @escaping () -> Void
     ) {
         self.appConfiguration = appConfiguration
+        self.appController = appController
         self.dismissHandler = dismissHandler
         self.userDefaults = userDefaults
         do {
@@ -139,7 +144,7 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
             .dropFirst()
             .map { (statistics: BotStatistics) -> Float in
                 // Calculate completion percentage
-                let completionFraction = Float(statistics.repo.messageCount) / Float(self.completionMessageCount)
+                let completionFraction = Float(statistics.db.messageCount) / Float(self.completionMessageCount)
                 return completionFraction.clamped(to: 0.0...1.0)
             }
             .receive(on: RunLoop.main)
@@ -182,5 +187,6 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
 
         cancellabes.forEach { $0.cancel() }
         dismissHandler()
+        appController.showMainViewController(animated: false)
     }
 }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -1397,8 +1397,12 @@ class GoBot: Bot {
             } catch {
                 Log.optional(error)
             }
-
-            self._statistics.db = DatabaseStatistics(lastReceivedMessage: sequence ?? -3)
+            
+            let sqliteMessageCount = (try? self.database.messageCount()) ?? 0
+            self._statistics.db = DatabaseStatistics(
+                lastReceivedMessage: sequence ?? -3,
+                messageCount: sqliteMessageCount
+            )
             
             let statistics = self._statistics
             queue.async {

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -191,6 +191,8 @@ start using Planetary right away, but:
 
 • you may not see all previous messages until they are downloaded.
 """
+    case areYouSure = "Are you sure?"
+    case dismissMigrationEarlyMessage = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?"
 }
 
 // MARK: - ImagePicker

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Bist du sicher, dass du {{ name }} blockieren willst? Du wirst den Inhalt des anderen nicht mehr sehen oder dich gegenseitig kontaktieren können.";
 "Blocking.buttonTitle" = "Ja, {{ name }} blockieren";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "¿Estás seguro de que querés bloquear a {{ name }}? No vas a poder ver su contenido mutuamente ni tampoco volver a contactarse.";
 "Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "¿Estás seguro de que quieres bloquear a {{ name }}? No podrás ver el contenido de ambos ni tampoco volver a contactarse.";
 "Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "¿Estás seguro de que querés bloquear a {{ name }}? No vas a poder ver su contenido mutuamente ni tampoco volver a contactarse.";
 "Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "¿Estás seguro de que quieres bloquear a {{ name }}? No podrás ver el contenido de ambos ni tampoco volver a contactarse.";
 "Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Czy na pewno chcesz zablokować {{ name }}? You will no longer see each other's content or be able to contact each other. Nie będziecie już widzieć wzajemnych treści ani nie będziecie mogli się ze sobą kontaktować.";
 "Blocking.buttonTitle" = "Tak, zablokuj {{ name }}";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Czy na pewno chcesz zablokować {{ name }}? You will no longer see each other's content or be able to contact each other. Nie będziecie już widzieć wzajemnych treści ani nie będziecie mogli się ze sobą kontaktować.";
 "Blocking.buttonTitle" = "Tak, zablokuj {{ name }}";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "您确定要屏蔽 {{ name }} 吗？您将不再看到对方的内容或能够相互联系。";
 "Blocking.buttonTitle" = "是，封禁 {{ name }}";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -122,6 +122,8 @@
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";
 "Text.percentComplete" = "complete";
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
+"Text.areYouSure" = "Are you sure?";
+"Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
 "Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
 "Blocking.buttonTitle" = "Yes, block {{ name }}";

--- a/Source/UI/Beta1MigrationDescriptionText.swift
+++ b/Source/UI/Beta1MigrationDescriptionText.swift
@@ -126,7 +126,7 @@ fileprivate struct TextLabelWithHyperlink: UIViewRepresentable {
         let textView = HeightUITextView(height: $height)
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textView.isEditable = false
-        textView.isSelectable = false
+        textView.isSelectable = true
         textView.tintColor = self.tintColor
         textView.delegate = context.coordinator
         textView.isScrollEnabled = false

--- a/Source/UI/Beta1MigrationDescriptionText.swift
+++ b/Source/UI/Beta1MigrationDescriptionText.swift
@@ -55,7 +55,7 @@ struct Beta1MigrationDescriptionText<ViewModel>: View where ViewModel: Beta1Migr
                         .init(subText: Text.startUsingPlanetary.text)
                     ],
                     openLink: { _ in
-                        viewModel.buttonPressed()
+                        viewModel.confirmDismissal()
                     }
                 )
                 .frame(height: textLabelHeight)
@@ -214,12 +214,15 @@ fileprivate struct HyperLinkItem: Hashable {
 }
 
 fileprivate class PreviewViewModel: Beta1MigrationViewModel {
-    func buttonPressed() {}
     var progress: Float
+    var shouldConfirmDismissal = false
     
     init(progress: Float) {
         self.progress = progress
     }
+    
+    func dismissPressed() {}
+    func confirmDismissal() {}
 }
 
 struct Beta1MigrationDescriptionText_Previews: PreviewProvider {

--- a/Source/UI/Beta1MigrationView.swift
+++ b/Source/UI/Beta1MigrationView.swift
@@ -9,8 +9,10 @@
 import SwiftUI
 
 protocol Beta1MigrationViewModel: ProgressButtonViewModel {
-    func buttonPressed()
     var progress: Float { get }
+    var shouldConfirmDismissal: Bool { get set }
+    func dismissPressed()
+    func confirmDismissal()
 }
 
 /// A view to show the user while they are upgrading from GoBot version "beta1" to "beta2"
@@ -67,6 +69,18 @@ struct Beta1MigrationView<ViewModel>: View where ViewModel: Beta1MigrationViewMo
             
             Spacer()
         }
+        .alert(isPresented: $viewModel.shouldConfirmDismissal, content: {
+            Alert(
+                title: Text.areYouSure.view,
+                message: Text.dismissMigrationEarlyMessage.view,
+                primaryButton: .default(Text.yes.view, action: {
+                    viewModel.dismissPressed()
+                }),
+                secondaryButton: .destructive(Text.cancel.view, action: {
+                    viewModel.shouldConfirmDismissal = false
+                })
+            )
+        })
         .background(
             Color("appBackground").edgesIgnoringSafeArea(.all)
         )
@@ -74,12 +88,16 @@ struct Beta1MigrationView<ViewModel>: View where ViewModel: Beta1MigrationViewMo
 }
 
 fileprivate class PreviewViewModel: Beta1MigrationViewModel {
-    func buttonPressed() {}
+    
     var progress: Float
+    var shouldConfirmDismissal = false
     
     init(progress: Float) {
         self.progress = progress
     }
+    
+    func dismissPressed() {}
+    func confirmDismissal() {}
 }
 
 struct Beta1MigrationView_Previews: PreviewProvider {

--- a/Source/UI/Buttons/ProgressButton.swift
+++ b/Source/UI/Buttons/ProgressButton.swift
@@ -11,7 +11,7 @@ import SwiftUI
 // swiftlint:disable function_body_length
 
 protocol ProgressButtonViewModel: ObservableObject {
-    func buttonPressed()
+    func dismissPressed()
     var progress: Float { get }
 }
 
@@ -21,7 +21,7 @@ struct ProgressButton<ViewModel>: View where ViewModel: ProgressButtonViewModel 
     @ObservedObject var viewModel: ViewModel
     
     var body: some View {
-        Button(action: viewModel.buttonPressed, label: {
+        Button(action: viewModel.dismissPressed, label: {
             if viewModel.progress < 0.995 {
                 SwiftUI.Text(
                     String(
@@ -135,7 +135,7 @@ fileprivate class PreviewViewModel: ProgressButtonViewModel {
         self.progress = progress
     }
     
-    func buttonPressed() {}
+    func dismissPressed() {}
 }
 
 struct ProgressButton_Previews: PreviewProvider {


### PR DESCRIPTION
This makes a few small improvements to the experience of dismissing the migration screen early:
- Fixes the button on macos
- Refreshes the home feed when you dismiss the migration screen
- add a confirmation dialog before dismissing early