### PR TITLE
Update migration message

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -640,7 +640,6 @@
 		8D8105822346A9740029C72E /* Relationship.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8105812346A9740029C72E /* Relationship.swift */; };
 		8D8A7B17231944030087895B /* CGSize+Square.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A7B16231944030087895B /* CGSize+Square.swift */; };
 		8D8A7B19231995670087895B /* PostHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A7B18231995670087895B /* PostHeaderView.swift */; };
-		8D9143F5230C5F4E0075BC8A /* Generated.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8D9143EC230C5F4E0075BC8A /* Generated.strings */; };
 		8D9143F6230C5F4E0075BC8A /* Localizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9143EE230C5F4E0075BC8A /* Localizable.swift */; };
 		8D9143F7230C5F4E0075BC8A /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9143EF230C5F4E0075BC8A /* Text.swift */; };
 		8DA9567D230DA46C00A334EB /* UIButton+Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9567C230DA46C00A334EB /* UIButton+Text.swift */; };
@@ -676,8 +675,8 @@
 		C93FE9BB27D6C3F10013D4CF /* UIImage+Verse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E341FD224FF9EE002BB5F4 /* UIImage+Verse.swift */; };
 		C941A6E427ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
 		C941A6E527ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
-		C943A12F2819BBEC00E1AF96 /* Pub.json in Resources */ = {isa = PBXBuildFile; fileRef = C943A12E2819BBEC00E1AF96 /* Pub.json */; };
 		C943A12C2818900500E1AF96 /* Beta1MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9724B0B28089499000EBCCD /* Beta1MigrationTests.swift */; };
+		C943A12F2819BBEC00E1AF96 /* Pub.json in Resources */ = {isa = PBXBuildFile; fileRef = C943A12E2819BBEC00E1AF96 /* Pub.json */; };
 		C949E96E28119B47006C5F18 /* ProgressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C949E96D28119B47006C5F18 /* ProgressButton.swift */; };
 		C949E96F28119B47006C5F18 /* ProgressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C949E96D28119B47006C5F18 /* ProgressButton.swift */; };
 		C949E9712811A8AF006C5F18 /* VerticallyCenteringScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C949E9702811A8AF006C5F18 /* VerticallyCenteringScrollView.swift */; };
@@ -1024,7 +1023,6 @@
 		C9F0B6C427E2728800BE2F0E /* Generated.strings in Resources */ = {isa = PBXBuildFile; fileRef = C9F0B67727E2728700BE2F0E /* Generated.strings */; };
 		C9F1C84827C9283A005A3228 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9143EF230C5F4E0075BC8A /* Text.swift */; };
 		C9F1C84927C92842005A3228 /* Localizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9143EE230C5F4E0075BC8A /* Localizable.swift */; };
-		C9F1C84A27C93018005A3228 /* Generated.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8D9143EC230C5F4E0075BC8A /* Generated.strings */; };
 		C9F1C84B27C932A8005A3228 /* Generated.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0AC10DD9246C43DC00CCA22A /* Generated.strings */; };
 		C9F1C84C27C932AF005A3228 /* Generated.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0A04D8B62477220F00DD37B7 /* Generated.strings */; };
 		C9F1C84D27C932B3005A3228 /* Generated.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0A04D8BA2477260F00DD37B7 /* Generated.strings */; };
@@ -1513,7 +1511,6 @@
 		8D8105812346A9740029C72E /* Relationship.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationship.swift; sourceTree = "<group>"; };
 		8D8A7B16231944030087895B /* CGSize+Square.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Square.swift"; sourceTree = "<group>"; };
 		8D8A7B18231995670087895B /* PostHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderView.swift; sourceTree = "<group>"; };
-		8D9143ED230C5F4E0075BC8A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Generated.strings; sourceTree = "<group>"; };
 		8D9143EE230C5F4E0075BC8A /* Localizable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Localizable.swift; sourceTree = "<group>"; };
 		8D9143EF230C5F4E0075BC8A /* Text.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
 		8DA9567C230DA46C00A334EB /* UIButton+Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Text.swift"; sourceTree = "<group>"; };
@@ -2522,7 +2519,6 @@
 				C9F0B63727E2728600BE2F0E /* el-GR.lproj */,
 				C9F0B61C27E2728600BE2F0E /* en-US.lproj */,
 				C9F0B61627E2728500BE2F0E /* en.lproj */,
