### PR TITLE
SQL harder

### DIFF
--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -34,7 +34,7 @@ typealias StatisticsCompletion = ((BotStatistics) -> Void)
 
 enum RefreshLoad: Int32, CaseIterable {
     case tiny = 500 // about 1 second on modern hardware
-    case short = 15_000 // about 10 seconds
+    case short = 5_000 
     case medium = 45_000 // about 30 seconds
     case long = 100_000 // about 60 seconds
 }

--- a/Source/Bot/BotError.swift
+++ b/Source/Bot/BotError.swift
@@ -16,7 +16,8 @@ enum BotError: Error, LocalizedError {
     case notLoggedIn
     case forkProtection
     case invalidAppConfiguration
-
+    case restoring
+    
     // MARK: - LocalizedError
     
     var errorDescription: String? {
@@ -41,6 +42,8 @@ enum BotError: Error, LocalizedError {
             return Text.Error.cannotPublishBecauseRestoring.text
         case .invalidAppConfiguration:
             return Text.Error.invalidAppConfiguration.text
+        case .restoring:
+            return Text.Error.restoring.text
         }
     }
 }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -104,7 +104,7 @@ class GoBot: Bot {
         self.preloadedPubService = preloadedPubService
         self.utilityQueue = DispatchQueue(
             label: "GoBot-utility",
-            qos: .utility,
+            qos: .userInitiated,
             attributes: .concurrent,
             autoreleaseFrequency: .workItem,
             target: nil
@@ -785,7 +785,7 @@ class GoBot: Bot {
         guard diff > 0 else {
             // still might want to update privates
             #if DEBUG
-            print("[rx log] viewdb already up to date.")
+            Log.debug("[rx log] viewdb already up to date.")
             #endif
             self.updatePrivate(completion: completion)
             return
@@ -793,6 +793,7 @@ class GoBot: Bot {
         
         // TOOD: redo until diff==0
         do {
+            Log.debug("[rx log] asking go-ssb for new messages.")
             let msgs = try self.bot.getReceiveLog(startSeq: UInt64(max(0, current + 1)), limit: limit)
             
             guard msgs.count > 0 else {
@@ -922,6 +923,11 @@ class GoBot: Bot {
 
         guard identifier.isValidIdentifier else {
             completion(identifier, nil, BotError.blobInvalidIdentifier)
+            return
+        }
+        
+        guard !isRestoring else {
+            completion(identifier, nil, BotError.restoring)
             return
         }
 

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -2155,6 +2155,8 @@ class ViewDatabase {
         guard let db = self.openDB else {
             throw ViewDatabaseError.notOpen
         }
+        
+        Log.info("[rx log] starting fillMessages with \(msgs.count) new messages")
 
         #if SSB_MSGDEBUG
         // google claimed this is the tool to use to measure block execution time

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -440,6 +440,7 @@ extension Text {
         case supportNotConfigured = "Support is not configured."
         case invitationRedemptionFailed = "Could not join {{ starName }}. Please try again or contact support."
         case cannotPublishBecauseRestoring = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time."
+        case restoring = "Planetary is currently restoring your data from the network."
         case invalidAppConfiguration = "Invalid app configuration"
         case couldNotGenerateLink = "Could not generate link."
     }

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support ist nicht konfiguriert.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -264,6 +264,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Soporte no está configurado.";
 "Error.invitationRedemptionFailed" = "No se pudo unir a {{ starName }}. Por favor, inténtalo de nuevo o contacta con soporte.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Soporte no está configurado.";
 "Error.invitationRedemptionFailed" = "No pudimos unirte a {{ starName }}. Por favor, intentá de vuelta o contactá con soporte.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Wsparcie techniczne nie jest dostępne.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "支持未配置。";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -265,6 +265,7 @@
 "Error.supportNotConfigured" = "Support is not configured.";
 "Error.invitationRedemptionFailed" = "Could not join {{ starName }}. Please try again or contact support.";
 "Error.cannotPublishBecauseRestoring" = "Planetary is currently restoring your data from the network, and cannot publish new posts at this time.";
+"Error.restoring" = "Planetary is currently restoring your data from the network.";
 "Error.invalidAppConfiguration" = "Invalid app configuration";
 "Error.couldNotGenerateLink" = "Could not generate link.";
 

--- a/Source/Model/MissionControlCenter.swift
+++ b/Source/Model/MissionControlCenter.swift
@@ -39,7 +39,7 @@ class MissionControlCenter {
     
     /// Timer for the RefreshOperation
     private lazy var refreshTimer: RepeatingTimer = {
-        RepeatingTimer(interval: 14) { [weak self] in self?.pokeRefresh() }
+        RepeatingTimer(interval: 5) { [weak self] in self?.pokeRefresh() }
     }()
     
     /// Background Task Identifier for the SendMissionOperation

--- a/Source/Onboarding/Steps/DoneOnboardingStep.swift
+++ b/Source/Onboarding/Steps/DoneOnboardingStep.swift
@@ -114,7 +114,7 @@ class DoneOnboardingStep: OnboardingStep {
         let preloadOperation = LoadBundleOperation(bundle: bundle)
         preloadOperation.addDependency(publicWebHostingOperation)
         
-        let refreshOperation = RefreshOperation(refreshLoad: .long)
+        let refreshOperation = RefreshOperation(refreshLoad: .short)
         refreshOperation.addDependency(preloadOperation)
         
         let completionOperation = BlockOperation { [weak self] in


### PR DESCRIPTION
Since we are planning to put this on TestFlight tomorrow I decided to sit down and run through the migration a few more times. As I was testing I started tweaking things and ended up making things a lot faster.

The main changes I made are:
- Do SQLite writes on a higher priority thread.
- Make RefreshOperations smaller and do them more frequently.
- Don't ask the Bot for blobs during the migration.

I tested all of this thoroughly on a real iOS device on the main network with a database size equivalent to our median user. Over 20 tests I managed to speed up the time it takes to migrate 15k messages from 10 minutes down to 2-3 minutes. I only saw the bot get stuck once, and it actually fixed itself after 13 minutes and finished. There are no changes to go-ssb here. I think the main difference in speed is that SQLite is doing a better job keeping up with what's in Badger now. 