### PR TITLE
Show votes from other clients

### DIFF
--- a/Source/Controller/ThreadViewController.swift
+++ b/Source/Controller/ThreadViewController.swift
@@ -418,9 +418,10 @@ extension ThreadViewController: ThreadInteractionViewDelegate {
     func threadInteractionView(_ view: ThreadInteractionView, didLike post: KeyValue) {
         let vote = ContentVote(link: self.rootKey,
                                value: 1,
+                               expression: "💜",
                                root: self.rootKey,
                                branches: [self.branchKey])
-        // AppController.shared.showProgress()
+        AppController.shared.showProgress()
         Bots.current.publish(content: vote) { [weak self] _, error in
             Log.optional(error)
             CrashReporting.shared.reportIfNeeded(error: error)

--- a/Source/GoBot/FeedStrategy/PostsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/PostsAlgorithm.swift
@@ -229,6 +229,7 @@ class PostsAlgorithm: NSObject, FeedStrategy {
         let colDescr = Expression<String?>("description")
         let colDecrypted = Expression<Bool>("is_decrypted")
         let colValue = Expression<Int>("value")
+        let colExpression = Expression<String?>("expression")
 
         return try connection.prepare(query).compactMap { keyValueRow in
             let msgID = try keyValueRow.get(colMessageID)
@@ -254,9 +255,11 @@ class PostsAlgorithm: NSObject, FeedStrategy {
                 let lnkKey = try self.msgKey(id: lnkID, connection: connection)
                 let rootID = try keyValueRow.get(colRoot)
                 let rootKey = try self.msgKey(id: rootID, connection: connection)
+                let expression = try keyValueRow.get(colExpression)
                 let contentVote = ContentVote(
                     link: lnkKey,
                     value: try keyValueRow.get(colValue),
+                    expression: expression,
                     root: rootKey,
                     branches: []
                 )

--- a/Source/GoBot/FeedStrategy/PostsAndContactsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/PostsAndContactsAlgorithm.swift
@@ -310,16 +310,19 @@ class PostsAndContactsAlgorithm: NSObject, FeedStrategy {
         let colRoot = Expression<Int64>("root")
         let colLinkID = Expression<Int64>("link_id")
         let colValue = Expression<Int>("value")
+        let colExpression = Expression<String?>("expression")
 
         let lnkID = try keyValueRow.get(colLinkID)
         let lnkKey = try self.msgKey(id: lnkID, connection: connection)
 
         let rootID = try keyValueRow.get(colRoot)
         let rootKey = try self.msgKey(id: rootID, connection: connection)
+        let expression = try keyValueRow.get(colExpression)
 
         let voteContent = ContentVote(
             link: lnkKey,
             value: try keyValueRow.get(colValue),
+            expression: expression,
             root: rootKey,
             branches: []
         )

--- a/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
@@ -282,6 +282,7 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
         let colRoot = Expression<Int64>("root")
         let colLinkID = Expression<Int64>("link_id")
         let colValue = Expression<Int>("value")
+        let colExpression = Expression<String?>("expression")
 
         let lnkID = try keyValueRow.get(colLinkID)
         let lnkKey = try self.msgKey(id: lnkID, connection: connection)
@@ -292,6 +293,7 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
         let voteContent = ContentVote(
             link: lnkKey,
             value: try keyValueRow.get(colValue),
+            expression: try keyValueRow.get(colExpression),
             root: rootKey,
             branches: []
         )

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -133,7 +133,7 @@ class ViewDatabase {
     private var votes: Table
     private let colLinkID = Expression<Int64>("link_id")
     private let colValue = Expression<Int>("value")
-    private let colExpression = Expression<String>("expression")
+    private let colExpression = Expression<String?>("expression")
 
     private var channels: Table
     // id
@@ -1297,6 +1297,7 @@ class ViewDatabase {
                 let cv = ContentVote(
                     link: lnkKey,
                     value: try row.get(colValue),
+                    expression: try row.get(colExpression),
                     root: rootKey,
                     branches: [] // TODO: branches for root
                 )
@@ -1430,6 +1431,7 @@ class ViewDatabase {
                 
                 let lnkID = try row.get(colLinkID)
                 let lnkKey = try self.msgKey(id: lnkID)
+                let expression = try row.get(colExpression)
                 
                 let rootID = try row.get(colRoot)
                 let rootKey = try self.msgKey(id: rootID)
@@ -1437,6 +1439,7 @@ class ViewDatabase {
                 let cv = ContentVote(
                     link: lnkKey,
                     value: try row.get(colValue),
+                    expression: expression,
                     root: rootKey,
                     branches: [] // TODO: branches for root
                 )
@@ -1587,6 +1590,7 @@ class ViewDatabase {
                 let cv = ContentVote(
                     link: lnkKey,
                     value: try row.get(colValue),
+                    expression: try row.get(colExpression),
                     root: rootKey,
                     branches: [] // TODO: branches for root
                 )
@@ -2113,7 +2117,7 @@ class ViewDatabase {
             colValue <- v.vote.value
         ))
         
-        try self.insertBranches(msgID: msgID, root: v.root, branches: v.branch)
+        try self.insertBranches(msgID: msgID, root: v.vote.link, branches: [v.vote.link])
     }
     
     private func fillReportIfNeeded(msgID: Int64, msg: KeyValue, pms: Bool) throws -> [Report] {

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -92,8 +92,8 @@ enum Text: String, Localizable, CaseIterable {
     case name = "Name"
     case bio = "Bio"
     case seeMore = "See more"
-    case likesThis = "Likes this"
-    case dislikesThis = "Dislikes this"
+    case likesThis = "likes this"
+    case dislikesThis = "dislikes this"
 
     case block = "Block"
     case blocked = "Blocked"

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Namen";
 "Text.bio" = "Über mich";
 "Text.seeMore" = "Mehr anzeigen";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Blockieren";
 "Text.blocked" = "Blockiert";
 "Text.deleteSecretAndIdentity" = "Schlüssel und Identität löschen";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Nombre";
 "Text.bio" = "Bio";
 "Text.seeMore" = "Ver más";
-"Text.likesThis" = "Le gusta";
-"Text.dislikesThis" = "No le gusta";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Bloquear";
 "Text.blocked" = "Bloqueado";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Nombre";
 "Text.bio" = "Bio";
 "Text.seeMore" = "Ver más";
-"Text.likesThis" = "Le gusta esto";
-"Text.dislikesThis" = "No le gusta esto";
+"Text.likesThis" = "le gusta esto";
+"Text.dislikesThis" = "no le gusta esto";
 "Text.block" = "Bloquear";
 "Text.blocked" = "Bloqueado";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Nombre";
 "Text.bio" = "Bio";
 "Text.seeMore" = "Ver más";
-"Text.likesThis" = "Le gusta";
-"Text.dislikesThis" = "No le gusta";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Bloquear";
 "Text.blocked" = "Bloqueado";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Nombre";
 "Text.bio" = "Bio";
 "Text.seeMore" = "Ver más";
-"Text.likesThis" = "Le gusta";
-"Text.dislikesThis" = "No le gusta";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Bloquear";
 "Text.blocked" = "Bloqueado";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Nazwa";
 "Text.bio" = "Opis";
 "Text.seeMore" = "Więcej";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Zablokuj";
 "Text.blocked" = "Zablokowani";
 "Text.deleteSecretAndIdentity" = "Usuń ten sekret i tożsamość";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Nazwa";
 "Text.bio" = "Opis";
 "Text.seeMore" = "Więcej";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Zablokuj";
 "Text.blocked" = "Zablokowani";
 "Text.deleteSecretAndIdentity" = "Usuń ten sekret i tożsamość";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "输入标题";
 "Text.bio" = "个性签名";
 "Text.seeMore" = "查看更多";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "区块";
 "Text.blocked" = "屏蔽";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -55,8 +55,8 @@
 "Text.name" = "Name";
 "Text.bio" = "Bio";
 "Text.seeMore" = "See more";
-"Text.likesThis" = "Likes this";
-"Text.dislikesThis" = "Dislikes this";
+"Text.likesThis" = "likes this";
+"Text.dislikesThis" = "dislikes this";
 "Text.block" = "Block";
 "Text.blocked" = "Blocked";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";

--- a/Source/Model/Vote.swift
+++ b/Source/Model/Vote.swift
@@ -57,57 +57,18 @@ struct ContentVote: ContentCodable {
         }
     }
 
-    // create/publish
-    init(link: LinkIdentifier, value: Int) {
+    init(
+        link: LinkIdentifier,
+        value: Int,
+        expression: String?,
+        root: MessageIdentifier,
+        branches: [MessageIdentifier]
+    ) {
         self.type = .vote
-        
-        let exp: String
-        if value == 1 {
-            exp = "❤️"
-        } else {
-            exp = "💔"
-        }
-        self.vote = Vote(link: link, value: value, expression: exp)
-        
-        self.root = nil
-        self.branch = nil
-        
-        // TODO: constructor for PMs (should maybe also live in Content.init
-        self.recps = nil
-    }
-
-    init(link: LinkIdentifier, value: Int, root: MessageIdentifier, branches: [MessageIdentifier]) {
-        self.type = .vote
-        
-        let exp: String
-        if value == 1 {
-            exp = "❤️"
-        } else {
-            exp = "💔"
-        }
-        self.vote = Vote(link: link, value: value, expression: exp)
+        self.vote = Vote(link: link, value: value, expression: expression)
 
         self.root = root
         self.branch = branches
-        
-        // TODO: constructor for PMs (should maybe also live in Content.init
-        self.recps = nil
-    }
-    
-    init(value: Int, root: MessageIdentifier) {
-        self.type = .vote
-        
-        let exp: String
-        if value == 1 {
-            exp = "❤️"
-        } else {
-            exp = "💔"
-        }
-        self.vote = Vote(link: LinkIdentifier.null, value: value, expression: exp)
-        // self.link = Identity.null
-        
-        self.root = root
-        self.branch = nil
         
         // TODO: constructor for PMs (should maybe also live in Content.init
         self.recps = nil

--- a/Source/UI/PostCellView.swift
+++ b/Source/UI/PostCellView.swift
@@ -224,11 +224,14 @@ class PostCellView: KeyValueView {
         self.headerView.update(with: keyValue)
 
         if let vote = keyValue.value.content.vote {
-            let expression: String
-            if vote.vote.value > 0 {
-                expression = "💜 \(Text.likesThis.text)"
+            var expression: String 
+            if let explicitExpression = vote.vote.expression,
+               explicitExpression.isSingleEmoji {
+                expression = explicitExpression
+            } else if vote.vote.value > 0 {
+                expression = "\(Text.likesThis.text)"
             } else {
-                expression = "💔 \(Text.dislikesThis.text)"
+                expression = "\(Text.dislikesThis.text)"
             }
 
             let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.italicSystemFont(ofSize: 16),

--- a/Source/UI/PostCellView.swift
+++ b/Source/UI/PostCellView.swift
@@ -226,7 +226,7 @@ class PostCellView: KeyValueView {
         if let vote = keyValue.value.content.vote {
             var expression: String 
             if let explicitExpression = vote.vote.expression,
-               explicitExpression.isSingleEmoji {
+                explicitExpression.isSingleEmoji {
                 expression = explicitExpression
             } else if vote.vote.value > 0 {
                 expression = "\(Text.likesThis.text)"

--- a/UnitTests/ContentTests.swift
+++ b/UnitTests/ContentTests.swift
@@ -419,42 +419,48 @@ class ContentTests: XCTestCase {
         do {
             try ContentType.allCases.forEach {
                 switch $0 {
-
-                    case .about:
-                        let data = try About(about: .testIdentity, name: "test").encodeToData()
-                        let content = try? JSONDecoder().decode(Content.self, from: data)
-                        XCTAssertTrue(content?.assertValid() ?? false)
-                        break
-
-                    case .contact:
-                        let data = try Contact(contact: .testIdentity, blocking: true).encodeToData()
-                        let content = try? JSONDecoder().decode(Content.self, from: data)
-                        XCTAssertTrue(content?.assertValid() ?? false)
-                        break
                     
-                    case .dropContentRequest:
-                        let fakeHash = "%ifDrcOptVFcnYmXggTDnhIsux+J9VaiV0Tlgsh/My24=.ggfeed-v1"
-                        let data = try DropContentRequest(sequence: 1, hash: fakeHash).encodeToData()
-                        let content = try? JSONDecoder().decode(DropContentRequest.self, from: data)
-//                        XCTAssertTrue(content?.assertValid() ?? false)
-                        XCTAssertNotNil(content)
-                        XCTAssertEqual(content?.sequence, 1)
-                        XCTAssertEqual(content?.hash, fakeHash)
-                        break
-
-                    case .post:
-                        let data = try Post(text: "this is a test").encodeToData()
-                        let content = try? JSONDecoder().decode(Content.self, from: data)
-                        XCTAssertTrue(content?.assertValid() ?? false)
-                        break
-
-                    case .vote:
-                        let data = try ContentVote(link: .testLink, value: 1).encodeToData()
-                        let content = try? JSONDecoder().decode(Content.self, from: data)
-                        XCTAssertTrue(content?.assertValid() ?? false)
-
+                case .about:
+                    let data = try About(about: .testIdentity, name: "test").encodeToData()
+                    let content = try? JSONDecoder().decode(Content.self, from: data)
+                    XCTAssertTrue(content?.assertValid() ?? false)
+                    break
+                    
+                case .contact:
+                    let data = try Contact(contact: .testIdentity, blocking: true).encodeToData()
+                    let content = try? JSONDecoder().decode(Content.self, from: data)
+                    XCTAssertTrue(content?.assertValid() ?? false)
+                    break
+                    
+                case .dropContentRequest:
+                    let fakeHash = "%ifDrcOptVFcnYmXggTDnhIsux+J9VaiV0Tlgsh/My24=.ggfeed-v1"
+                    let data = try DropContentRequest(sequence: 1, hash: fakeHash).encodeToData()
+                    let content = try? JSONDecoder().decode(DropContentRequest.self, from: data)
+                    //                        XCTAssertTrue(content?.assertValid() ?? false)
+                    XCTAssertNotNil(content)
+                    XCTAssertEqual(content?.sequence, 1)
+                    XCTAssertEqual(content?.hash, fakeHash)
+                    break
+                    
+                case .post:
+                    let data = try Post(text: "this is a test").encodeToData()
+                    let content = try? JSONDecoder().decode(Content.self, from: data)
+                    XCTAssertTrue(content?.assertValid() ?? false)
+                    break
+                    
+                case .vote:
+                    let data = try ContentVote(
+                        link: .testLink,
+                        value: 1,
+                        expression: nil,
+                        root: "1",
+                        branches: ["1"]
+                    ).encodeToData()
+                    let content = try? JSONDecoder().decode(Content.self, from: data)
+                    XCTAssertTrue(content?.assertValid() ?? false)
+                    
                     // models that SHOULD NOT be encoded
-                    case .pub, .address, .unknown, .unsupported: break
+                case .pub, .address, .unknown, .unsupported: break
                 }
             }
         } catch {

--- a/UnitTests/ViewDatabaseTests.swift
+++ b/UnitTests/ViewDatabaseTests.swift
@@ -270,7 +270,7 @@ class ViewDatabaseTests: XCTestCase {
         do {
             // TODO: verify ordering
             let replies = try self.vdb.getRepliesTo(thread: "%fmm1SMij8QGyT1fyvBX686FdmVyetkDIpr+nMoURvWs=.sha256")
-            XCTAssertEqual(replies.count, 13)
+            XCTAssertEqual(replies.count, 7)
             for (i, kv) in replies.enumerated() {
                 XCTAssertNil(kv.value.content.typeException, "type exception on reply \(i)")
                 
@@ -296,53 +296,17 @@ class ViewDatabaseTests: XCTestCase {
                     XCTAssertEqual(kv.value.content.type, .post)
                     XCTAssertEqual(kv.value.content.post?.text, "[@realUserThree](@TiCSZy2ICusS4RbL3H0I7tyrDFkucAVqTp6cjw2PETI=.ed25519) who are you?!")
                 case 4:
-                    XCTAssertEqual(kv.key, "%l1IwSOOeofqmiOyT84y42Tcn9RJKLeg6zKtVN0v/nIE=.sha256")
-                    XCTAssertEqual(kv.value.author, testFeeds[0])
-                    XCTAssertEqual(kv.value.content.type, .vote)
-                    XCTAssertEqual(kv.value.content.vote?.vote.value, 1)
-                    XCTAssertEqual(kv.value.content.vote?.vote.link, "%2q0+HuVVun2LWCb/uQVQThFAA65VHxrzDIwRYuljoSY=.sha256")
-                case 5:
                     XCTAssertEqual(kv.key, "%M44KTcFtA0HuBAMqnZmLHgmJDj/XnE5a3KdgCosfnSU=.sha256")
                     XCTAssertEqual(kv.value.author, testFeeds[3])
                     XCTAssertEqual(kv.value.content.type, .post)
                     XCTAssertEqual(kv.value.content.post?.text, "hello people!")
-                case 6:
-                    XCTAssertEqual(kv.key, "%YR/7RhApX0Znb5s4w9B/eDK8fN3/5Jx3z5ih/gOoB6Y=.sha256")
-                    XCTAssertEqual(kv.value.author, testFeeds[3])
-                    XCTAssertEqual(kv.value.content.type, .vote)
-                    XCTAssertEqual(kv.value.content.vote?.vote.value, 1)
-                    XCTAssertEqual(kv.value.content.vote?.vote.link, "%M44KTcFtA0HuBAMqnZmLHgmJDj/XnE5a3KdgCosfnSU=.sha256")
-                case 7:
-                    XCTAssertEqual(kv.key, "%oQTjGmUQ9S0SLAoKSz+KNL8mRN6aCj2Mrsy0E/nRwOg=.sha256")
-                    XCTAssertEqual(kv.value.author, testFeeds[3])
-                    XCTAssertEqual(kv.value.content.type, .vote)
-                    XCTAssertEqual(kv.value.content.vote?.vote.value, 0)
-                    XCTAssertEqual(kv.value.content.vote?.vote.link, "%M44KTcFtA0HuBAMqnZmLHgmJDj/XnE5a3KdgCosfnSU=.sha256")
-                case 8:
-                    XCTAssertEqual(kv.key, "%as5O7FtNV1ZfIHnmirVZ2ptHfrBpQWVITtvL5z/CfUc=.sha256")
-                    XCTAssertEqual(kv.value.author, testFeeds[3])
-                    XCTAssertEqual(kv.value.content.type, .vote)
-                    XCTAssertEqual(kv.value.content.vote?.vote.value, 1)
-                    XCTAssertEqual(kv.value.content.vote?.vote.link, "%ytHCZiyd7MJ6F4vHjQwliGZx/vnm98URcF390KmQluE=.sha256")
-                case 9:
-                    XCTAssertEqual(kv.key, "%CRGKl5idyt7UjFQf7GlgVDd3lcvvCUaWqYs4iip9sjE=.sha256")
-                    XCTAssertEqual(kv.value.author, testFeeds[1])
-                    XCTAssertEqual(kv.value.content.type, .vote)
-                    XCTAssertEqual(kv.value.content.vote?.vote.value, 1)
-                    XCTAssertEqual(kv.value.content.vote?.vote.link, "%M44KTcFtA0HuBAMqnZmLHgmJDj/XnE5a3KdgCosfnSU=.sha256")
-                case 10:
-                    XCTAssertEqual(kv.key, "%00TehcsrAYe1fHbivR1j0htNj26mzeldSNt7uDO4RZ0=.sha256")
-                    XCTAssertEqual(kv.value.author, testFeeds[1])
-                    XCTAssertEqual(kv.value.content.type, .vote)
-                    XCTAssertEqual(kv.value.content.vote?.vote.value, 1)
-                    XCTAssertEqual(kv.value.content.vote?.vote.link, "%ytHCZiyd7MJ6F4vHjQwliGZx/vnm98URcF390KmQluE=.sha256")
-                case 11:
+                case 5:
                     XCTAssertEqual(kv.key, "%YGZ8L7iAv3b50k3/Nks7Jm//2v6t9Jd/di1l6q/eIe8=.sha256")
                     XCTAssertEqual(kv.value.author, testFeeds[1])
                     XCTAssertEqual(kv.value.content.type, .post)
                     XCTAssertEqual(kv.value.content.post?.text, "[@userFour](@27PkouhQuhr9Ffn+rgSnN0zabcfoE31qD3ZMkCs3c+0=.ed25519) hey you!\n\n[@userOne](@gIBNiimNRlGPP0Ob2jV6cpiVukfbHoIvGlkYIidHpKY=.ed25519) i don\'t know either..")
                     // TODO: decode & check mentions
-                case 12:
+                case 6:
                     XCTAssertEqual(kv.key, "%ruVFSar2PMCK1WZdz0AL7JIOgxjbFuwcHL8zWrqw9Ig=.sha256")
                     XCTAssertEqual(kv.value.author, DatabaseFixture.exampleFeed.secret.identity)
                     XCTAssertEqual(kv.value.content.type, .post)


### PR DESCRIPTION
#410 this was another small thing that has been bugging me for a while. We were looking for root and branch fields in votes, and Planetary is the only client that puts these. Other clients use the link field, so I changed `fillMessages()` to use that.

We were also hardcoding the vote expression to be a purple heart emoji even when it was set to something else. This was probably intentional, but feels bad because the person posting the vote may have been expressing something very different than "likes this". I changed the behavior here so that if the vote `expression` field is a single emoji then we just show that. If it isn't then we just show the "likes this" or "dislikes this" message without the purple heart. All votes from Planetary users will now have the purple heart set as their expression so they show up that way in other clients.

Since we have been writing votes to SQLite incorrectly this build doesn't fix existing votes that have already been written to SQLite. Only new votes that are replicated after this build is installed will show up correctly.

I would love to implement @Chardot's design for emoji reactions eventually, but this is a quick fix that is better than what we had.