-				8D9143EB230C5F4E0075BC8A /* en.lproj */,
 				0A04D8B9247723C100DD37B7 /* es-ar.lproj */,
 				C9F0B64927E2728600BE2F0E /* es-AR.lproj */,
 				C9F0B67627E2728700BE2F0E /* es-ES.lproj */,
@@ -2558,14 +2554,6 @@
 				C9F0B60E27E2728500BE2F0E /* zh-TW.lproj */,
 			);
 			path = Localization;
-			sourceTree = "<group>";
-		};
-		8D9143EB230C5F4E0075BC8A /* en.lproj */ = {
-			isa = PBXGroup;
-			children = (
-				8D9143EC230C5F4E0075BC8A /* Generated.strings */,
-			);
-			path = en.lproj;
 			sourceTree = "<group>";
 		};
 		8DE093D6234651AD009E505D /* Buttons */ = {
@@ -3291,7 +3279,6 @@
 				C9F0B68427E2728800BE2F0E /* Generated.strings in Resources */,
 				C9F0B68827E2728800BE2F0E /* Generated.strings in Resources */,
 				23C7445C2200B1EF00FB554A /* KeyValueVote.json in Resources */,
-				C9F1C84A27C93018005A3228 /* Generated.strings in Resources */,
 				237D058023351F5B00973D63 /* PostWithHashtags.json in Resources */,
 				C9F0B68C27E2728800BE2F0E /* Generated.strings in Resources */,
 				0A41F578248F1638005BB1DE /* Feed_example_preload.json in Resources */,
@@ -3318,7 +3305,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8D9143F5230C5F4E0075BC8A /* Generated.strings in Resources */,
 				2DBA7C98263DB1FA008B646F /* Generated.strings in Resources */,
 				C9F0B6BB27E2728800BE2F0E /* Generated.strings in Resources */,
 				5369D2A6220B970100A65622 /* Feed.json in Resources */,
@@ -4627,14 +4613,6 @@
 				5344D83821C4649A00704A34 /* Base */,
 			);
 			name = LaunchScreen.storyboard;
