### PR TITLE
Remove ability for user to crop image during selection

### DIFF
--- a/Source/UI/ImagePicker.swift
+++ b/Source/UI/ImagePicker.swift
@@ -143,7 +143,7 @@ class ImagePicker: NSObject, UIImagePickerControllerDelegate, UINavigationContro
         // present OS image picker
         // source type must be set before other options
         let controller = UIImagePickerController()
-        controller.allowsEditing = true
+//        controller.allowsEditing = true
         controller.delegate = self
         controller.sourceType = type
         if type == .camera && self.selfieMode { controller.cameraDevice = .front }


### PR DESCRIPTION
This is a tweak I made for myself this weekend when I wanted to post some images from Planetary. I think it's a better experience than what we have in the App Store currently. There are many issues with the current cropping UI (#390 #317 #233). This PR simply removes the ability for users to crop their photos in Planetary. The photo is simply uploaded exactly as it is given from the photos app/camera.