### PR TITLE
Add back PubAddress model and add stricter tests for parsing Pub mess…

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -90,7 +90,6 @@
 		0ABCA9062437C12C00D7F39C /* NSAttributedString+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABCA9052437C12C00D7F39C /* NSAttributedString+Markdown.swift */; };
 		0ABCA9072437C16100D7F39C /* NSAttributedString+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABCA9052437C12C00D7F39C /* NSAttributedString+Markdown.swift */; };
 		0ABCA9082437C16200D7F39C /* NSAttributedString+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABCA9052437C12C00D7F39C /* NSAttributedString+Markdown.swift */; };
-		0ABCA90A2437C22400D7F39C /* MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABCA9092437C22400D7F39C /* MarkdownTests.swift */; };
 		0ABCBCA6247708000009036D /* SSBNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F692209108F007264CB /* SSBNetwork.swift */; };
 		0AC10DDB246C43DC00CCA22A /* Generated.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0AC10DD9246C43DC00CCA22A /* Generated.strings */; };
 		0AC10DE6246DBDDD00CCA22A /* KnownPubsTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC10DE5246DBDDD00CCA22A /* KnownPubsTableViewDataSource.swift */; };
@@ -238,7 +237,6 @@
 		53033E9C23831CD1004609F8 /* Onboarding+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53033E9B23831CD1004609F8 /* Onboarding+Status.swift */; };
 		53033E9F2383322B004609F8 /* Onboarding+AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53033E9E2383322B004609F8 /* Onboarding+AppConfiguration.swift */; };
 		5306F770228E65240058D67A /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306F76F228E65240058D67A /* RepeatingTimer.swift */; };
-		5308168821C46A53005C48ED /* IdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5308168721C46A53005C48ED /* IdentifierTests.swift */; };
 		5308169421C46A6E005C48ED /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5308169321C46A6E005C48ED /* OnboardingTests.swift */; };
 		530816A821C46E68005C48ED /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 530816A721C46E68005C48ED /* Settings.bundle */; };
 		530AC93522051D5600B7F2F2 /* SecretViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FCAFDD22051C88009E9E82 /* SecretViewController.swift */; };
@@ -390,7 +388,6 @@
 		53211CE622838121007FB785 /* Image+UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53211CE32283717C007FB785 /* Image+UIImage.swift */; };
 		53211CE722838137007FB785 /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53211CE122836666007FB785 /* MIMEType.swift */; };
 		53211CE92284B9F5007FB785 /* AppConfigurationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53211CE82284B9F5007FB785 /* AppConfigurationViewController.swift */; };
-		53211CED22852216007FB785 /* AppConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53211CEC22852216007FB785 /* AppConfigurationTests.swift */; };
 		53211CEE22852285007FB785 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62A22445BE900C57A4B /* AppConfiguration.swift */; };
 		53211CEF228522A0007FB785 /* Bots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532751D0222497A70026500F /* Bots.swift */; };
 		53211CF0228522B2007FB785 /* FakeBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5369D2A1220B561800A65622 /* FakeBot.swift */; };
@@ -399,7 +396,6 @@
 		532751D32224A0CD0026500F /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532751D22224A0CD0026500F /* ContentViewController.swift */; };
 		53362F672208C2B3007264CB /* AppController+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F662208C2B3007264CB /* AppController+Lifecycle.swift */; };
 		53362F6A2209108F007264CB /* SSBNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F692209108F007264CB /* SSBNetwork.swift */; };
-		53362F6E2209F754007264CB /* NetworkKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F6D2209F754007264CB /* NetworkKeyTests.swift */; };
 		53362F6F2209F8D5007264CB /* SSBNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F692209108F007264CB /* SSBNetwork.swift */; };
 		5336611122D965B300100707 /* UIColor+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336611022D965B300100707 /* UIColor+Random.swift */; };
 		5336611322D965C700100707 /* UIColor+UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336611222D965C700100707 /* UIColor+UIImage.swift */; };
@@ -536,7 +532,6 @@
 		53BD748823235A450060E47E /* Post+Blob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BD748723235A450060E47E /* Post+Blob.swift */; };
 		53BD748A23289B3F0060E47E /* ImageGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BD748923289B3F0060E47E /* ImageGalleryView.swift */; };
 		53BD748C23289BBA0060E47E /* Array+IndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BD748B23289BBA0060E47E /* Array+IndexPath.swift */; };
-		53BD748D233191000060E47E /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F018422DACDC3007EBAE2 /* DateTests.swift */; };
 		53C2B12C2294E8A50018D0A8 /* AppConfiguration+Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C2B12B2294E8A50018D0A8 /* AppConfiguration+Keychain.swift */; };
 		53C2B1342295AC000018D0A8 /* AppConfiguration+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C2B1332295AC000018D0A8 /* AppConfiguration+Data.swift */; };
 		53C2B1352295AC040018D0A8 /* AppConfiguration+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C2B1332295AC000018D0A8 /* AppConfiguration+Data.swift */; };
@@ -588,7 +583,6 @@
 		53E29CDF22D7EE1C008A2CB1 /* Hashtag+NSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E29CDE22D7EE1C008A2CB1 /* Hashtag+NSAttributedString.swift */; };
 		53E29CE022D80424008A2CB1 /* Hashtag+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E29CDC22D7EC6F008A2CB1 /* Hashtag+String.swift */; };
 		53E29CE122D80427008A2CB1 /* Hashtag+NSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E29CDE22D7EE1C008A2CB1 /* Hashtag+NSAttributedString.swift */; };
-		53E29CE422D8E423008A2CB1 /* AttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E29CE322D8E423008A2CB1 /* AttributedStringTests.swift */; };
 		53E341F2224D9B9D002BB5F4 /* UIColor+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E341F1224D9B9D002BB5F4 /* UIColor+Debug.swift */; };
 		53E341F4224D9E3B002BB5F4 /* URL+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E341F3224D9E3B002BB5F4 /* URL+Identifier.swift */; };
 		53E341F6224D9FC7002BB5F4 /* AppController+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E341F5224D9FC7002BB5F4 /* AppController+URL.swift */; };
