### PR TITLE
Remove old messages from progress target

### DIFF
--- a/Source/Controller/Beta1MigrationCoordinator.swift
+++ b/Source/Controller/Beta1MigrationCoordinator.swift
@@ -202,7 +202,11 @@ class Beta1MigrationCoordinator: ObservableObject, Beta1MigrationViewModel {
     private static func getNumberOfMessagesInViewDatabase(with configuration: AppConfiguration) throws -> Int {
         let dbConnection = try Connection(try dbPath(with: configuration))
         let msgs = Table("messages")
-        return try dbConnection.scalar(msgs.count)
+        let colClaimedAt = Expression<Double>("claimed_at")
+        let sixMonthsAgo = Date().millisecondsSince1970 - 1000 * 60 * 60 * 24 * 30 * 6
+        return try dbConnection.scalar(
+            msgs.count.where(colClaimedAt > sixMonthsAgo)
+        ) + configuration.numberOfPublishedMessages
     }
     
     private static func dbPath(with configuration: AppConfiguration) throws -> String {


### PR DESCRIPTION
I just realized that the progress target was being calculated incorrectly in Beta1MigrationCoordinator. We need to count the messages within the last 6 months now, because we are computing progress based on the messages in SQLite and not Badger.

This would only be an issue for active users with accounts older than six months who would sit and wait for the migration bar to hit 100%, which probably isn't many users, but still definitely worth fixing.