### PR TITLE
Update delete identity flow

### DIFF
--- a/Shared/Debug/DebugTableViewController.swift
+++ b/Shared/Debug/DebugTableViewController.swift
@@ -53,7 +53,7 @@ class DebugTableViewController: UITableViewController {
         self.settings[section].cellModels.count
     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let model = self.settings[indexPath.section].cellModels[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: model.cellReuseIdentifier, for: indexPath)
         cell.accessoryType = .none

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -235,13 +235,13 @@ extension Text {
 extension Text {
 
     enum Offboarding: String, Localizable, CaseIterable {
-        case reset = "Reset"
-        case resetApplicationAndIdentity = "Reset application and identity"
+        case reset = "Delete"
+        case resetIdentity = "Delete My Identity"
         case resetConfirmTitle = "Warning"
-        case resetConfirmMessage = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone."
+        case resetConfirmMessage = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone."
         case resetConfirmAgainTitle = "Are you sure?"
-        case resetConfirmAgainMessage = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone."
-        case resetFooter = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one."
+        case resetConfirmAgainMessage = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone."
+        case resetFooter = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one."
         case resetApiErrorTryAgain = "We weren't able to connect to the directory to remove you. Please try again."
         case resetBotErrorTryAgain = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again."
     }

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Dieses Bild aus dem Beitrag entfernen? Du kannst es immer wieder hinzufügen.";
 "NewPost.remove" = "Entfernen";
 
-"Offboarding.reset" = "Zurücksetzen";
-"Offboarding.resetApplicationAndIdentity" = "Anwendung und Identität zurücksetzen";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warnung";
-"Offboarding.resetConfirmMessage" = "Bist du sicher, dass du Planetary zurücksetzen möchtest? Du verlierst diese Identität und alle damit verbundenen Inhalte. Dies kann nicht rückgängig gemacht werden.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Bist du sicher?";
-"Offboarding.resetConfirmAgainMessage" = "Bist du sicher, dass du Planetary zurücksetzen möchtest? Du verlierst diese Identität und alle damit verbundenen Inhalte. Dies kann nicht rückgängig gemacht werden.";
-"Offboarding.resetFooter" = "Das Zurücksetzen der Planetary-App wird dich aus dem Benutzerverzeichnis entfernen. Die anderen Benutzer folgen dich nicht mehr und zerstören deine Identität auf ihrem Gerät. Du wirst nicht in der Lage sein, deine Identität wiederherzustellen, aber du wirst in der Lage sein, eine neue zu erstellen.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "Wir konnten keine Verbindung zum Verzeichnis herstellen, um dich zu entfernen. Bitte versuche es erneut.";
 "Offboarding.resetBotErrorTryAgain" = "Etwas Unerwartetes ist passiert, aber keine Sorge, wir haben eine Notiz gemacht, um es zu beheben. Bitte versuche es erneut.";
 

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -150,13 +150,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "¿Querés eliminar esta imagen de la publicación? La podés volver a agregar si te arrepentís.";
 "NewPost.remove" = "Eliminar";
 
-"Offboarding.reset" = "Resetear";
-"Offboarding.resetApplicationAndIdentity" = "Resetear aplicación e identidad";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Cuidado";
-"Offboarding.resetConfirmMessage" = "¿Estás seguro de que querés resetear tu aplicación de Planetary? Vas a perder esta identidad y todo su contenido. Esto no se puede deshacer.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "¿Estás seguro?";
-"Offboarding.resetConfirmAgainMessage" = "¿De verdad estás seguro de que quieres reiniciar tu aplicación de Planetary? Vas a perder esta identidad y todo su contenido. Esto no se puede deshacer.";
-"Offboarding.resetFooter" = "Resetear la aplicación de Planetary te va a borrar del directorio de usuarios, vas a dejar de seguir a todos, y se va a eliminar tu identidad en tu dispositivo. No vas a poder recuperar tu identidad, pero vas a poder crear una nueva.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "No nos pudimos contectar al directorio para quitarte. Por favor intentá de nuevo.";
 "Offboarding.resetBotErrorTryAgain" = "Pasó algo inesperado pero no te preocupes, creamos una nota para arreglarlo. Por favor intentá de nuevo.";
 

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Ups";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "¿Eliminar esta imagen de la publicación? Podrás volver a añadirla si te arrepientes.";
 "NewPost.remove" = "Quitar";
 
-"Offboarding.reset" = "Resetear";
-"Offboarding.resetApplicationAndIdentity" = "Resetear aplicación e identidad";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Cuidado";
-"Offboarding.resetConfirmMessage" = "¿Estás seguro de que quieres resetear tu aplicación Planetary? Perderás esta identidad y todo su contenido. Esto no puede deshacerse.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "¿Estás seguro?";
-"Offboarding.resetConfirmAgainMessage" = "¿De verdad estás seguro de que quieres reiniciar tu aplicación Planetary? Perderás esta identidad y todo su contenido. Esto no puede deshacerse.";
-"Offboarding.resetFooter" = "Resetear la aplicación Planetary te quitará del directorio de usuarios, dejarás de seguir a todos, y destruirá tu identidad en tu dispositivo. No te será posible recuperar tu identidad, pero podrás crear una nueva.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "No hemos podido contectarnos al directorio para quitarte. Por favor intenta de nuevo.";
 "Offboarding.resetBotErrorTryAgain" = "Algo inesperado ocurrió pero no te preocupes, creamos una nota para arreglarlo. Por favor intenta de nuevo.";
 

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Opa";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "¿Querés eliminar esta imagen de la publicación? La podés volver a agregar si te arrepentís.";
 "NewPost.remove" = "Eliminar";
 
-"Offboarding.reset" = "Resetear";
-"Offboarding.resetApplicationAndIdentity" = "Resetear aplicación e identidad";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Cuidado";
-"Offboarding.resetConfirmMessage" = "¿Estás seguro de que querés resetear tu aplicación de Planetary? Vas a perder esta identidad y todo su contenido. Esto no se puede deshacer.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "¿Estás seguro?";
-"Offboarding.resetConfirmAgainMessage" = "¿De verdad estás seguro de que quieres reiniciar tu aplicación de Planetary? Vas a perder esta identidad y todo su contenido. Esto no se puede deshacer.";
-"Offboarding.resetFooter" = "Resetear la aplicación de Planetary te va a borrar del directorio de usuarios, vas a dejar de seguir a todos, y se va a eliminar tu identidad en tu dispositivo. No vas a poder recuperar tu identidad, pero vas a poder crear una nueva.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "No nos pudimos contectar al directorio para quitarte. Por favor intentá de nuevo.";
 "Offboarding.resetBotErrorTryAgain" = "Pasó algo inesperado pero no te preocupes, creamos una nota para arreglarlo. Por favor intentá de nuevo.";
 

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "¿Eliminar esta imagen de la publicación? Podrás volver a añadirla si te arrepientes.";
 "NewPost.remove" = "Quitar";
 
-"Offboarding.reset" = "Resetear";
-"Offboarding.resetApplicationAndIdentity" = "Resetear aplicación e identidad";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Cuidado";
-"Offboarding.resetConfirmMessage" = "¿Estás seguro de que quieres resetear tu aplicación Planetary? Perderás esta identidad y todo su contenido. Esto no puede deshacerse.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "¿Estás seguro?";
-"Offboarding.resetConfirmAgainMessage" = "¿De verdad estás seguro de que quieres reiniciar tu aplicación Planetary? Perderás esta identidad y todo su contenido. Esto no puede deshacerse.";
-"Offboarding.resetFooter" = "Resetear la aplicación Planetary te quitará del directorio de usuarios, dejarás de seguir a todos, y destruirá tu identidad en tu dispositivo. No te será posible recuperar tu identidad, pero podrás crear una nueva.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "No hemos podido contectarnos al directorio para quitarte. Por favor intenta de nuevo.";
 "Offboarding.resetBotErrorTryAgain" = "Algo inesperado ocurrió pero no te preocupes, creamos una nota para arreglarlo. Por favor intenta de nuevo.";
 

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Ojejku";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Usunąć ten obraz z posta? Zawsze możesz dodać go ponownie.";
 "NewPost.remove" = "Usuń";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Zresetuj aplikację i tożsamość";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Uwaga";
-"Offboarding.resetConfirmMessage" = "Czy na pewno chcesz zresetować profil w Planetary? Utracisz tę tożsamość i wszystkie powiązane treści. Tego nie można cofnąć.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Na pewno?";
-"Offboarding.resetConfirmAgainMessage" = "Czy na pewno na pewno chcesz zresetować profil w Planetary?? Utracisz tę tożsamość i wszystkie powiązane treści. Tego nie można cofnąć.";
-"Offboarding.resetFooter" = "Zresetowanie aplikacji Planetary usunie Cię z katalogu użytkownika, przestanie obserwować wszystkich znajomych i zniszczy Twoją tożsamość na tym urządzeniu. Nie będziesz w stanie odzyskać swojej tożsamości, ale będziesz mógł stworzyć nową.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "Nie mogliśmy połączyć się z katalogiem, aby usunąć Twój profil. Proszę spróbuj ponownie.";
 "Offboarding.resetBotErrorTryAgain" = "Stało się coś nieoczekiwanego, ale nie martw się, zostaliśmy o tym powiadomieni i spróbujemy to naprawić. Proszę spróbuj ponownie.";
 

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Usunąć ten obraz z posta? Zawsze możesz dodać go ponownie.";
 "NewPost.remove" = "Usuń";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Zresetuj aplikację i tożsamość";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Uwaga";
-"Offboarding.resetConfirmMessage" = "Czy na pewno chcesz zresetować profil w Planetary? Utracisz tę tożsamość i wszystkie powiązane treści. Tego nie można cofnąć.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Na pewno?";
-"Offboarding.resetConfirmAgainMessage" = "Czy na pewno na pewno chcesz zresetować profil w Planetary?? Utracisz tę tożsamość i wszystkie powiązane treści. Tego nie można cofnąć.";
-"Offboarding.resetFooter" = "Zresetowanie aplikacji Planetary usunie Cię z katalogu użytkownika, przestanie obserwować wszystkich znajomych i zniszczy Twoją tożsamość na tym urządzeniu. Nie będziesz w stanie odzyskać swojej tożsamości, ale będziesz mógł stworzyć nową.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "Nie mogliśmy połączyć się z katalogiem, aby usunąć Twój profil. Proszę spróbuj ponownie.";
 "Offboarding.resetBotErrorTryAgain" = "Stało się coś nieoczekiwanego, ale nie martw się, zostaliśmy o tym powiadomieni i spróbujemy to naprawić. Proszę spróbuj ponownie.";
 

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Планетарные";
 "Text.error" = "Ой";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -151,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "从帖子中删除此图像？您总是可以重新添加。";
 "NewPost.remove" = "移除";
 
-"Offboarding.reset" = "重置";
-"Offboarding.resetApplicationAndIdentity" = "重置应用程序和身份";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "警告";
-"Offboarding.resetConfirmMessage" = "您确定要重置您的行星应用吗？您将丢失此身份和所有相关内容。此操作无法撤消。";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "您确定吗？";
-"Offboarding.resetConfirmAgainMessage" = "您确定要重置您的行星应用吗？您将丢失此身份和所有相关内容。此操作无法撤消。";
-"Offboarding.resetFooter" = "重置行星应用将从用户目录中删除您，取消关注所有人，并在您的设备上摧毁您的身份。 您将无法恢复您的身份，但您将能够创建一个新的身份。";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "我们无法连接到目录来移除您。请重试。";
 "Offboarding.resetBotErrorTryAgain" = "发生了一些意外事件，但不用担心，我们已经做了笔记来修复它。请再试一次。";
 

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -1,4 +1,5 @@
-// This file is auto-generated at build time and should not be modified by hand
+// This file is auto-generated at build time
+// Existing translations are left in place, and new keys are added as needed
 
 "Text.planetary" = "Planetary";
 "Text.error" = "Oops";
@@ -150,13 +151,13 @@
 "NewPost.confirmRemove" = "Remove this image from the post?  You can always add it back again.";
 "NewPost.remove" = "Remove";
 
-"Offboarding.reset" = "Reset";
-"Offboarding.resetApplicationAndIdentity" = "Reset application and identity";
+"Offboarding.reset" = "Delete";
+"Offboarding.resetIdentity" = "Delete My Identity";
 "Offboarding.resetConfirmTitle" = "Warning";
-"Offboarding.resetConfirmMessage" = "Are you sure want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
+"Offboarding.resetConfirmMessage" = "Are you sure want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
 "Offboarding.resetConfirmAgainTitle" = "Are you sure?";
-"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to reset your Planetary app? You will lose this identity and all related content. This cannot be undone.";
-"Offboarding.resetFooter" = "Resetting the Planetary app will remove you from the user directory, unfollow everyone, and destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
+"Offboarding.resetConfirmAgainMessage" = "Are you really sure you want to delete your identity from this device? You will lose this profile and all related content. This cannot be undone.";
+"Offboarding.resetFooter" = "This will destroy your identity on your device. You will not be able to recover your identity, but you will be able to create a new one.";
 "Offboarding.resetApiErrorTryAgain" = "We weren't able to connect to the directory to remove you. Please try again.";
 "Offboarding.resetBotErrorTryAgain" = "Something unexpected happened but don't worry, we've made a note to fix it. Please try again.";
 

--- a/Source/Settings/PreviewSettingsViewController.swift
+++ b/Source/Settings/PreviewSettingsViewController.swift
@@ -69,11 +69,17 @@ class PreviewSettingsViewController: DebugTableViewController {
     private func reset() -> DebugTableViewController.Settings {
         var settings: [DebugTableViewCellModel] = []
 
-        settings += [DebugTableViewCellModel(title: Text.Offboarding.resetApplicationAndIdentity.text,
-                                             actionClosure: {
-                [unowned self] _ in
-                self.confirmOffboard()
-            })]
+        settings += [
+            DebugTableViewCellModel(
+                title: Text.Offboarding.resetIdentity.text,
+                valueClosure: { cell in
+                    cell.textLabel?.textColor = .systemRed
+                },
+                actionClosure: { [weak self] _ in
+                    self?.confirmOffboard()
+                }
+            )
+        ]
 
         return (Text.Offboarding.reset.text, settings, Text.Offboarding.resetFooter.text)
     }


### PR DESCRIPTION
This updates and clarifies our language around deleting your identity. The old text talked about "resetting Planetary", unfollowing people, and removing you from the user directory. The user directory is gone, unfollowing people didn't actually do anything, and the language about resetting the application was unclear.

<img src="https://user-images.githubusercontent.com/1165004/176037614-acce584a-6f2d-415d-a9b4-de0924cdda71.png" width="300" />