@@ -605,7 +599,6 @@
 		53EAB39A239B106900DF5530 /* CachesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EAB399239B106900DF5530 /* CachesViewController.swift */; };
 		53EE01F12204C16800DFDF16 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5316E95E21FFEB130053832E /* Post.swift */; };
 		53EE01F42204F66200DFDF16 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01F32204F66200DFDF16 /* Secret.swift */; };
-		53EE01F62204FFC400DFDF16 /* SecretTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01F52204FFC400DFDF16 /* SecretTests.swift */; };
 		53EE01F82205003500DFDF16 /* Secret.json in Resources */ = {isa = PBXBuildFile; fileRef = 53EE01F72205003500DFDF16 /* Secret.json */; };
 		53EE01FB2205035800DFDF16 /* XCTestCase+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01FA2205035800DFDF16 /* XCTestCase+JSON.swift */; };
 		53EE01FC220503C400DFDF16 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01F32204F66200DFDF16 /* Secret.swift */; };
@@ -619,7 +612,6 @@
 		5B0D585227BEAE9E002F927D /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = 5B0D585127BEAE9E002F927D /* Support */; };
 		5B22EF2F280778F300C5F1E1 /* Support+GoBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B22EF2E280778F300C5F1E1 /* Support+GoBot.swift */; };
 		5B22EF312807792700C5F1E1 /* JoinPlanetarySystemOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B22EF302807792700C5F1E1 /* JoinPlanetarySystemOperation.swift */; };
-		5B22EF35280779AA00C5F1E1 /* EncodeJSONtest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B22EF34280779AA00C5F1E1 /* EncodeJSONtest.swift */; };
 		5B9A5EF827E8D1F1001D7CA3 /* CrashReporting+GoBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9A5EF727E8D1F1001D7CA3 /* CrashReporting+GoBot.swift */; };
 		5B9A5EF927E8DBAF001D7CA3 /* CrashReporting+GoBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9A5EF727E8D1F1001D7CA3 /* CrashReporting+GoBot.swift */; };
 		5BAA0BB427DF9CE200C7BE63 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 5BAA0BB327DF9CE200C7BE63 /* CrashReporting */; };
@@ -659,7 +651,6 @@
 		C90EBE7327E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
 		C90EBE7427E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
 		C9134DDB28184AF700595D49 /* JoinPlanetarySystemOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B22EF302807792700C5F1E1 /* JoinPlanetarySystemOperation.swift */; };
-		C9134DE028184B3B00595D49 /* MultiserverAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9134DDF28184B3B00595D49 /* MultiserverAddressTests.swift */; };
 		C9134DE228184C2700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE128184C2700595D49 /* Support */; };
 		C9134DE328184D4200595D49 /* Support+GoBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B22EF2E280778F300C5F1E1 /* Support+GoBot.swift */; };
 		C9134DE6281854E700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE5281854E700595D49 /* Support */; };
@@ -671,7 +662,6 @@
 		C93A4B3A279894AC009F963D /* GoBotTestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93A4B39279894AC009F963D /* GoBotTestExtensions.swift */; };
 		C93A4B3C2798B711009F963D /* KeyValueWithReceivedSeq.json in Resources */ = {isa = PBXBuildFile; fileRef = C93A4B3B2798B711009F963D /* KeyValueWithReceivedSeq.json */; };
 		C93A4B3E2798C68B009F963D /* KeyValueFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93A4B3D2798C68B009F963D /* KeyValueFixtures.swift */; };
-		C93FE9BA27D663220013D4CF /* BlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93FE9B927D663220013D4CF /* BlobTests.swift */; };
 		C93FE9BB27D6C3F10013D4CF /* UIImage+Verse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E341FD224FF9EE002BB5F4 /* UIImage+Verse.swift */; };
 		C941A6E427ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
 		C941A6E527ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */; };
@@ -920,6 +910,7 @@
 		C9724BF32809EFC9000EBCCD /* AvatarImageViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F1C85227C980A6005A3228 /* AvatarImageViewRepresentable.swift */; };
 		C9724BF42809EFFA000EBCCD /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F1C85427C9875A005A3228 /* Color+Hex.swift */; };
 		C9724BF52809F151000EBCCD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5344D83521C4649A00704A34 /* Assets.xcassets */; };
+		C97270932832A47100EBF023 /* GoSSB.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C933908F27FB5498007B5FD8 /* GoSSB.xcframework */; };
 		C978D35127BF051700842458 /* OperationQueue+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = C978D35027BF018600842458 /* OperationQueue+Async.swift */; };
 		C978D35327BF053B00842458 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A01472790B9F200E29A97 /* Environment.swift */; };
 		C98A013C2790AED800E29A97 /* ViewDatabasePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A013B2790AED800E29A97 /* ViewDatabasePerformanceTests.swift */; };
@@ -947,6 +938,16 @@
 		C9C3788E27C6CCD400238B58 /* BotStatisticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3788D27C6CCD400238B58 /* BotStatisticsService.swift */; };
 		C9C3788F27C6CCD400238B58 /* BotStatisticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3788D27C6CCD400238B58 /* BotStatisticsService.swift */; };
 		C9C3789127C6CCFB00238B58 /* GoBotStatisticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3789027C6CCFB00238B58 /* GoBotStatisticsServiceTests.swift */; };
+		C9D1EACA2832A0230092E098 /* AttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC02832A0220092E098 /* AttributedStringTests.swift */; };
+		C9D1EACB2832A0230092E098 /* IdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC12832A0220092E098 /* IdentifierTests.swift */; };
+		C9D1EACC2832A0230092E098 /* BlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC22832A0230092E098 /* BlobTests.swift */; };
+		C9D1EACD2832A0230092E098 /* NetworkKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC32832A0230092E098 /* NetworkKeyTests.swift */; };
+		C9D1EACE2832A0230092E098 /* EncodeJSONtest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC42832A0230092E098 /* EncodeJSONtest.swift */; };
+		C9D1EACF2832A0230092E098 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC52832A0230092E098 /* DateTests.swift */; };
+		C9D1EAD02832A0230092E098 /* MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC62832A0230092E098 /* MarkdownTests.swift */; };
+		C9D1EAD12832A0230092E098 /* MultiserverAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC72832A0230092E098 /* MultiserverAddressTests.swift */; };
+		C9D1EAD22832A0230092E098 /* SecretTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC82832A0230092E098 /* SecretTests.swift */; };
+		C9D1EAD32832A0230092E098 /* AppConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC92832A0230092E098 /* AppConfigurationTests.swift */; };
 		C9E144C427E3C6ED00D6668A /* FakeBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5369D2A1220B561800A65622 /* FakeBot.swift */; };
 		C9EADA8727D162F3002066D9 /* Optional+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EADA8627D162F3002066D9 /* Optional+Map.swift */; };
 		C9EADA8927D178D5002066D9 /* View+RoundedCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EADA8827D178D5002066D9 /* View+RoundedCorner.swift */; };
