### PR TITLE
Add 6 month post limit

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -130,6 +130,7 @@ identifier_name:
     - bob
     - db
     - top
+    - now
 number_separator:
   minimum_length: 5
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)

--- a/Source/Bot/BotStatistics.swift
+++ b/Source/Bot/BotStatistics.swift
@@ -64,7 +64,7 @@ struct RepoStatistics: Equatable {
     /// Number of feeds in the repo
     let feedCount: Int
 
-    /// Total number of messages
+    /// Total number of messages in Badger
     let messageCount: Int
 
     /// Number of messages published by the user

--- a/Source/Debug/BotViewController.swift
+++ b/Source/Debug/BotViewController.swift
@@ -142,13 +142,25 @@ class BotViewController: DebugTableViewController {
             },
                                              actionClosure: nil)]
 
-        settings += [DebugTableViewCellModel(title: "Messages",
-                                             cellReuseIdentifier: DebugValueTableViewCell.className,
-                                             valueClosure: {
-                cell in
-                cell.detailTextLabel?.text = "\(statistics.repo.messageCount)"
-            },
-                                             actionClosure: nil)]
+        settings += [
+            DebugTableViewCellModel(
+                title: "Messages in Badger",
+                cellReuseIdentifier: DebugValueTableViewCell.className,
+                valueClosure: { cell in
+                    cell.detailTextLabel?.text = String(statistics.repo.messageCount)
+                }
+            )
+        ]
+        
+        settings += [
+            DebugTableViewCellModel(
+                title: "Messages in SQLite",
+                cellReuseIdentifier: DebugValueTableViewCell.className,
+                valueClosure: { cell in
+                    cell.detailTextLabel?.text = String(statistics.db.messageCount)
+                }
+            )
+        ]
         
         settings += [DebugTableViewCellModel(title: "Published Messages",
                                          cellReuseIdentifier: DebugValueTableViewCell.className,

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -1468,7 +1468,7 @@ class GoBot: Bot {
         let currentNumberOfPublishedMessages = statistics.numberOfPublishedMessages
         if let configuration = config,
             currentNumberOfPublishedMessages > -1,
-            configuration.numberOfPublishedMessages <= currentNumberOfPublishedMessages {
+            configuration.numberOfPublishedMessages < currentNumberOfPublishedMessages {
             configuration.numberOfPublishedMessages = currentNumberOfPublishedMessages
             configuration.apply()
         }

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -263,6 +263,7 @@ class ViewDatabase {
     
     func close() {
         self.openDB = nil
+        self.currentUser = nil
         self.currentUserID = -1
     }
     

--- a/UnitTests/ViewDatabaseTests.swift
+++ b/UnitTests/ViewDatabaseTests.swift
@@ -7,6 +7,7 @@ class ViewDatabaseTests: XCTestCase {
     let expMsgCount = 81
     let fixture = DatabaseFixture.exampleFeed
     var testFeeds: [Identity] { fixture.identities }
+    var currentUser: Identity { fixture.identities[4] }
 
     override func setUp() {
         let data = self.data(for: fixture.fileName)
@@ -27,7 +28,7 @@ class ViewDatabaseTests: XCTestCase {
             
             // open DB
             let  damnPath = self.tmpURL.absoluteString.replacingOccurrences(of: "file://", with: "")
-            try self.vdb.open(path: damnPath, user: testFeeds[4], maxAge: -60 * 60 * 24 * 30 * 48) // 48 month (so roughtly until 2023)
+            try self.vdb.open(path: damnPath, user: currentUser, maxAge: -60 * 60 * 24 * 30 * 48) // 48 month (so roughtly until 2023)
             
             // get test messages from JSON
             let msgs = try JSONDecoder().decode([KeyValue].self, from: data)
@@ -382,10 +383,10 @@ class ViewDatabaseTests: XCTestCase {
     
     func test41_feed() {
         do {
-            let replies = try self.vdb.feed(for: testFeeds[4])
+            let replies = try self.vdb.feed(for: currentUser)
             for (i, kv) in replies.enumerated() {
                 XCTAssertNil(kv.value.content.typeException, "type exception on reply \(i)")
-                XCTAssertEqual(kv.value.author, testFeeds[4])
+                XCTAssertEqual(kv.value.author, currentUser)
                 XCTAssertEqual(kv.value.content.type, .post)
                 switch i {
                 case 0:
@@ -406,7 +407,7 @@ class ViewDatabaseTests: XCTestCase {
     }
 
     func test42_feed_paginated() throws {
-        let dataProxy = try self.vdb.paginated(feed: testFeeds[4])
+        let dataProxy = try self.vdb.paginated(feed: currentUser)
         let prefetchedCount = 2
         XCTAssertEqual(dataProxy.count, 3)
         for idx in 0...prefetchedCount - 1 {
@@ -414,7 +415,7 @@ class ViewDatabaseTests: XCTestCase {
                 XCTFail("failed to get KV for index \(idx)")
                 continue
             }
-            XCTAssertEqual(kv.value.author, testFeeds[4])
+            XCTAssertEqual(kv.value.author, currentUser)
             XCTAssertEqual(kv.value.content.type, .post)
             switch idx {
             case 0:
@@ -660,15 +661,33 @@ class ViewDatabaseTests: XCTestCase {
         XCTAssertEqual(try vdb.messageCount(), messageCount + 1)
     }
     
-    /// Verify that fillMessages fills messages older than 6 months.
+    /// Verify that fillMessages does not fill messages older than 6 months.
     func testFillMessagesGivenOldMessage() throws {
+        // Arrange
+        let messageCount = try vdb.messageCount()
+        let oldDate = Date(timeIntervalSince1970: 5)
+        let testMessage = KeyValueFixtures.post(
+            timestamp: oldDate.millisecondsSince1970,
+            receivedSeq: 800,
+            author: IdentityFixture.alice
+        )
+        
+        // Act
+        try vdb.fillMessages(msgs: [testMessage])
+        
+        // Assert
+        XCTAssertEqual(try vdb.messageCount(), messageCount)
+    }
+    
+    /// Verify that fillMessages fills messages older than 6 months for messages the current user published.
+    func testFillMessagesGivenOldMessageFromSelf() throws {
         // Arrange
         let messageCount = try vdb.messageCount()
         let oldDate = Date(timeIntervalSince1970: 1_619_037_184)
         let testMessage = KeyValueFixtures.post(
             timestamp: oldDate.millisecondsSince1970,
             receivedSeq: 800,
-            author: IdentityFixture.alice
+            author: currentUser
         )
         
         // Act
@@ -701,6 +720,7 @@ class ViewDatabasePreloadTest: XCTestCase {
     let preloadExpMsgCount = 5
     let expMsgCount = 81
     let testFeeds = DatabaseFixture.exampleFeed.identities
+    var currentUser: Identity { DatabaseFixture.exampleFeed.identities[4] }
 
     override func setUp() {
         let preloadData = self.data(for: "Feed_example_preload.json")
@@ -721,7 +741,7 @@ class ViewDatabasePreloadTest: XCTestCase {
             
             // open DB
             let  damnPath = self.tmpURL.absoluteString.replacingOccurrences(of: "file://", with: "")
-            try self.vdb.open(path: damnPath, user: testFeeds[4], maxAge: -60 * 60 * 24 * 30 * 48) // 48 month (so roughtly until 2023)
+            try self.vdb.open(path: damnPath, user: currentUser, maxAge: -60 * 60 * 24 * 30 * 48) // 48 month (so roughtly until 2023)
             
             // get test messages from JSON
             let msgs = try JSONDecoder().decode([KeyValue].self, from: preloadData)


### PR DESCRIPTION
This adds back the 6 month limit for copying posts into SQLite. This should get the performance for most of the queries back to acceptable levels. I also filed #595 so we remember to revisit this in the future.