### PR TITLE
Make GC less aggressive

### DIFF
--- a/GoSSB/Sources/api-ios.go
+++ b/GoSSB/Sources/api-ios.go
@@ -29,7 +29,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -54,8 +53,6 @@ func init() {
 	versionString = C.CString("beta2")
 	log = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
 	log = kitlog.With(log, "warning", "pre-init")
-
-	debug.SetGCPercent(10)
 }
 
 // globals


### PR DESCRIPTION
Garbage collection is responsible for a large percentage of our CPU usage. This
pull request tries to revert GC settings to the default ones (collection once
newly allocated memory reaches 100% of previously allocated memory).