@@ -1124,7 +1125,6 @@
 		0ABCA8FE2436B48E00D7F39C /* AppError+LocalizedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppError+LocalizedError.swift"; sourceTree = "<group>"; };
 		0ABCA9002437BF3400D7F39C /* String+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Markdown.swift"; sourceTree = "<group>"; };
 		0ABCA9052437C12C00D7F39C /* NSAttributedString+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Markdown.swift"; sourceTree = "<group>"; };
-		0ABCA9092437C22400D7F39C /* MarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTests.swift; sourceTree = "<group>"; };
 		0AC10DDA246C43DC00CCA22A /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = Generated.strings; sourceTree = "<group>"; };
 		0AC10DE5246DBDDD00CCA22A /* KnownPubsTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownPubsTableViewDataSource.swift; sourceTree = "<group>"; };
 		0ACA5741243CFAEC001C5E37 /* MarkdownStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownStyler.swift; sourceTree = "<group>"; };
@@ -1209,13 +1209,11 @@
 		5306F76F228E65240058D67A /* RepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
 		5306F773228E65DF0058D67A /* Bot+SyncAndRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bot+SyncAndRefresh.swift"; sourceTree = "<group>"; };
 		5308168521C46A52005C48ED /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		5308168721C46A53005C48ED /* IdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierTests.swift; sourceTree = "<group>"; };
 		5308168921C46A53005C48ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5308169121C46A6E005C48ED /* APITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = APITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5308169321C46A6E005C48ED /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
 		5308169521C46A6E005C48ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		530816A721C46E68005C48ED /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
-		530F018422DACDC3007EBAE2 /* DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTests.swift; sourceTree = "<group>"; };
 		530F018622DAD0FD007EBAE2 /* Date+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Random.swift"; sourceTree = "<group>"; };
 		530F018922DADCE7007EBAE2 /* Date+OlderThan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+OlderThan.swift"; sourceTree = "<group>"; };
 		530F018C22DCE78A007EBAE2 /* String+PhoneNumberKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+PhoneNumberKit.swift"; sourceTree = "<group>"; };
@@ -1308,7 +1306,6 @@
 		53211CE122836666007FB785 /* MIMEType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIMEType.swift; sourceTree = "<group>"; };
 		53211CE32283717C007FB785 /* Image+UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+UIImage.swift"; sourceTree = "<group>"; };
 		53211CE82284B9F5007FB785 /* AppConfigurationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigurationViewController.swift; sourceTree = "<group>"; };
-		53211CEC22852216007FB785 /* AppConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigurationTests.swift; sourceTree = "<group>"; };
 		53211CF222863056007FB785 /* EarlyAccessOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlyAccessOnboardingViewController.swift; sourceTree = "<group>"; };
 		532751CE222495940026500F /* AboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		532751D0222497A70026500F /* Bots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bots.swift; sourceTree = "<group>"; };
@@ -1316,7 +1313,6 @@
 		532751D5222A3EF60026500F /* increment_build.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = increment_build.sh; sourceTree = "<group>"; };
 		53362F662208C2B3007264CB /* AppController+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppController+Lifecycle.swift"; sourceTree = "<group>"; };
 		53362F692209108F007264CB /* SSBNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSBNetwork.swift; sourceTree = "<group>"; };
-		53362F6D2209F754007264CB /* NetworkKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkKeyTests.swift; sourceTree = "<group>"; };
 		5336611022D965B300100707 /* UIColor+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Random.swift"; sourceTree = "<group>"; };
 		5336611222D965C700100707 /* UIColor+UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+UIImage.swift"; sourceTree = "<group>"; };
 		53375F802321757C00610932 /* GalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryView.swift; sourceTree = "<group>"; };
@@ -1470,7 +1466,6 @@
 		53E29CD722D7DF84008A2CB1 /* Hashtag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hashtag.swift; sourceTree = "<group>"; };
 		53E29CDC22D7EC6F008A2CB1 /* Hashtag+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Hashtag+String.swift"; sourceTree = "<group>"; };
 		53E29CDE22D7EE1C008A2CB1 /* Hashtag+NSAttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Hashtag+NSAttributedString.swift"; sourceTree = "<group>"; };
-		53E29CE322D8E423008A2CB1 /* AttributedStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringTests.swift; sourceTree = "<group>"; };
 		53E341F1224D9B9D002BB5F4 /* UIColor+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Debug.swift"; sourceTree = "<group>"; };
 		53E341F3224D9E3B002BB5F4 /* URL+Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Identifier.swift"; sourceTree = "<group>"; };
 		53E341F5224D9FC7002BB5F4 /* AppController+URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppController+URL.swift"; sourceTree = "<group>"; };
@@ -1482,7 +1477,6 @@
 		53EAB3902398692000DF5530 /* AvatarStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarStackView.swift; sourceTree = "<group>"; };
 		53EAB399239B106900DF5530 /* CachesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachesViewController.swift; sourceTree = "<group>"; };
 		53EE01F32204F66200DFDF16 /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
-		53EE01F52204FFC400DFDF16 /* SecretTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretTests.swift; sourceTree = "<group>"; };
 		53EE01F72205003500DFDF16 /* Secret.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Secret.json; sourceTree = "<group>"; };
 		53EE01FA2205035800DFDF16 /* XCTestCase+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+JSON.swift"; sourceTree = "<group>"; };
 		53EE01FD2205099100DFDF16 /* InvalidSecretMissingPrivate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = InvalidSecretMissingPrivate.json; sourceTree = "<group>"; };
@@ -1494,7 +1488,6 @@
 		5B22EF2D2807732B00C5F1E1 /* swiftlint_diffonly.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = swiftlint_diffonly.sh; sourceTree = "<group>"; };
 		5B22EF2E280778F300C5F1E1 /* Support+GoBot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Support+GoBot.swift"; sourceTree = "<group>"; };
 		5B22EF302807792700C5F1E1 /* JoinPlanetarySystemOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinPlanetarySystemOperation.swift; sourceTree = "<group>"; };
-		5B22EF34280779AA00C5F1E1 /* EncodeJSONtest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncodeJSONtest.swift; sourceTree = "<group>"; };
 		5B8DC4CC27FF826D0007E73F /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		5B9A5EF727E8D1F1001D7CA3 /* CrashReporting+GoBot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashReporting+GoBot.swift"; sourceTree = "<group>"; };
 		5EA32E74C0DFF1EF8924773F /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1532,7 +1525,6 @@
 		B048339688C76587A4977D81 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BAC5369BCA54E7B2D4790182 /* Pods-UnitTests.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.appstore.xcconfig"; sourceTree = "<group>"; };
 		C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadedPubService.swift; sourceTree = "<group>"; };
-		C9134DDF28184B3B00595D49 /* MultiserverAddressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiserverAddressTests.swift; sourceTree = "<group>"; };
 		C91D9E5C27EDE56B00C79009 /* swiftlint */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = swiftlint; sourceTree = BUILT_PRODUCTS_DIR; };
 		C931927B2811CBC80001FD92 /* Beta1MigrationDescriptionText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beta1MigrationDescriptionText.swift; sourceTree = "<group>"; };
 		C933908F27FB5498007B5FD8 /* GoSSB.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoSSB.xcframework; path = Frameworks/GoSSB.xcframework; sourceTree = "<group>"; };
@@ -1540,7 +1532,6 @@
 		C93A4B39279894AC009F963D /* GoBotTestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBotTestExtensions.swift; sourceTree = "<group>"; };
 		C93A4B3B2798B711009F963D /* KeyValueWithReceivedSeq.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = KeyValueWithReceivedSeq.json; sourceTree = "<group>"; };
 		C93A4B3D2798C68B009F963D /* KeyValueFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueFixtures.swift; sourceTree = "<group>"; };
-		C93FE9B927D663220013D4CF /* BlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlobTests.swift; sourceTree = "<group>"; };
 		C941A6E327ECBE2A009B38C9 /* PreloadedBlobService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadedBlobService.swift; sourceTree = "<group>"; };
 		C943A12E2819BBEC00E1AF96 /* Pub.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Pub.json; sourceTree = "<group>"; };
 		C9489999278CCC3A009BE021 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -1581,6 +1572,16 @@
 		C9C3788D27C6CCD400238B58 /* BotStatisticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotStatisticsService.swift; sourceTree = "<group>"; };
 		C9C3789027C6CCFB00238B58 /* GoBotStatisticsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBotStatisticsServiceTests.swift; sourceTree = "<group>"; };
 		C9C8F0EB27E8EC3400F78ABC /* GoSSB.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GoSSB.xcodeproj; path = GoSSB/GoSSB.xcodeproj; sourceTree = "<group>"; };
+		C9D1EAC02832A0220092E098 /* AttributedStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringTests.swift; sourceTree = "<group>"; };
+		C9D1EAC12832A0220092E098 /* IdentifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierTests.swift; sourceTree = "<group>"; };
+		C9D1EAC22832A0230092E098 /* BlobTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlobTests.swift; sourceTree = "<group>"; };
+		C9D1EAC32832A0230092E098 /* NetworkKeyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkKeyTests.swift; sourceTree = "<group>"; };
+		C9D1EAC42832A0230092E098 /* EncodeJSONtest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncodeJSONtest.swift; sourceTree = "<group>"; };
+		C9D1EAC52832A0230092E098 /* DateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateTests.swift; sourceTree = "<group>"; };
+		C9D1EAC62832A0230092E098 /* MarkdownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTests.swift; sourceTree = "<group>"; };
+		C9D1EAC72832A0230092E098 /* MultiserverAddressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiserverAddressTests.swift; sourceTree = "<group>"; };
+		C9D1EAC82832A0230092E098 /* SecretTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecretTests.swift; sourceTree = "<group>"; };
+		C9D1EAC92832A0230092E098 /* AppConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfigurationTests.swift; sourceTree = "<group>"; };
 		C9EADA8627D162F3002066D9 /* Optional+Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Map.swift"; sourceTree = "<group>"; };
 		C9EADA8827D178D5002066D9 /* View+RoundedCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedCorner.swift"; sourceTree = "<group>"; };
 		C9EE7BD727FF371200748106 /* Beta1MigrationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Beta1MigrationView.swift; sourceTree = "<group>"; };
@@ -1650,6 +1651,7 @@
 			files = (
 				5396A617223D467200C57A4B /* libsqlite3.0.tbd in Frameworks */,
 				5396A618223D467200C57A4B /* libsqlite3.tbd in Frameworks */,
