### PR TITLE
Tweak follow messages

### DIFF
--- a/Source/GoBot/FeedStrategy/PostsAndContactsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/PostsAndContactsAlgorithm.swift
@@ -40,9 +40,11 @@ class PostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND messages.is_decrypted == false
         AND messages.hidden == false
         AND (type <> 'post' OR posts.is_root == true)
-        AND (type <> 'contact'  OR (
-                contact_about.about_id IS NOT NULL AND contact_author.author NOT IN (SELECT key FROM pubs)
-            ))
+        AND (type <> 'contact'
+             OR (contact_about.about_id IS NOT NULL
+                 AND contact_author.author NOT IN (SELECT key FROM pubs))
+                 AND contacts.state != -1
+                )
         AND (authors.author IN (
                 SELECT authors.author FROM contacts
                 JOIN authors ON contacts.contact_id == authors.id
@@ -83,7 +85,10 @@ class PostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND messages.hidden == false
         AND (type <> 'post' OR posts.is_root == true)
         AND (type <> 'contact'
-             OR (contact_about.about_id IS NOT NULL AND contact_author.author NOT IN (SELECT key FROM pubs)))
+             OR (contact_about.about_id IS NOT NULL
+                 AND contact_author.author NOT IN (SELECT key FROM pubs))
+                 AND contacts.state != -1
+                )
         AND (authors.author IN (
                 SELECT authors.author FROM contacts
                 JOIN authors ON contacts.contact_id == authors.id
@@ -162,7 +167,10 @@ class PostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND hidden == false
         AND (type <> 'post' OR posts.is_root == true)
         AND (type <> 'contact'
-             OR (contact_about.about_id IS NOT NULL AND contact_author.author NOT IN (SELECT key FROM pubs)))
+             OR (contact_about.about_id IS NOT NULL
+                 AND contact_author.author NOT IN (SELECT key FROM pubs))
+                 AND contacts.state != -1
+                )
         AND (authors.author IN (SELECT authors.author FROM contacts
                                JOIN authors ON contacts.contact_id == authors.id
                                WHERE contacts.author_id = ? AND contacts.state == 1)

--- a/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
@@ -30,9 +30,11 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND messages.is_decrypted == false
         AND messages.hidden == false
         AND (type <> 'post' OR posts.is_root == true)
-        AND (type <> 'contact'  OR (
-                contact_about.about_id IS NOT NULL AND contact_author.author NOT IN (SELECT key FROM pubs)
-            ))
+        AND (type <> 'contact'
+             OR (contact_about.about_id IS NOT NULL
+                 AND contact_author.author NOT IN (SELECT key FROM pubs))
+                 AND contacts.state != -1
+                )
         AND (authors.author IN (
                 SELECT authors.author FROM contacts
                 JOIN authors ON contacts.contact_id == authors.id
@@ -67,7 +69,10 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND messages.hidden == false
         AND (type <> 'post' OR posts.is_root == true)
         AND (type <> 'contact'
-             OR (contact_about.about_id IS NOT NULL AND contact_author.author NOT IN (SELECT key FROM pubs)))
+             OR (contact_about.about_id IS NOT NULL
+                 AND contact_author.author NOT IN (SELECT key FROM pubs))
+                 AND contacts.state != -1
+                )
         AND (authors.author IN (
                 SELECT authors.author FROM contacts
                 JOIN authors ON contacts.contact_id == authors.id
@@ -130,7 +135,10 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND hidden == false
         AND (type <> 'post' OR posts.is_root == true)
         AND (type <> 'contact'
-             OR (contact_about.about_id IS NOT NULL AND contact_author.author NOT IN (SELECT key FROM pubs)))
+             OR (contact_about.about_id IS NOT NULL
+                 AND contact_author.author NOT IN (SELECT key FROM pubs))
+                 AND contacts.state != -1
+                )
         AND (authors.author IN (SELECT authors.author FROM contacts
                                JOIN authors ON contacts.contact_id == authors.id
                                WHERE contacts.author_id = ? AND contacts.state == 1)

--- a/Source/UI/Buttons/PillButton.swift
+++ b/Source/UI/Buttons/PillButton.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SkeletonView
 
 // a button class with an icon on the left and a label on the right
 class PillButton: AppButton {
@@ -56,7 +57,9 @@ class PillButton: AppButton {
     
     override func draw(_ rect: CGRect) {
         super.draw(rect)
-        if isSelected {
+        if sk.isSkeletonActive {
+            self.layer.borderColor = UIColor.clear.cgColor
+        } else if isSelected {
             self.layer.borderColor = self.primaryColor.cgColor
         } else {
             self.layer.borderColor = self.secondaryColor.cgColor

--- a/Source/UI/ContactCellView.swift
+++ b/Source/UI/ContactCellView.swift
@@ -104,6 +104,10 @@ class ContactCellView: KeyValueView {
                     Log.optional(error)
                 }
                 try Task.checkCancellation()
+                await self?.contactView.update(with: identity, about: about)
+                await self?.headerView.update(with: keyValue)
+                await self?.headerView.hideSkeleton()
+                
                 var stats = SocialStats(numberOfFollowers: 0, numberOfFollows: 0)
                 do {
                     stats = try await Bots.current.socialStats(for: identity)
@@ -111,6 +115,8 @@ class ContactCellView: KeyValueView {
                     Log.optional(error)
                 }
                 try Task.checkCancellation()
+                await self?.contactView.update(socialStats: stats)
+                
                 var hashtags: [Hashtag] = []
                 do {
                     hashtags = try await Bots.current.hashtags(usedBy: identity, limit: 3)
@@ -118,14 +124,7 @@ class ContactCellView: KeyValueView {
                     Log.optional(error)
                 }
                 try Task.checkCancellation()
-                await self?.headerView.update(with: keyValue)
-                await self?.contactView.update(
-                    with: identity,
-                    about: about,
-                    socialStats: stats,
-                    hashtags: hashtags
-                )
-                await self?.hideSkeleton()
+                await self?.contactView.update(hashtags: hashtags)
             }
         } else {
             return

--- a/Source/UI/ContactCellView.swift
+++ b/Source/UI/ContactCellView.swift
@@ -106,7 +106,6 @@ class ContactCellView: KeyValueView {
                 try Task.checkCancellation()
                 await self?.contactView.update(with: identity, about: about)
                 await self?.headerView.update(with: keyValue)
-                await self?.headerView.hideSkeleton()
                 
                 var stats = SocialStats(numberOfFollowers: 0, numberOfFollows: 0)
                 do {

--- a/Source/UI/ContactHeaderView.swift
+++ b/Source/UI/ContactHeaderView.swift
@@ -70,6 +70,7 @@ class ContactHeaderView: UIView {
 
     func reset() {
         update(with: Identity.null, about: nil)
+        showSkeleton()
     }
 
     func update(with keyValue: KeyValue) {
@@ -97,6 +98,7 @@ class ContactHeaderView: UIView {
             identityButton.setImage(UIImage.verse.missingAbout, for: .normal)
         }
 
+        hideSkeleton()
         self.setNeedsLayout()
         self.layoutIfNeeded()
     }

--- a/Source/UI/ContactView.swift
+++ b/Source/UI/ContactView.swift
@@ -49,6 +49,7 @@ class ContactView: KeyValueView {
         label.textContainer.lineFragmentPadding = 0
         label.isSkeletonable = true
         label.linesCornerRadius = 7
+        label.backgroundColor = .clear
         return label
     }()
 
@@ -106,21 +107,12 @@ class ContactView: KeyValueView {
 
     override func reset() {
         super.reset()
-        update(
-            with: Identity.null,
-            about: nil,
-            socialStats: SocialStats(numberOfFollowers: 0, numberOfFollows: 0),
-            hashtags: []
-        )
+        update(with: Identity.null, about: nil)
+        update(socialStats: SocialStats(numberOfFollowers: 0, numberOfFollows: 0))
+        update(hashtags: [])
     }
-
-    func update(with identity: Identity, about: About?, socialStats: SocialStats, hashtags: [Hashtag]) {
-        update(numberOfFollowers: socialStats.numberOfFollowers, numberOfFollows: socialStats.numberOfFollows)
-        update(hashtags: hashtags)
-        update(with: identity, about: about)
-    }
-
-    private func update(with identity: Identity, about: About?) {
+    
+    func update(with identity: Identity, about: About?) {
         if let about = about {
             self.label.text = about.nameOrIdentity
             self.imageView.set(image: about.image)
@@ -132,16 +124,23 @@ class ContactView: KeyValueView {
             followButton.removeFromSuperview()
         } else if let myIdentity = Bots.current.identity {
             stackView.addArrangedSubview(followButton)
+            followButton.showSkeleton()
             let relationship = Relationship(from: myIdentity, to: identity)
             relationship.load {
                 self.followButton.relationship = relationship
+                self.followButton.hideSkeleton()
             }
         } else {
             followButton.removeFromSuperview()
         }
+        
+        label.hideSkeleton()
+        imageView.hideSkeleton()
     }
-
-    private func update(numberOfFollowers: Int, numberOfFollows: Int) {
+    
+    func update(socialStats: SocialStats) {
+        let numberOfFollowers = socialStats.numberOfFollowers
+        let numberOfFollows = socialStats.numberOfFollows
         let string = "Following numberOfFollows • Followed by numberOfFollowers"
 
         let primaryColor = [NSAttributedString.Key.foregroundColor: UIColor.text.default]
@@ -167,9 +166,10 @@ class ContactView: KeyValueView {
             )
         )
         followerCountLabel.attributedText = attributedString
+        followerCountLabel.hideSkeleton()
     }
 
-    private func update(hashtags: [Hashtag]) {
+    func update(hashtags: [Hashtag]) {
         if hashtags.isEmpty {
             hashtagsLabel.removeFromSuperview()
         } else {
@@ -197,9 +197,9 @@ class ContactView: KeyValueView {
                 }
             }
             hashtagsLabel.attributedText = attributedString
+            hashtagsLabel.hideSkeleton()
         }
     }
-
 }
 
 extension ContactView: UITextViewDelegate {

--- a/UnitTests/GoBotOrderedTests.swift
+++ b/UnitTests/GoBotOrderedTests.swift
@@ -1012,8 +1012,7 @@ class GoBotOrderedTests: XCTestCase {
         let exClean = self.expectation(description: "\(#function) recent")
         GoBotOrderedTests.shared.recent { msgs, err in
             XCTAssertNil(err)
-            // 1 = still have my follow to denise
-            XCTAssertEqual(msgs.count, startingCount + 1)
+            XCTAssertEqual(msgs.count, startingCount)
             exClean.fulfill()
         }
         self.wait(for: [exClean], timeout: 10)


### PR DESCRIPTION
- Fix block messages showing as follows #619
- Fix background color of hashtag label #620
- Show individual sections when they have finished loading instead of waiting for everything to load. This is not ticketed, but I noticed that the follow messages are taking a long time to load on my actual device, and I wanted to see if this makes it feel better. I think it does, but I'm not sure if this was an intentional design decision @martindsq so let me know.