### PR TITLE
Increase publish performance

### DIFF
--- a/Source/Controller/NewPostViewController.swift
+++ b/Source/Controller/NewPostViewController.swift
@@ -151,7 +151,7 @@ class NewPostViewController: ContentViewController {
     // MARK: Animations
 
     private func lookBusy() {
-        // AppController.shared.showProgress()
+        AppController.shared.showProgress()
         self.buttonsView.photoButton.isEnabled = false
         self.buttonsView.postButton.isEnabled = false
         self.buttonsView.previewToggle.isEnabled = false

--- a/Source/Controller/ThreadViewController.swift
+++ b/Source/Controller/ThreadViewController.swift
@@ -329,7 +329,7 @@ class ThreadViewController: ContentViewController {
         
         let post = Post(attributedText: text, root: self.rootKey, branches: [self.branchKey])
         let images = self.galleryView.images
-        // AppController.shared.showProgress()
+        AppController.shared.showProgress()
         Bots.current.publish(post, with: images) { [weak self] key, error in
             Log.optional(error)
             CrashReporting.shared.reportIfNeeded(error: error)


### PR DESCRIPTION
Fixes #583

The main change I made here was adding a lock to synchronize access to `AppConfig.numberOfPublishedMessages`. Before I had synchronized the entirety of the `publish()` function and `statistics()` function on the same queue, but this means publishing could end up waiting on the GoBot to return from `statistics()`, and sometimes the GoBot is slow. Now we only wait on the part of `statistics()` that reads from SQLite, so it's much faster.

I also uncommented the code to show a progress indicator if for some reason the publish is taking a long time. In most cases you won't see this though because publish happens very quickly.