+				C97270932832A47100EBF023 /* GoSSB.xcframework in Frameworks */,
 				C969F43E282C81A700FF6FE3 /* Lottie in Frameworks */,
 				5BAA0BB627DF9CEC00C7BE63 /* CrashReporting in Frameworks */,
 				C928DAF227B5AC850007C5FC /* Logger in Frameworks */,
@@ -2585,16 +2587,16 @@
 		C9134DDE28184B3B00595D49 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				53211CEC22852216007FB785 /* AppConfigurationTests.swift */,
-				53E29CE322D8E423008A2CB1 /* AttributedStringTests.swift */,
-				C93FE9B927D663220013D4CF /* BlobTests.swift */,
-				530F018422DACDC3007EBAE2 /* DateTests.swift */,
-				5B22EF34280779AA00C5F1E1 /* EncodeJSONtest.swift */,
-				5308168721C46A53005C48ED /* IdentifierTests.swift */,
-				0ABCA9092437C22400D7F39C /* MarkdownTests.swift */,
-				C9134DDF28184B3B00595D49 /* MultiserverAddressTests.swift */,
-				53362F6D2209F754007264CB /* NetworkKeyTests.swift */,
-				53EE01F52204FFC400DFDF16 /* SecretTests.swift */,
+				C9D1EAC92832A0230092E098 /* AppConfigurationTests.swift */,
+				C9D1EAC02832A0220092E098 /* AttributedStringTests.swift */,
+				C9D1EAC22832A0230092E098 /* BlobTests.swift */,
+				C9D1EAC52832A0230092E098 /* DateTests.swift */,
+				C9D1EAC42832A0230092E098 /* EncodeJSONtest.swift */,
+				C9D1EAC12832A0220092E098 /* IdentifierTests.swift */,
+				C9D1EAC62832A0230092E098 /* MarkdownTests.swift */,
+				C9D1EAC72832A0230092E098 /* MultiserverAddressTests.swift */,
+				C9D1EAC32832A0230092E098 /* NetworkKeyTests.swift */,
+				C9D1EAC82832A0230092E098 /* SecretTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3680,10 +3682,10 @@
 				C9A2DE3427CFD66000EAFA73 /* PeerConnectionInfo+Preview.swift in Sources */,
 				C9724BB42809EC4F000EBCCD /* DebugOnboardingViewController.swift in Sources */,
 				0ABCA9022437BF4A00D7F39C /* String+Markdown.swift in Sources */,
