### PR TITLE
replace time ago in feed for messages with the poster's identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Replace timestamp / posted x days ago with posters identity in home feed. #660 
+
 ## [1.2.2] 2022-07-04
 
 - Add a basic search bar to the Discover tab that allows you to search for posts. #679

--- a/Source/Controller/ThreadViewController.swift
+++ b/Source/Controller/ThreadViewController.swift
@@ -96,7 +96,7 @@ class ThreadViewController: ContentViewController {
         return view
     }()
 
-    private let headerView = PostHeaderView()
+    private let headerView = PostHeaderView(showTimestamp: true)
     
     // this view manages it's own height constraints
     // checkout ImageGallery.open() and close()

--- a/Source/UI/PostCellView.swift
+++ b/Source/UI/PostCellView.swift
@@ -32,9 +32,10 @@ class PostCellView: KeyValueView {
     }
 
     var allowSpaceUnderGallery = true
+    var showTimestamp: Bool
 
     var keyValue: KeyValue?
-    private lazy var headerView = PostHeaderView()
+    private lazy var headerView = PostHeaderView(showTimestamp: showTimestamp)
 
     private lazy var textView: UITextView = {
         let view = UITextView.forAutoLayout()
@@ -171,7 +172,10 @@ class PostCellView: KeyValueView {
 
     // MARK: Lifecycle
 
-    init() {
+    /// Initializes the view with the given parameters.
+    /// - Parameter showTimestamp: Will show the claimed post time if true, author id if false.
+    init(showTimestamp: Bool = false) {
+        self.showTimestamp = showTimestamp
         super.init(frame: CGRect.zero)
         self.useAutoLayout()
         

--- a/Source/UI/PostHeaderView.swift
+++ b/Source/UI/PostHeaderView.swift
@@ -25,7 +25,7 @@ class PostHeaderView: UIView {
         button.addTarget(self, action: #selector(selectAboutIdentity), for: .touchUpInside)
         button.setTitleColor(UIColor.text.default, for: .normal)
         button.contentHorizontalAlignment = .left
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 30, weight: .semibold)
         button.titleLabel?.lineBreakMode = .byTruncatingTail
         button.titleLabel?.numberOfLines = 1
         button.isSkeletonable = true
@@ -35,6 +35,14 @@ class PostHeaderView: UIView {
     private var rightButtonContainer = UIView()
 
     private let dateLabel: UILabel = {
+        let label = UILabel.forAutoLayout()
+        label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
+        label.numberOfLines = 1
+        label.textColor = UIColor.text.detail
+        return label
+    }()
+    
+    private let identiferLabel: UILabel = {
         let label = UILabel.forAutoLayout()
         label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         label.numberOfLines = 1
@@ -62,13 +70,20 @@ class PostHeaderView: UIView {
         self.nameButton.constrainLeading(toTrailingOf: self.identityButton, constant: Layout.horizontalSpacing)
         self.nameButton.constrainTrailing(toLeadingOf: self.rightButtonContainer, constant: -6)
 
-        self.addSubview(self.dateLabel)
-        self.dateLabel.pinTop(toBottomOf: self.nameButton)
-        self.dateLabel.constrainLeading(to: self.nameButton)
-        self.dateLabel.constrainTrailing(toTrailingOf: self.nameButton)
+        //self.addSubview(self.dateLabel)
+        //self.dateLabel.pinTop(toBottomOf: self.nameButton)
+        //self.dateLabel.constrainLeading(to: self.nameButton)
+        //self.dateLabel.constrainTrailing(toTrailingOf: self.nameButton)
+        
+        //self.addSubview(self.identiferLabel)
+        //self.identiferLabel.pinTop(toBottomOf: self.nameButton)
+        //self.identiferLabel.constrainLeading(to: self.nameButton)
+        //self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton)
 
-        self.nameButton.constrainHeight(to: 19)
-        self.dateLabel.constrainHeight(to: 19)
+        self.nameButton.constrainHeight(to: Layout.profileThumbSize)
+        //self.dateLabel.constrainHeight(to: 19)
+        //self.identiferLabel.constrainHeight(to: 19)
+        
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -89,7 +104,8 @@ class PostHeaderView: UIView {
         self.nameButton.setTitle(name, for: .normal)
         self.identityButton.setImage(for: about)
 
-        self.dateLabel.text = keyValue.timestampString
+        //self.dateLabel.text = keyValue.timestampString
+        self.identiferLabel.text = keyValue.metadata.author.about?.identity
 
         if let me = Bots.current.identity {
             let button: UIButton

--- a/Source/UI/PostHeaderView.swift
+++ b/Source/UI/PostHeaderView.swift
@@ -25,7 +25,7 @@ class PostHeaderView: UIView {
         button.addTarget(self, action: #selector(selectAboutIdentity), for: .touchUpInside)
         button.setTitleColor(UIColor.text.default, for: .normal)
         button.contentHorizontalAlignment = .left
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 30, weight: .semibold)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
         button.titleLabel?.lineBreakMode = .byTruncatingTail
         button.titleLabel?.numberOfLines = 1
         button.isSkeletonable = true
@@ -75,14 +75,14 @@ class PostHeaderView: UIView {
         //self.dateLabel.constrainLeading(to: self.nameButton)
         //self.dateLabel.constrainTrailing(toTrailingOf: self.nameButton)
         
-        //self.addSubview(self.identiferLabel)
-        //self.identiferLabel.pinTop(toBottomOf: self.nameButton)
-        //self.identiferLabel.constrainLeading(to: self.nameButton)
-        //self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton)
+        self.addSubview(self.identiferLabel)
+        self.identiferLabel.pinTop(toBottomOf: self.nameButton)
+        self.identiferLabel.constrainLeading(to: self.nameButton)
+        self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton)
 
-        self.nameButton.constrainHeight(to: Layout.profileThumbSize)
+        self.nameButton.constrainHeight(to: 19)
         //self.dateLabel.constrainHeight(to: 19)
-        //self.identiferLabel.constrainHeight(to: 19)
+        self.identiferLabel.constrainHeight(to: 19)
         
     }
 

--- a/Source/UI/PostHeaderView.swift
+++ b/Source/UI/PostHeaderView.swift
@@ -54,8 +54,10 @@ class PostHeaderView: UIView {
         self.init()
         update(with: keyValue)
     }
-
-    init() {
+    
+    /// Initializes the view with the given parameters.
+    /// - Parameter showTimestamp: Will show the claimed post time if true, author id if false.
+    init(showTimestamp: Bool = false) {
         super.init(frame: CGRect.zero)
         self.useAutoLayout()
 
@@ -70,15 +72,17 @@ class PostHeaderView: UIView {
         self.nameButton.constrainLeading(toTrailingOf: self.identityButton, constant: Layout.horizontalSpacing)
         self.nameButton.constrainTrailing(toLeadingOf: self.rightButtonContainer, constant: -6)
 
-        //self.addSubview(self.dateLabel)
-        //self.dateLabel.pinTop(toBottomOf: self.nameButton)
-        //self.dateLabel.constrainLeading(to: self.nameButton)
-        //self.dateLabel.constrainTrailing(toTrailingOf: self.nameButton)
-        
-        self.addSubview(self.identiferLabel)
-        self.identiferLabel.pinTop(toBottomOf: self.nameButton)
-        self.identiferLabel.constrainLeading(to: self.nameButton)
-        self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton, constant: 8)
+        if showTimestamp {
+            self.addSubview(self.dateLabel)
+            self.dateLabel.pinTop(toBottomOf: self.nameButton)
+            self.dateLabel.constrainLeading(to: self.nameButton)
+            self.dateLabel.constrainTrailing(toTrailingOf: self.nameButton)
+        } else {
+            self.addSubview(self.identiferLabel)
+            self.identiferLabel.pinTop(toBottomOf: self.nameButton)
+            self.identiferLabel.constrainLeading(to: self.nameButton)
+            self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton, constant: 8)
+        }
         
         self.nameButton.constrainHeight(to: 19)
         //self.dateLabel.constrainHeight(to: 19)
@@ -103,10 +107,8 @@ class PostHeaderView: UIView {
         let name = about?.nameOrIdentity ?? keyValue.value.author
         self.nameButton.setTitle(name, for: .normal)
         self.identityButton.setImage(for: about)
-
-        //self.dateLabel.text = keyValue.timestampString
-        let shortcode = identity.prefix (8)
-        self.identiferLabel.text = String(shortcode) + "..."
+        self.dateLabel.text = keyValue.timestampString
+        self.identiferLabel.text = String(identity.prefix(7))
 
         if let me = Bots.current.identity {
             let button: UIButton

--- a/Source/UI/PostHeaderView.swift
+++ b/Source/UI/PostHeaderView.swift
@@ -42,12 +42,18 @@ class PostHeaderView: UIView {
         return label
     }()
     
-    private let identiferLabel: UILabel = {
+    private let identifierLabel: UILabel = {
         let label = UILabel.forAutoLayout()
         label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         label.numberOfLines = 1
         label.textColor = UIColor.text.detail
         return label
+    }()
+    
+    private let labelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        return stackView
     }()
 
     convenience init(with keyValue: KeyValue) {
@@ -67,27 +73,31 @@ class PostHeaderView: UIView {
         Layout.fillRight(of: self, with: self.rightButtonContainer, respectSafeArea: false)
         self.rightButtonContainer.widthAnchor.constraint(lessThanOrEqualToConstant: Layout.profileThumbSize).isActive = true
 
-        self.addSubview(self.nameButton)
-        self.nameButton.pinTopToSuperview()
-        self.nameButton.constrainLeading(toTrailingOf: self.identityButton, constant: Layout.horizontalSpacing)
-        self.nameButton.constrainTrailing(toLeadingOf: self.rightButtonContainer, constant: -6)
+        addSubview(labelStackView)
+        labelStackView.pinTopToSuperview()
+        labelStackView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        labelStackView.constrainHeight(to: identityButton)
+        labelStackView.constrainLeading(toTrailingOf: self.identityButton, constant: Layout.horizontalSpacing)
+        labelStackView.constrainTrailing(toLeadingOf: self.rightButtonContainer, constant: -6)
+        labelStackView.addArrangedSubview(nameButton)
+        
+        labelStackView.addArrangedSubview(self.nameButton)
 
         if showTimestamp {
-            self.addSubview(self.dateLabel)
+            labelStackView.addArrangedSubview(dateLabel)
             self.dateLabel.pinTop(toBottomOf: self.nameButton)
             self.dateLabel.constrainLeading(to: self.nameButton)
             self.dateLabel.constrainTrailing(toTrailingOf: self.nameButton)
         } else {
-            self.addSubview(self.identiferLabel)
-            self.identiferLabel.pinTop(toBottomOf: self.nameButton)
-            self.identiferLabel.constrainLeading(to: self.nameButton)
-            self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton, constant: 8)
+            labelStackView.addArrangedSubview(identifierLabel)
+            self.identifierLabel.pinTop(toBottomOf: self.nameButton)
+            self.identifierLabel.constrainLeading(to: self.nameButton)
+            self.identifierLabel.constrainTrailing(toTrailingOf: self.nameButton, constant: 8)
         }
         
         self.nameButton.constrainHeight(to: 19)
-        //self.dateLabel.constrainHeight(to: 19)
-        self.identiferLabel.constrainHeight(to: 19)
-        
+        self.dateLabel.constrainHeight(to: 19)
+        self.identifierLabel.constrainHeight(to: 19)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -104,11 +114,16 @@ class PostHeaderView: UIView {
         self.identity = identity
 
         let about = keyValue.metadata.author.about
-        let name = about?.nameOrIdentity ?? keyValue.value.author
+        let name = about?.name ?? keyValue.value.author
         self.nameButton.setTitle(name, for: .normal)
         self.identityButton.setImage(for: about)
         self.dateLabel.text = keyValue.timestampString
-        self.identiferLabel.text = String(identity.prefix(7))
+        if name != keyValue.value.author {
+            identifierLabel.text = String(identity.prefix(7))
+            identifierLabel.isHidden = false
+        } else {
+            identifierLabel.isHidden = true
+        }
 
         if let me = Bots.current.identity {
             let button: UIButton

--- a/Source/UI/PostHeaderView.swift
+++ b/Source/UI/PostHeaderView.swift
@@ -78,8 +78,8 @@ class PostHeaderView: UIView {
         self.addSubview(self.identiferLabel)
         self.identiferLabel.pinTop(toBottomOf: self.nameButton)
         self.identiferLabel.constrainLeading(to: self.nameButton)
-        self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton)
-
+        self.identiferLabel.constrainTrailing(toTrailingOf: self.nameButton, constant: 8)
+        
         self.nameButton.constrainHeight(to: 19)
         //self.dateLabel.constrainHeight(to: 19)
         self.identiferLabel.constrainHeight(to: 19)
@@ -105,7 +105,8 @@ class PostHeaderView: UIView {
         self.identityButton.setImage(for: about)
 
         //self.dateLabel.text = keyValue.timestampString
-        self.identiferLabel.text = keyValue.metadata.author.about?.identity
+        let shortcode = identity.prefix (8)
+        self.identiferLabel.text = String(shortcode) + "..."
 
         if let me = Bots.current.identity {
             let button: UIButton

--- a/Source/UI/ThreadReplyView.swift
+++ b/Source/UI/ThreadReplyView.swift
@@ -10,8 +10,8 @@ import UIKit
 
 class ThreadReplyView: PostCellView {
 
-    override init() {
-        super.init()
+    init() {
+        super.init(showTimestamp: true)
         self.truncationLimit = (over: 12, to: 8)
         Layout.addSeparator(toBottomOf: self)
     }


### PR DESCRIPTION
![Screen Shot 2022-07-08 at 10 09 16 AM](https://user-images.githubusercontent.com/76/177879911-1ef10815-32a1-4ce3-b30c-bdbdf5dc44fa.png)

Replaces the time ago for messages in the home feed with the identity of the poster. This might not be right, but it does show a bit more of the underlying structure of ssb which is good and also makes the app less immediacy focused. 

This PR Resolves ticket #660