### PR TITLE
Make the recently downloaded post count load faster

### DIFF
--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -235,6 +235,8 @@ protocol Bot: AnyObject {
 
     func statistics(queue: DispatchQueue, completion: @escaping StatisticsCompletion)
     
+    func recentlyDownloadedPostData() -> (recentlyDownloadedPostCount: Int, recentlyDownloadedPostDuration: Int)
+    
     func lastReceivedTimestam() throws -> Double
     
     // MARK: Preloading

--- a/Source/Controller/ConnectedPeerListCoordinator.swift
+++ b/Source/Controller/ConnectedPeerListCoordinator.swift
@@ -123,7 +123,6 @@ class ConnectedPeerListCoordinator: ConnectedPeerListViewModel {
                 self.recentlyDownloadedPostDuration = duration
             })
             .store(in: &self.cancellables)
-        
     }
     
     private func unsubscribeFromBotStatistics() {

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -296,10 +296,9 @@ class FakeBot: Bot {
     
     var mockRecentlyDownloadedPostData = (0, 0)
     func recentlyDownloadedPostData() -> (recentlyDownloadedPostCount: Int, recentlyDownloadedPostDuration: Int) {
-        return mockRecentlyDownloadedPostData
+        mockRecentlyDownloadedPostData
     }
 
-    
     func statistics(queue: DispatchQueue, completion: @escaping StatisticsCompletion) {
         let statistics = mockStatistics.popLast() ?? _statistics
         queue.async {

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -294,6 +294,12 @@ class FakeBot: Bot {
     var mockStatistics = [BotStatistics]()
     var statistics: BotStatistics { mockStatistics.popLast() ?? _statistics }
     
+    var mockRecentlyDownloadedPostData = (0, 0)
+    func recentlyDownloadedPostData() -> (recentlyDownloadedPostCount: Int, recentlyDownloadedPostDuration: Int) {
+        return mockRecentlyDownloadedPostData
+    }
+
+    
     func statistics(queue: DispatchQueue, completion: @escaping StatisticsCompletion) {
         let statistics = mockStatistics.popLast() ?? _statistics
         queue.async {

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -448,7 +448,7 @@ class GoBot: Bot {
         completion: @escaping SyncCompletion
     ) {
         self._isSyncing = false
-        serialQueue.sync {
+        serialQueue.async {
             self._statistics.lastSyncDate = Date()
             self._statistics.lastSyncDuration = elapsed
         }
@@ -513,7 +513,7 @@ class GoBot: Bot {
         completion: @escaping RefreshCompletion
     ) {
         self._isRefreshing = false
-        serialQueue.sync {
+        serialQueue.async {
             self._statistics.lastRefreshDate = Date()
             self._statistics.lastRefreshDuration = elapsed
         }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -1497,14 +1497,9 @@ class GoBot: Bot {
                 open: openConnections
             )
             
-            self._statistics.recentlyDownloadedPostDuration = 15 // minutes
-            do {
-                self._statistics.recentlyDownloadedPostCount = try self.database.receivedMessageCount(
-                    since: Date(timeIntervalSinceNow: Double(self._statistics.recentlyDownloadedPostDuration) * -60)
-                )
-            } catch {
-                Log.optional(error)
-            }
+            let (recentlyDownloadedPostCount, recentlyDownloadedPostDuration) = self.recentlyDownloadedPostData()
+            self._statistics.recentlyDownloadedPostCount = recentlyDownloadedPostCount
+            self._statistics.recentlyDownloadedPostDuration = recentlyDownloadedPostDuration
             
             let sqliteMessageCount = (try? self.database.messageCount()) ?? 0
             self._statistics.db = DatabaseStatistics(
@@ -1518,6 +1513,18 @@ class GoBot: Bot {
             }
             Analytics.shared.trackStatistics(statistics.analyticsStatistics)
         }
+    }
+    
+    func recentlyDownloadedPostData() -> (recentlyDownloadedPostCount: Int, recentlyDownloadedPostDuration: Int) {
+        let recentlyDownloadedPostDuration = 15 // minutes
+        var recentlyDownloadedPostCount = 0
+        do {
+            let startDate = Date(timeIntervalSinceNow: Double(recentlyDownloadedPostDuration) * -60)
+            recentlyDownloadedPostCount = try self.database.receivedMessageCount(since: startDate)
+        } catch {
+            Log.optional(error)
+        }
+        return (recentlyDownloadedPostCount, recentlyDownloadedPostDuration)
     }
     
     /// Saves the number of published messages to the AppConfiguration. Used for forked feed protection.

--- a/UnitTests/Controller/ConnectedPeersCoordinatorTests.swift
+++ b/UnitTests/Controller/ConnectedPeersCoordinatorTests.swift
@@ -179,77 +179,30 @@ class ConnectedPeerListCoordinatorTests: XCTestCase {
         XCTAssertEqual(publishedPeers.first, secondExpectedPeers)
     }
     
-    /// Verifies that the coordinator publishes the latest recentPostCount from its BotStatisticsService
+    /// Verifies that the coordinator publishes the latest recentPostCount from the Bot
     func testRecentlyDownloadedPostCount() async throws {
         // Arrange
-        let newStatistics = BotStatistics(
-            lastSyncDate: Date(),
-            lastSyncDuration: 1,
-            lastRefreshDate: Date(),
-            lastRefreshDuration: 2,
-            recentlyDownloadedPostCount: 888,
-            recentlyDownloadedPostDuration: 999,
-            repo: RepoStatistics(
-                path: nil,
-                feedCount: 3,
-                messageCount: 4,
-                numberOfPublishedMessages: 5,
-                lastHash: "hash"
-            ),
-            peer: PeerStatistics(
-                count: 3,
-                connectionCount: 2,
-                identities: [],
-                open: []
-            ),
-            db: DatabaseStatistics(lastReceivedMessage: 10)
-        )
-        
         let recentlyDownloadedPostCountPublisher = await makeAwaitable(
             publisher: sut.$recentlyDownloadedPostCount.collectNext()
         )
         
         // Act
-        await mockStatistics.statisticsPasthrough.send(newStatistics)
+        mockBot.mockRecentlyDownloadedPostData = (888, 999)
         let recentlyDownloadedPostCounts = try await recentlyDownloadedPostCountPublisher.result.get().first
         
         // Assert
         XCTAssertEqual(recentlyDownloadedPostCounts, 888)
     }
     
-    /// Verifies that the coordinators passes through the recentlyDownloadedPostDuration from
-    /// its `BotStatisticsService`.
+    /// Verifies that the coordinators passes through the recentlyDownloadedPostDuration from the Bot
     func testRecentlyDownloadedPostDuration() async throws {
         // Arrange
-        let newStatistics = BotStatistics(
-            lastSyncDate: Date(),
-            lastSyncDuration: 1,
-            lastRefreshDate: Date(),
-            lastRefreshDuration: 2,
-            recentlyDownloadedPostCount: 888,
-            recentlyDownloadedPostDuration: 999,
-            repo: RepoStatistics(
-                path: nil,
-                feedCount: 3,
-                messageCount: 4,
-                numberOfPublishedMessages: 5,
-                lastHash: "hash"
-            ),
-            peer: PeerStatistics(
-                count: 3,
-                connectionCount: 2,
-                identities: [],
-                open: []
-            ),
-            db: DatabaseStatistics(lastReceivedMessage: 10)
-        )
-        
         let recentlyDownloadedPostDurationPublisher = await makeAwaitable(
             publisher: sut.$recentlyDownloadedPostDuration.collectNext()
         )
         
         // Act
-        await mockStatistics.statisticsPasthrough.send(newStatistics)
+        mockBot.mockRecentlyDownloadedPostData = (888, 999)
         let recentlyDownloadedPostDuration = try await recentlyDownloadedPostDurationPublisher.result.get().first
         
         // Assert


### PR DESCRIPTION
This is a little optimization for the number of recently downloaded posts shown in the sidebar. The GoBot takes a long time to respond to `statistics()` calls these days. But we actually fetch the recently downloaded post count from SQLite, which doesn't take very long. This code bypasses `statistics()` to show the count more quickly after the menu is opened.