+				C9D1EACB2832A0230092E098 /* IdentifierTests.swift in Sources */,
 				237D057E23351E4600973D63 /* Hashtag.swift in Sources */,
 				C9724B682809D70F000EBCCD /* AppController+URL.swift in Sources */,
 				C9724B952809EA6D000EBCCD /* Bool+YesOrNo.swift in Sources */,
-				53211CED22852216007FB785 /* AppConfigurationTests.swift in Sources */,
 				53EE01FC220503C400DFDF16 /* Secret.swift in Sources */,
 				C9724B4D2809D58A000EBCCD /* UIView+Stroke.swift in Sources */,
 				C9724BD92809EE2D000EBCCD /* BlobViewController.swift in Sources */,
@@ -3694,7 +3696,6 @@
 				5B9A5EF927E8DBAF001D7CA3 /* CrashReporting+GoBot.swift in Sources */,
 				C9724B232809D40D000EBCCD /* Layout+Fill.swift in Sources */,
 				C9724B8F2809E9B7000EBCCD /* Offboarding.swift in Sources */,
-				0ABCA90A2437C22400D7F39C /* MarkdownTests.swift in Sources */,
 				C9724BD02809EDDC000EBCCD /* AppDelegate+Push.swift in Sources */,
 				C9724B592809D5FE000EBCCD /* UIEdgeInsets+Layout.swift in Sources */,
 				0AF9966E24D8A232001113BE /* Report.swift in Sources */,
@@ -3707,6 +3708,7 @@
 				C9724B442809D4FC000EBCCD /* LoadBundleOperation.swift in Sources */,
 				C9724B0E2809D1BE000EBCCD /* Layout.swift in Sources */,
 				53B4F5FD22B8732800027C6A /* NSAttributedString+Markdownable.swift in Sources */,
+				C9D1EACA2832A0230092E098 /* AttributedStringTests.swift in Sources */,
 				5369D2AF220CF39E00A65622 /* Data+JSON.swift in Sources */,
 				C98A013C2790AED800E29A97 /* ViewDatabasePerformanceTests.swift in Sources */,
 				530F018822DAD5D8007EBAE2 /* Date+Random.swift in Sources */,
@@ -3785,13 +3787,13 @@
 				C9724BC32809ED2C000EBCCD /* NSAttributedString+Mutable.swift in Sources */,
 				530F018B22DADCF7007EBAE2 /* Date+OlderThan.swift in Sources */,
 				C9724B272809D42E000EBCCD /* UIViewController+Keyboard.swift in Sources */,
+				C9D1EACC2832A0230092E098 /* BlobTests.swift in Sources */,
 				C9724B582809D5F8000EBCCD /* PostCollectionViewCell.swift in Sources */,
 				C9724BF32809EFC9000EBCCD /* AvatarImageViewRepresentable.swift in Sources */,
 				C9724BC92809ED7C000EBCCD /* KeyValuePaginatedTableViewDelegate.swift in Sources */,
 				C9C3787C27C68DE900238B58 /* ConnectedPeersCoordinatorTests.swift in Sources */,
 				C9724BBA2809ECA2000EBCCD /* StatisticsOperation.swift in Sources */,
 				5316E96721FFED620053832E /* About.swift in Sources */,
-				53EE01F62204FFC400DFDF16 /* SecretTests.swift in Sources */,
 				C9724BB12809EC10000EBCCD /* ImageButton.swift in Sources */,
 				C9724BB82809EC77000EBCCD /* SecretViewController.swift in Sources */,
 				C9724BBF2809ED0D000EBCCD /* MenuViewController.swift in Sources */,
@@ -3804,13 +3806,13 @@
 				8DB041FD234FA994006AC35B /* Identity+Bot.swift in Sources */,
 				C9724B9A2809EA8C000EBCCD /* Array+IndexPath.swift in Sources */,
 				C9F1C84827C9283A005A3228 /* Text.swift in Sources */,
-				53BD748D233191000060E47E /* DateTests.swift in Sources */,
 				C9724BAE2809EBE4000EBCCD /* MarkdownStyler.swift in Sources */,
 				23EF5AAF249D185E00469977 /* BearerBlockedAPI.swift in Sources */,
 				C9724B832809E934000EBCCD /* AboutView.swift in Sources */,
 				53E26C5B23039631009240B2 /* Dictionary+Transform.swift in Sources */,
 				C9724B632809D6CE000EBCCD /* KeyValueTableViewDataSource.swift in Sources */,
 				C90EBE7427E0D5C900EAE560 /* PreloadedPubService.swift in Sources */,
+				C9D1EACD2832A0230092E098 /* NetworkKeyTests.swift in Sources */,
 				C9724B852809E93C000EBCCD /* UnsupportedView.swift in Sources */,
 				C9724B1B2809D370000EBCCD /* DebugTableViewCell.swift in Sources */,
 				C9724B292809D43B000EBCCD /* UIViewController+NavigationItems.swift in Sources */,
