### PR TITLE
Fix Patchwork algorithm sorting

### DIFF
--- a/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
@@ -46,13 +46,15 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
     // swiftlint:disable indentation_width
     private let fetchKeysQuery = """
         SELECT messagekeys.key,
-               (SELECT COALESCE(tangled_message.claimed_at, messages.claimed_at)
+           (SELECT COALESCE(
+                (SELECT tangled_message.claimed_at
                 FROM tangles
                 JOIN messages AS tangled_message ON tangles.msg_ref == tangled_message.msg_id
                 WHERE tangles.root == messages.msg_id
                 AND tangled_message.claimed_at < ?
-                ORDER BY tangled_message.claimed_at DESC LIMIT 1
-               ) as last_reply
+                ORDER BY tangled_message.claimed_at DESC LIMIT 1),
+                messages.claimed_at
+           )) as last_reply
         FROM messages
         JOIN authors ON authors.id == messages.author_id
         JOIN messagekeys ON messagekeys.id == messages.msg_id
@@ -105,13 +107,15 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
                 JOIN authors ON authors.id == tangled_message.author_id
                 WHERE tangles.root == messages.msg_id LIMIT 3
                ) as replies,
-               (SELECT COALESCE(tangled_message.claimed_at, messages.claimed_at)
-                FROM tangles
-                JOIN messages AS tangled_message ON tangles.msg_ref == tangled_message.msg_id
-                WHERE tangles.root == messages.msg_id
-                AND tangled_message.claimed_at < ?
-                ORDER BY tangled_message.claimed_at DESC LIMIT 1
-               ) as last_reply
+               (SELECT COALESCE(
+                    (SELECT tangled_message.claimed_at
+                    FROM tangles
+                    JOIN messages AS tangled_message ON tangles.msg_ref == tangled_message.msg_id
+                    WHERE tangles.root == messages.msg_id
+                    AND tangled_message.claimed_at < ?
+                    ORDER BY tangled_message.claimed_at DESC LIMIT 1),
+                    messages.claimed_at
+               )) as last_reply
         FROM messages
         LEFT JOIN posts ON messages.msg_id == posts.msg_ref
         LEFT JOIN contacts ON messages.msg_id == contacts.msg_ref

--- a/UnitTests/FeedStrategyTests.swift
+++ b/UnitTests/FeedStrategyTests.swift
@@ -42,7 +42,7 @@ class FeedStrategyTests: XCTestCase {
         db.close()
     }
 
-    func testPatchworkFeedStrategy() throws {
+    func testRecentlyActivePostsAndContactsAlgorithm() throws {
         let referenceDate: Double = 1_652_813_189_000 // May 17, 2022 in millis
         let receivedDate: Double = 1_652_813_515_000 // May 17, 2022 in millis
         let alice = DatabaseFixture.exampleFeed.identities[1]
@@ -93,15 +93,24 @@ class FeedStrategyTests: XCTestCase {
             receivedSeq: 4,
             author: bob
         )
+        let post5 = KeyValueFixtures.post(
+            key: "%5",
+            sequence: 5,
+            timestamp: referenceDate + 5,
+            receivedTimestamp: receivedDate,
+            receivedSeq: 5,
+            author: testAuthor
+        )
         
-        try db.fillMessages(msgs: [post0, follow1, about2, post3, reply4])
+        try db.fillMessages(msgs: [post0, follow1, about2, post3, reply4, post5])
         
         let strategy = RecentlyActivePostsAndContactsAlgorithm()
         let proxy = try db.paginatedFeed(with: strategy)
         
-        XCTAssertEqual(proxy.count, 3)
-        XCTAssertEqual(proxy.keyValueBy(index: 0), post0)
-        XCTAssertEqual(proxy.keyValueBy(index: 1), follow1)
+        XCTAssertEqual(proxy.count, 4)
+        XCTAssertEqual(proxy.keyValueBy(index: 0), post5)
+        XCTAssertEqual(proxy.keyValueBy(index: 1), post0)
         XCTAssertEqual(proxy.keyValueBy(index: 2), post3)
+        XCTAssertEqual(proxy.keyValueBy(index: 3), follow1)
     }
 }


### PR DESCRIPTION
This fixes a bug I found this morning in the "Recently Active Posts and Contacts" algorithm where a root post with no replies would be incorrectly sorted too far down. My SQL COALESCE statement needed to be outside of the subquery that gets the timestamp of the latest reply, not inside.