-			sourceTree = "<group>";
-		};
-		8D9143EC230C5F4E0075BC8A /* Generated.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				8D9143ED230C5F4E0075BC8A /* en */,
-			);
-			name = Generated.strings;
 			sourceTree = "<group>";
 		};
 		C9F0B60C27E2728500BE2F0E /* Generated.strings */ = {

--- a/Source/Localization/ExportStrings.swift
+++ b/Source/Localization/ExportStrings.swift
@@ -1,6 +1,9 @@
 // this file is executed during the Run Phase in a Run Script action
 // it is not to be included in an app target.
 
+typealias TranslationKey = String
+typealias Translation = String
+
 extension Text {
     static func writeFiles(to path: String, locale primaryLocale: String = "en", translations: [String] = []) {
         let stringsFileName = "Generated.strings"
@@ -8,44 +11,50 @@ extension Text {
 
         guard let primaryLocation = dir.appendingPathComponent("\(primaryLocale).lproj/\(stringsFileName)") else { return }
 
-        let stringsText = localizableTypes.map { $0.exportForStringsFile() }.joined(separator: "\n\n")
+        let oldPrimaryLocaleStrings = try! String(contentsOf: primaryLocation)
+        let newPrimaryLocaleStrings = localizableTypes.map { $0.exportForStringsFile() }.joined(separator: "\n\n")
 
-        let primaryText = "// This file is auto-generated at build time and should not be modified by hand\n\n\(stringsText)"
+        /// These are the keys that will be overwritten in the rest of the Generated.strings files.
+        let changedKeys = changedKeys(from: oldPrimaryLocaleStrings, to: newPrimaryLocaleStrings)
+        let orderedKeys = orderedKeys(fromGeneratedStrings: newPrimaryLocaleStrings)
+        
+        let primaryText = "// This file is auto-generated at build time and should not be modified by hand\n\n\(newPrimaryLocaleStrings)"
 
         write(text: primaryText, file: primaryLocation)
 
         for locale in translations {
-            guard let translationFile = dir.appendingPathComponent("\(locale).lproj/\(stringsFileName)") else { return }
-            var translatedStrings = stringsText
+            let translationFilePath = dir.appendingPathComponent("\(locale).lproj/\(stringsFileName)")!
 
             // here we want to export our new strings and remove unused strings
             // without removing already translated strings
-            if let translatedContent = try? String(contentsOf: translationFile) {
-                var existingTranslations = [String: String]()
-
-                for line in translatedContent.components(separatedBy: "\n") {
-                    if let key = line.components(separatedBy: " = ").first {
-                        existingTranslations[key] = line
-                    }
-                }
-
-                let lines = stringsText.components(separatedBy: "\n")
-                let newLines: [String] = lines.map { line in
-                    if let key = line.components(separatedBy: " = ").first {
-                        return existingTranslations[key] ?? line
+            var newTranslations = [String: String]()
+            if let translatedContent = try? String(contentsOf: translationFilePath) {
+                let newSource = dictionary(fromGeneratedStrings: newPrimaryLocaleStrings)
+                let existingTranslations = dictionary(fromGeneratedStrings: translatedContent)
+                
+                for (sourceKey, sourceTranslation) in newSource {
+                    if changedKeys.contains(sourceKey) {
+                        // This key is new or the translation was updated in the primary locale. Reset the translation
+                        // so it can be re-translated.
+                        newTranslations[sourceKey] = sourceTranslation
                     } else {
-                        // not a line with a translation, either empty or a comment
-                        return line
+                        newTranslations[sourceKey] = existingTranslations[sourceKey]
                     }
                 }
-
-                translatedStrings = newLines.joined(separator: "\n")
             }
 
             var translatedText = "// This file is auto-generated at build time\n"
             translatedText += "// Existing translations are left in place, and new keys are added as needed\n\n"
-            translatedText += translatedStrings
-            write(text: translatedText, file: translationFile)
+            for translationKey in orderedKeys {
+                if translationKey.isEmpty {
+                    translatedText += "\n"
+                } else {
+                    let translation = newTranslations[translationKey]!
+                    translatedText += "\(translationKey) = \(translation)\n"
+                }
+            }
+            
+            write(text: translatedText, file: translationFilePath)
         }
     }
 
@@ -53,6 +62,65 @@ extension Text {
         try? FileManager().createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? text.write(to: file, atomically: true, encoding: .utf8)
     }
+}
+
+/// Converts a Generated.strings file into a dictionary of translation keys and translation strings.
+func dictionary(fromGeneratedStrings generatedStrings: String) -> [TranslationKey: Translation] {
+    var dict = [TranslationKey: Translation]()
+    
+    for line in generatedStrings.components(separatedBy: "\n") {
+        let components = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
+        guard components.count == 2 else {
+            // comment or blank line
+            continue
+        }
+        
+        let trimmedComponents = components.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let key = trimmedComponents[0]
+        let translation = trimmedComponents[1]
+        dict[key] = translation
+    }
+    
+    return dict
+}
+
+/// Creates an array of translations keys from a Generated.strings file, preserving their order. This is used to keep
+/// strings in the same order across all Generated.strings files.
+///
+/// Empty string are used to signal that a blank line was in the source file, because we want to preserve those too.
+func orderedKeys(fromGeneratedStrings generatedStrings: String) -> [TranslationKey] {
+    let lines = generatedStrings.components(separatedBy: "\n")
+    return lines.compactMap { line in
+        let components = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: true)
+        guard components.count == 2 else {
+            // comment or blank line
+            return ""
+        }
+        
+        let trimmedComponents = components.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        let key = trimmedComponents[0]
+        return key
+    }
+}
+
+/// Takes two Generates.strings file contents and computes the set of TranslationKeys that were:
+/// 1) Added in the new file
+/// 2) Removed from the new file
+/// 3) Had their translation changed between the old and new files.
+func changedKeys(from oldStrings: String, to newStrings: String) -> Set<TranslationKey> {
+    let oldKeysAndTranslations = dictionary(fromGeneratedStrings: oldStrings)
+    let newKeysAndTranslations = dictionary(fromGeneratedStrings: newStrings)
+    var changedKeys = Set(oldKeysAndTranslations.keys).symmetricDifference(Set(newKeysAndTranslations.keys))
+    
+    // Find any lines where the tranlation changed but they key didn't
+    for (oldKey, oldTranslation) in oldKeysAndTranslations {
+        if let newTranslation = newKeysAndTranslations[oldKey],
+           newTranslation != oldTranslation {
+            changedKeys.insert(oldKey)
+        }
+    }
+    
+    return changedKeys
 }
 
 Text.writeFiles(to: "/Source/Localization", locale: "en", translations: [
@@ -64,7 +132,6 @@ Text.writeFiles(to: "/Source/Localization", locale: "en", translations: [
     "de-DE",
     "el-GR",
     "en-US",
-    "en",
     "es-AR",
     "es-ES",
     "es-UY",

--- a/Source/Localization/ExportStrings.swift
+++ b/Source/Localization/ExportStrings.swift
@@ -118,7 +118,7 @@ func changedKeys(from oldStrings: String, to newStrings: String) -> Set<Translat
     // Find any lines where the tranlation changed but they key didn't
     for (oldKey, oldTranslation) in oldKeysAndTranslations {
         if let newTranslation = newKeysAndTranslations[oldKey],
-           newTranslation != oldTranslation {
+            newTranslation != oldTranslation {
             changedKeys.insert(oldKey)
         }
     }

--- a/Source/Localization/ExportStrings.swift
+++ b/Source/Localization/ExportStrings.swift
@@ -1,6 +1,8 @@
 // this file is executed during the Run Phase in a Run Script action
 // it is not to be included in an app target.
 
+// swiftlint:disable force_try force_unwrapping
+
 typealias TranslationKey = String
 typealias Translation = String
 
@@ -18,7 +20,8 @@ extension Text {
         let changedKeys = changedKeys(from: oldPrimaryLocaleStrings, to: newPrimaryLocaleStrings)
         let orderedKeys = orderedKeys(fromGeneratedStrings: newPrimaryLocaleStrings)
         
-        let primaryText = "// This file is auto-generated at build time and should not be modified by hand\n\n\(newPrimaryLocaleStrings)"
+        let primaryText = "// This file is auto-generated at build time and should not be modified by hand\n\n"
+            + newPrimaryLocaleStrings
 
         write(text: primaryText, file: primaryLocation)
 

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -175,7 +175,7 @@ enum Text: String, Localizable, CaseIterable {
     // MARK: - Beta 1 migration strings
     case upgradingAndRestoring = "Planetary is upgrading and restoring your messages from the network."
     case beta1MigrationComplete = "Tap on the following button to close this screen and go back to your feed."
-    case beta1MigrationPleaseLeaveAppOpen = "This will take around 5 minutes.\n\nPlease leave the app open until it's done.\n"
+    case beta1MigrationPleaseLeaveAppOpen = "This may take a while.\n\nPlease leave the app open until it's done.\n"
     case beta1StartUsingPlanetary =
 """
 If you don't want to wait, you can

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -1,5 +1,4 @@
-// This file is auto-generated at build time
-// Existing translations are left in place, and new keys are added as needed
+// This file is auto-generated at build time and should not be modified by hand
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -116,7 +115,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 5 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -116,7 +116,7 @@
 "Text.loggingOut" = "Logging out...";
 "Text.upgradingAndRestoring" = "Planetary is upgrading and restoring your messages from the network.";
 "Text.beta1MigrationComplete" = "Tap on the following button to close this screen and go back to your feed.";
-"Text.beta1MigrationPleaseLeaveAppOpen" = "This will take around 2 minutes.\n\nPlease leave the app open until it's done.\n";
+"Text.beta1MigrationPleaseLeaveAppOpen" = "This may take a while.\n\nPlease leave the app open until it's done.\n";
 "Text.beta1StartUsingPlanetary" = "If you don't want to wait, you can\nstart using Planetary right away, but:";
 "Text.startUsingPlanetary" = "start using Planetary";
 "Text.startUsingPlanetaryTitle" = "Start Using Planetary";


### PR DESCRIPTION
Closes #526. This updates the "This will take around 5 minutes" message we are showing during the migration to say "This may take a while" since it will take a lot longer than 5 minutes for some users.

I also found a major issue in ExportStrings.swift while making this change. If you updated a string in `Text.swift` it wouldn't regenerate any of the Generated.strings files. I updated ExportStrings.swift to diff the old and new Generated.strings files for English, so it detects changed strings and resets their translations to English in all other Generated.strings files so they can be re-translated.