@@ -3862,6 +3864,7 @@
 				C9724BE72809EEA4000EBCCD /* SimplePublishView.swift in Sources */,
 				C9724B432809D4F1000EBCCD /* UIButton+Text.swift in Sources */,
 				535754F722692B59002A6989 /* BotError.swift in Sources */,
+				C9D1EAD22832A0230092E098 /* SecretTests.swift in Sources */,
 				C9724BA82809EB23000EBCCD /* FollowCountView.swift in Sources */,
 				C9724BE12809EE6D000EBCCD /* EditAboutViewController.swift in Sources */,
 				C9724B552809D5E6000EBCCD /* ThreadViewController.swift in Sources */,
@@ -3913,7 +3916,6 @@
 				C9724B0D2809CC2A000EBCCD /* LaunchViewController.swift in Sources */,
 				C98A013E2790AF4400E29A97 /* DatabaseFixtures.swift in Sources */,
 				C9724B222809D403000EBCCD /* Layout+Center.swift in Sources */,
-				C9134DE028184B3B00595D49 /* MultiserverAddressTests.swift in Sources */,
 				53CF2A4D22026B1700F0A2CC /* ImageMetadata.swift in Sources */,
 				C9724B6A2809D71D000EBCCD /* ImageGalleryView.swift in Sources */,
 				C9724BBC2809ECBB000EBCCD /* UIViewController+Report.swift in Sources */,
@@ -3927,7 +3929,6 @@
 				C941A6E527ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */,
 				2388897D22086A650030CB92 /* GoBotInternal.swift in Sources */,
 				C9724B4F2809D59A000EBCCD /* ChannelsViewController.swift in Sources */,
-				53E29CE422D8E423008A2CB1 /* AttributedStringTests.swift in Sources */,
 				C9724B812809E929000EBCCD /* ManagePubsViewController.swift in Sources */,
 				C9C3788027C691EA00238B58 /* PeerConnectionInfo.swift in Sources */,
 				2358695724A0FAA200F4FC1D /* API.swift in Sources */,
@@ -3935,19 +3936,19 @@
 				C9724B8C2809E985000EBCCD /* AboutsMenu.swift in Sources */,
 				C9724BA32809EACD000EBCCD /* IconButton.swift in Sources */,
 				C9724BAD2809EBAE000EBCCD /* RelationshipButton.swift in Sources */,
-				53362F6E2209F754007264CB /* NetworkKeyTests.swift in Sources */,
 				C9A2DE2B27CFCB6000EAFA73 /* Publisher+Async.swift in Sources */,
 				2356500D2369C6CB00C3DBC0 /* DropContentRequest.swift in Sources */,
 				C9724B282809D435000EBCCD /* UIScrollView+Default.swift in Sources */,
+				C9D1EAD12832A0230092E098 /* MultiserverAddressTests.swift in Sources */,
 				C9724B412809D4E2000EBCCD /* TitledToggle.swift in Sources */,
 				236BCB7222689406006DF05B /* Address.swift in Sources */,
+				C9D1EAD02832A0230092E098 /* MarkdownTests.swift in Sources */,
 				53C2B13D2295BCC10018D0A8 /* Bundle+Version.swift in Sources */,
 				C9724BCE2809EDD4000EBCCD /* AppDelegate+Repair.swift in Sources */,
+				C9D1EACE2832A0230092E098 /* EncodeJSONtest.swift in Sources */,
 				C9724BA62809EB09000EBCCD /* DebugViewController.swift in Sources */,
-				C93FE9BA27D663220013D4CF /* BlobTests.swift in Sources */,
 				C9724BF12809EFBE000EBCCD /* EditValueView.swift in Sources */,
 				53C2B1362295ACFE0018D0A8 /* AppConfiguration+Keychain.swift in Sources */,
-				5308168821C46A53005C48ED /* IdentifierTests.swift in Sources */,
 				C9724B162809D2F3000EBCCD /* SettingsViewController.swift in Sources */,
 				C9724BF02809EF4D000EBCCD /* UIView+Superview.swift in Sources */,
 				531A8A4A21FA3C6400D5C8C0 /* KeyValue.swift in Sources */,
@@ -3956,7 +3957,6 @@
 				C9724B6E2809E735000EBCCD /* KeyValueView.swift in Sources */,
 				C9A2DE3527D0038700EAFA73 /* UIViewController+Alert.swift in Sources */,
 				C9724BCA2809ED83000EBCCD /* SnowView.swift in Sources */,
-				5B22EF35280779AA00C5F1E1 /* EncodeJSONtest.swift in Sources */,
 				C9724BDC2809EE3C000EBCCD /* SuspendOperation.swift in Sources */,
 				5316E95F21FFEB130053832E /* Post.swift in Sources */,
 				5336611622D96AD500100707 /* Dictionary+JSONSerialization.swift in Sources */,
@@ -4024,6 +4024,7 @@
 				C9724B722809E788000EBCCD /* UIView+Round.swift in Sources */,
 				531A8A4821FA37B000D5C8C0 /* Content.swift in Sources */,
 				0A64A84D24735766009A5EBF /* PhoneVerificationResponse.swift in Sources */,
+				C9D1EACF2832A0230092E098 /* DateTests.swift in Sources */,
 				C9A2DE3627D003EF00EAFA73 /* UIColor+Verse.swift in Sources */,
 				C9724BCB2809ED88000EBCCD /* Date+Holidays.swift in Sources */,
 				2343F1CD245851E5008D7ECE /* DispatchQueue+Deduped.swift in Sources */,
@@ -4043,6 +4044,7 @@
 				C9724B802809E925000EBCCD /* PreviewSettingsViewController.swift in Sources */,
 				C9724B942809EA26000EBCCD /* EditPostButton.swift in Sources */,
 				C9724BB32809EC4A000EBCCD /* CachesViewController.swift in Sources */,
+				C9D1EAD32832A0230092E098 /* AppConfigurationTests.swift in Sources */,
 				C9724BB22809EC42000EBCCD /* UIDevice+Localhost.swift in Sources */,
 				533EDBE82385F7CD008B3565 /* CacheTests.swift in Sources */,
 				2370620823CFC53C0070712C /* GoBotReproductionHelper.swift in Sources */,
