### PR TITLE
Revert "Make GC less aggressive"

### DIFF
--- a/GoSSB/Sources/api-ios.go
+++ b/GoSSB/Sources/api-ios.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -53,6 +54,8 @@ func init() {
 	versionString = C.CString("beta2")
 	log = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
 	log = kitlog.With(log, "warning", "pre-init")
+
+	debug.SetGCPercent(10)
 }
 
 // globals


### PR DESCRIPTION
Reverts planetary-social/planetary-ios#651

This change has caused frequent crashes for some of us and hasn't solved the energy usage problem, so I'm reverting it for our release build today.