### PR TITLE
Detect incorrect Go version during builds

### DIFF
--- a/GoSSB/GoSSB.xcodeproj/project.pbxproj
+++ b/GoSSB/GoSSB.xcodeproj/project.pbxproj
@@ -170,7 +170,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"${PROJECT_DIR}/Sources/.goroot",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/GoSSB/GoSSB.xcodeproj/project.pbxproj
+++ b/GoSSB/GoSSB.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"${PROJECT_DIR}/Sources/.goroot",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/GoSSB/GoSSB.xcodeproj/project.pbxproj
+++ b/GoSSB/GoSSB.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		C933908827FB5134007B5FD8 /* Install Golang toolchain */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Scripts/go_install.sh
+++ b/Scripts/go_install.sh
@@ -82,9 +82,17 @@ elif [ ! -z "$1" ]; then
 fi
 
 if [ -d "$GOROOT" ]; then
-    echo "The Go install directory ($GOROOT) already exists. Exiting."
-    ${GOROOT}/bin/go version
-    exit 0
+    installed_version=$(${GOROOT}/bin/go version | cut -f3 -d' ')
+    expected_version="go$VERSION"
+    echo "Installed Go version $installed_version, expected Go version $expected_version"
+
+    if [ "$installed_version" = "$expected_version" ]; then
+      echo "Expected Go version is already installed"
+      exit 0
+    else
+      echo "Incorrect Go version detected, removing"
+      rm -r "$GOROOT"
+    fi
 fi
 
 echo "Downloading $PACKAGE_NAME ..."


### PR DESCRIPTION
The script will now check the installed Go version and if it is incorrect the
Go tools will be redownloaded. This should streamline our development process.

Fixes #541.