@@ -5264,7 +5266,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				delete_me = "";
 			};
 			name = Debug;
 		};
@@ -5296,7 +5297,6 @@
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				delete_me = "";
 			};
 			name = Release;
 		};

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -70,7 +70,7 @@ protocol Bot: AnyObject {
     // MARK: Sync
     
     /// Ensure that these list of addresses are taken into consideration when establishing connections
-    func seedPubAddresses(addresses: [MultiserverAddress],
+    func seedPubAddresses(addresses: [PubAddress],
                           queue: DispatchQueue,
                           completion: @escaping (Result<Void, Error>) -> Void)
     
@@ -376,7 +376,7 @@ extension Bot {
         self.keyAtEveryoneTop(queue: .main, completion: completion)
     }
     
-    func seedPubAddresses(addresses: [MultiserverAddress], completion: @escaping (Result<Void, Error>) -> Void) {
+    func seedPubAddresses(addresses: [PubAddress], completion: @escaping (Result<Void, Error>) -> Void) {
         self.seedPubAddresses(addresses: addresses, queue: .main, completion: completion)
     }
 }

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -79,7 +79,7 @@ class SendMissionOperation: AsynchronousOperation {
                 let minPeers = JoinPlanetarySystemOperation.minNumberOfStars
                 if peerPool.count < minPeers {
                     let someSystemPubs = systemPubs.randomSample(UInt(minPeers - peerPool.count))
-                    peerPool += someSystemPubs.map { $0.address }
+                    peerPool += someSystemPubs.map { $0.address.multiserver }
                 }
                 
                 let syncOperation = SyncOperation(peerPool: peerPool)

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -41,7 +41,7 @@ class FakeBot: Bot {
         }
     }
     
-    func seedPubAddresses(addresses: [MultiserverAddress],
+    func seedPubAddresses(addresses: [PubAddress],
                           queue: DispatchQueue,
                           completion: @escaping (Result<Void, Error>) -> Void) {
         queue.async {

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -289,13 +289,19 @@ class GoBot: Bot {
 
     // MARK: Sync
     
-    func seedPubAddresses(addresses: [MultiserverAddress], queue: DispatchQueue, completion: @escaping (Result<Void, Error>) -> Void) {
+    func seedPubAddresses(
+        addresses: [PubAddress],
+        queue: DispatchQueue,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         utilityQueue.async {
             do {
                 try addresses.forEach { address throws in
-                    try self.database.saveAddress(feed: address.key,
-                                                  address: address.string,
-                                                  redeemed: nil)
+                    try self.database.saveAddress(
+                        feed: address.key,
+                        address: address.multiserver,
+                        redeemed: nil
+                    )
                 }
                 queue.async {
                     completion(.success(()))
@@ -519,10 +525,10 @@ class GoBot: Bot {
                     if ssbInviteAccept(goStr) {
                         do {
                             let feed = star.feed
-                            let address = star.address.string
+                            let address = star.address
                             let redeemed = Date().timeIntervalSince1970 * 1000
-                            try self.database.saveAddress(feed: feed, address: address, redeemed: redeemed)
-                            Analytics.shared.trackDidJoinPub(at: star.address.string)
+                            try self.database.saveAddress(feed: feed, address: address.multiserver, redeemed: redeemed)
+                            Analytics.shared.trackDidJoinPub(at: star.address.multiserver.string)
                         } catch {
                             CrashReporting.shared.reportIfNeeded(error: error)
                         }

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -20,6 +20,10 @@ typealias CFSCKProgressCallback = @convention(c) (Float64, UnsafePointer<Int8>?)
 // get's called with a token and an expiry date as unix timestamp
 typealias CPlanetaryBearerTokenCallback = @convention(c) (UnsafePointer<Int8>?, Int64) -> Void
 
+/// An abstract representation of a peer that we can replicate with.
+/// 
+/// Note: This model only really supports peers we talk to over secret handshake and the IP protocol. Much of the stack
+/// has been upgraded to support the new `MultiserverAddress` format which is more flexible.
 struct Peer {
     let tcpAddr: String
     let pubKey: Identity
@@ -27,11 +31,6 @@ struct Peer {
     init(tcpAddr: String, pubKey: Identity) {
         self.tcpAddr = tcpAddr
         self.pubKey = pubKey
-    }
-    
-    init(multiserver: MultiserverAddress) {
-        self.tcpAddr = "\(multiserver.host):\(multiserver.port)"
-        self.pubKey = multiserver.key
     }
     
     var multiserverAddress: MultiserverAddress? {

--- a/Source/Model/Identifier.swift
+++ b/Source/Model/Identifier.swift
@@ -49,7 +49,7 @@ typealias InviteIdentifier = Identifier
 
 /// A public key identifier. For the identity @kS1GT34Sg+Kzjcqoehz//afmIQC5+CGo8O/KvMddVrM=.ed25519
 /// the public key would be kS1GT34Sg+Kzjcqoehz//afmIQC5+CGo8O/KvMddVrM=
-typealias PublicKey = String
+typealias KeyID = String
 
 extension Identifier {
 
@@ -64,7 +64,7 @@ extension Identifier {
     }
 
     /// the base64 number between the sigil, marker, and algorithm
-    var id: String {
+    var id: KeyID {
         let components = self.components(separatedBy: ".")
         guard components.count == 2 else { return Identifier.unsupported }
         let component = components[0] as Identifier

--- a/Source/Model/Star.swift
+++ b/Source/Model/Star.swift
@@ -23,8 +23,8 @@ struct Star {
         "\(host):\(port)"
     }
     
-    var address: MultiserverAddress {
-        MultiserverAddress(key: self.feed.id, host: self.host, port: self.port)
+    var address: PubAddress {
+        PubAddress(key: self.feed, host: self.host, port: self.port)
     }
     
     init(invite: String) {
@@ -61,7 +61,7 @@ struct Star {
     }
     
     func toPub() -> Pub {
-        Pub(type: .pub, address: self.address)
+        Pub(type: .pub, address: PubAddress(key: feed, host: host, port: port))
     }
     
     /// Checks whether we can establish a TCP connection to the star. This is only necessary to work around a bug

--- a/UnitTests/ContentTests.swift
+++ b/UnitTests/ContentTests.swift
@@ -206,6 +206,11 @@ class ContentTests: XCTestCase {
         XCTAssertEqual(msg.value.content.type, .pub)
         XCTAssertEqual(msg.value.content.isValid, true)
         XCTAssertEqual(msg.value.content.contentException, nil)
+        let pub = try XCTUnwrap(msg.value.content.pub)
+        XCTAssertEqual(pub.address.key, "@7jJ7oou5pKKuyKvIlI5tl3ncjEXmZcbm3TvKqQetJIo=.ed25519")
+        XCTAssertEqual(pub.address.host, "two.planetary.pub")
+        XCTAssertEqual(pub.address.port, 8008)
+        XCTAssertEqual(pub.address.multiserver.string, "net:two.planetary.pub:8008~shs:7jJ7oou5pKKuyKvIlI5tl3ncjEXmZcbm3TvKqQetJIo=")
     }
 
     // TODO need to confirm string content to ensure everything was captured

--- a/UnitTests/Model/MultiserverAddressTests.swift
+++ b/UnitTests/Model/MultiserverAddressTests.swift
@@ -13,7 +13,7 @@ class MultiserverAddressTests: XCTestCase {
     func testInitFromStringGivenSystemPub() {
         let string = "net:four.planetary.pub:8008~shs:5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw="
         let multiserverAddress = MultiserverAddress(string: string)
-        XCTAssertEqual(multiserverAddress?.key, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
+        XCTAssertEqual(multiserverAddress?.keyID, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
         XCTAssertEqual(multiserverAddress?.host, "four.planetary.pub")
         XCTAssertEqual(multiserverAddress?.port, 8008)
         XCTAssertEqual(multiserverAddress?.string, string)
@@ -22,7 +22,7 @@ class MultiserverAddressTests: XCTestCase {
     func testInitFromStringGivenDiacritics() {
         let string = "net:âßàÁâãóôþüúðæåïçèõöÿýòäœêëìíøùîûñé:8008~shs:5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw="
         let multiserverAddress = MultiserverAddress(string: string)
-        XCTAssertEqual(multiserverAddress?.key, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
+        XCTAssertEqual(multiserverAddress?.keyID, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
         XCTAssertEqual(multiserverAddress?.host, "âßàÁâãóôþüúðæåïçèõöÿýòäœêëìíøùîûñé")
         XCTAssertEqual(multiserverAddress?.port, 8008)
         XCTAssertEqual(multiserverAddress?.string, string)
@@ -31,7 +31,7 @@ class MultiserverAddressTests: XCTestCase {
     func testInitFromStringGivenIPHost() {
         let string = "net:192.168.1.1:8008~shs:5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw="
         let multiserverAddress = MultiserverAddress(string: string)
-        XCTAssertEqual(multiserverAddress?.key, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
+        XCTAssertEqual(multiserverAddress?.keyID, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
         XCTAssertEqual(multiserverAddress?.host, "192.168.1.1")
         XCTAssertEqual(multiserverAddress?.port, 8008)
         XCTAssertEqual(multiserverAddress?.string, string)
@@ -40,11 +40,11 @@ class MultiserverAddressTests: XCTestCase {
     func testInitMemberwiseGivenSystemPub() {
         let string = "net:four.planetary.pub:8008~shs:5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw="
         let multiserverAddress = MultiserverAddress(
-            key: "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=",
+            keyID: "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=",
             host: "four.planetary.pub",
             port: 8008
         )
-        XCTAssertEqual(multiserverAddress.key, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
+        XCTAssertEqual(multiserverAddress.keyID, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
         XCTAssertEqual(multiserverAddress.host, "four.planetary.pub")
         XCTAssertEqual(multiserverAddress.port, 8008)
         XCTAssertEqual(multiserverAddress.string, string)
@@ -53,11 +53,11 @@ class MultiserverAddressTests: XCTestCase {
     func testInitMemberwiseGivenDiacritics() {
         let string = "net:âßàÁâãóôþüúðæåïçèõöÿýòäœêëìíøùîûñé:8008~shs:5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw="
         let multiserverAddress = MultiserverAddress(
-            key: "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=",
+            keyID: "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=",
             host: "âßàÁâãóôþüúðæåïçèõöÿýòäœêëìíøùîûñé",
             port: 8008
         )
-        XCTAssertEqual(multiserverAddress.key, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
+        XCTAssertEqual(multiserverAddress.keyID, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
         XCTAssertEqual(multiserverAddress.host, "âßàÁâãóôþüúðæåïçèõöÿýòäœêëìíøùîûñé")
         XCTAssertEqual(multiserverAddress.port, 8008)
         XCTAssertEqual(multiserverAddress.string, string)
@@ -66,11 +66,11 @@ class MultiserverAddressTests: XCTestCase {
     func testInitMemberwiseGivenIPHost() {
         let string = "net:192.168.1.1:8008~shs:5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw="
         let multiserverAddress = MultiserverAddress(
-            key: "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=",
+            keyID: "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=",
             host: "192.168.1.1",
             port: 8008
         )
-        XCTAssertEqual(multiserverAddress.key, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
+        XCTAssertEqual(multiserverAddress.keyID, "5KDK98cjIQ8bPoBkvp7bCwBXoQMlWpdIbCFyXER8Lbw=")
         XCTAssertEqual(multiserverAddress.host, "192.168.1.1")
         XCTAssertEqual(multiserverAddress.port, 8008)
         XCTAssertEqual(multiserverAddress.string, string)


### PR DESCRIPTION
Fixes #557. This was caused when I changed the `address` field on our `Pub` model to be a `MultiserverAddress`. I didn't realize that this field was being used to parse `type: pub` messages, and our unit tests didn't test for this either. 

This PR adds a `PubAddress` model that is used for parsing `type: pub` messages and adds some more tests. I also renamed the `PublicKey` typealias to make it more clear that `MultiserverAddress` does not contain a full identity in it's `key` field.

I also added some validation to our SQL calls for the `pubs` table to make sure that the address is well-formatted before reading or writing it. This will prevent bad address from being written and used in replication if we find them on someone's feed.