### PR TITLE
Add changelog check to CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
     steps:
       - uses: dangoslen/changelog-enforcer@v3
         with:
-          - skipLabels: 'Skip-Changelog'
-          - missingUpdateErrorMessage: 'You have not updated CHANGELOG.md. If an entry is not applicable add the Skip-Changelog label to your PR. See the top of the CHANGELOG.md for more details.'
+          skipLabels: 'Skip-Changelog'
+          missingUpdateErrorMessage: 'You have not updated CHANGELOG.md. If an entry is not applicable add the Skip-Changelog label to your PR. See the top of the CHANGELOG.md for more details.'
   logger:
     name: Logger
     runs-on: macOS-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: dangoslen/changelog-enforcer@v3
-          with:
-            - skipLabels: 'Skip-Changelog'
-            - missingUpdateErrorMessage: 'You have not updated CHANGELOG.md. If an entry is not applicable add the Skip-Changelog label to your PR. See the top of the CHANGELOG.md for more details.'
+        with:
+          - skipLabels: 'Skip-Changelog'
+          - missingUpdateErrorMessage: 'You have not updated CHANGELOG.md. If an entry is not applicable add the Skip-Changelog label to your PR. See the top of the CHANGELOG.md for more details.'
   logger:
     name: Logger
     runs-on: macOS-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,11 @@ jobs:
       run: set -o pipefail && xcodebuild build-for-testing -workspace Planetary.xcworkspace -scheme UnitTests -destination "platform=iOS Simulator,name=iPhone 13,OS=15.4" | xcpretty
     - name: Run Tests
       run: set -o pipefail && xcodebuild test-without-building -workspace Planetary.xcworkspace -scheme UnitTests -destination "platform=iOS Simulator,name=iPhone 13,OS=15.4" | xcpretty
+  changelog:
+    name: Check CHANGELOG
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dangoslen/changelog-enforcer@v3
   logger:
     name: Logger
     runs-on: macOS-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: dangoslen/changelog-enforcer@v3
+          with:
+            skipLabels: 'Skip-Changelog'
   logger:
     name: Logger
     runs-on: macOS-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
     steps:
       - uses: dangoslen/changelog-enforcer@v3
           with:
-            skipLabels: 'Skip-Changelog'
-            missingUpdateErrorMessage: 'You have not updated CHANGELOG.md. If an entry is not applicable add the Skip-Changelog label to your PR. See the top of the CHANGELOG.md for more details.'
+            - skipLabels: 'Skip-Changelog'
+            - missingUpdateErrorMessage: 'You have not updated CHANGELOG.md. If an entry is not applicable add the Skip-Changelog label to your PR. See the top of the CHANGELOG.md for more details.'
   logger:
     name: Logger
     runs-on: macOS-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v3
           with:
             skipLabels: 'Skip-Changelog'
+            missingUpdateErrorMessage: 'You have not updated CHANGELOG.md. If an entry is not applicable add the Skip-Changelog label to your PR. See the top of the CHANGELOG.md for more details.'
   logger:
     name: Logger
     runs-on: macOS-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) significant technical or architectural changes that contributors will notice. If your Pull Request does not contain any changes of this nature i.e. minor string/translation changes, patch releases of dependencies, refactoring, etc. then add the `Skip-Changelog` label. 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 


### PR DESCRIPTION
This is a proposal to add a step to our CI to make sure the CHANGELOG has been updated. I have been updating the CHANGELOG just prior to release but since we are releasing more frequently now I think it makes more sense to do it at the PR level.

Not every PR needs a CHANGELOG update... we should write down somewhere what kinds of things belong in the CHANGELOG. You can ignore the check in these cases by adding the `Skip-Changelog` label to a PR. 