### PR TITLE
Updating the info and layout of the contact view in the home feed

### DIFF
--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a80abf1f0f0bb6366518cf711bad4b8bc255eb601f6464a3d656296c043f5a76
+oid sha256:a1c952fd47569172411fcb20420c3a75def55189fc9fa817f6736ce6690aeb9e
 size 40840224

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e39102b32efcd79d791d4cd72a9863676fad65038804216d6173164aa793bd13
+oid sha256:d22fd416a7826b7d01d9ec82d8b5c8076aff4d14aa383bc17a3debc7d3d66fb4
 size 81084424

--- a/Shared/Extensions/UIView+Round.swift
+++ b/Shared/Extensions/UIView+Round.swift
@@ -10,6 +10,13 @@ import Foundation
 import UIKit
 
 extension UIView {
+    
+    func round(borderColor: UIColor, borderWidth: CGFloat) {
+        let radius = min(self.bounds.width, self.bounds.height) / 2
+        self.roundedCorners(radius: radius)
+        layer.borderColor = borderColor.cgColor
+        layer.borderWidth = borderWidth
+    }
 
     func round() {
         let radius = min(self.bounds.width, self.bounds.height) / 2

--- a/Source/Extension/UIFont+Verse.swift
+++ b/Source/Extension/UIFont+Verse.swift
@@ -31,8 +31,9 @@ struct VerseFonts {
     let pillButton = UIFont.systemFont(ofSize: 14, weight: .medium)
 
     let contactName = UIFont.systemFont(ofSize: 15, weight: .semibold)
-    let contactFollowerCount = UIFont.systemFont(ofSize: 10, weight: .regular)
-    let contactHashtags = UIFont.systemFont(ofSize: 10, weight: .regular)
+    let contactFollowerCount = UIFont.systemFont(ofSize: 14, weight: .regular)
+    let contactHashtags = UIFont.systemFont(ofSize: 14, weight: .regular)
+    let contactIdentity = UIFont.systemFont(ofSize: 14, weight: .regular)
 }
 
 struct PostFonts {

--- a/Source/Extension/UIFont+Verse.swift
+++ b/Source/Extension/UIFont+Verse.swift
@@ -30,7 +30,7 @@ struct VerseFonts {
 
     let pillButton = UIFont.systemFont(ofSize: 14, weight: .medium)
 
-    let contactName = UIFont.systemFont(ofSize: 15, weight: .semibold)
+    let contactName = UIFont.systemFont(ofSize: 17, weight: .semibold)
     let contactFollowerCount = UIFont.systemFont(ofSize: 14, weight: .regular)
     let contactHashtags = UIFont.systemFont(ofSize: 14, weight: .regular)
     let contactIdentity = UIFont.systemFont(ofSize: 14, weight: .regular)

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -64,6 +64,7 @@ enum Text: String, Localizable, CaseIterable {
     case emptyHomeFeedMessage = "And it is rather bare! Have you considered following a few users or topics?"
     case startedFollowing = "{{somebody}} started following"
     case stoppedFollowing = "{{somebody}} stopped following"
+    case followStats = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}"
     case showMeInDirectory = "Show me in the directory"
     case showMeInUserDirectory = "Show me in the user directory"
     case hideMeFromUserDirectory = "Hide me from the user directory"

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Zeige mich im Verzeichnis";
 "Text.showMeInUserDirectory" = "Zeige mich im Benutzerverzeichnis";
 "Text.hideMeFromUserDirectory" = "Verstecke mich im Benutzerverzeichnis";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -30,6 +30,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} empezó a seguir a";
 "Text.stoppedFollowing" = "{{somebody}} dejo de seguir a";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Mostrame en el directorio";
 "Text.showMeInUserDirectory" = "Mostrame en el directorio de usuarios";
 "Text.hideMeFromUserDirectory" = "Ocultame en el directorio de usuarios";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "Y está vacío! ¿Has considerado seguir unos cuántos usuarios o tópicos?";
 "Text.startedFollowing" = "{{somebody}} empezó a seguirte";
 "Text.stoppedFollowing" = "{{somebody}} dejó de seguirte";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Mostrarme en el directorio";
 "Text.showMeInUserDirectory" = "Mostrarme en el directorio de usuarios";
 "Text.hideMeFromUserDirectory" = "No mostrarme en el directorio de usuarios";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "¡Y está bastante vacío! ¿Y si seguís algunos usuarios o temas?";
 "Text.startedFollowing" = "{{somebody}} empezó a seguir a";
 "Text.stoppedFollowing" = "{{somebody}} dejo de seguir a";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Mostrame en el directorio";
 "Text.showMeInUserDirectory" = "Mostrame en el directorio de usuarios";
 "Text.hideMeFromUserDirectory" = "Ocultame en el directorio de usuarios";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} empezó a seguir a";
 "Text.stoppedFollowing" = "{{somebody}} dejo de seguir a";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Mostrarme en el directorio";
 "Text.showMeInUserDirectory" = "Mostrarme en el directorio de usuarios";
 "Text.hideMeFromUserDirectory" = "No mostrarme en el directorio de usuarios";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Pokaż mnie w katalogu";
 "Text.showMeInUserDirectory" = "Pokaż mnie w katalogu użytkowników";
 "Text.hideMeFromUserDirectory" = "Nie pokazuj mnie w katalogu użytkowników";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Pokaż mnie w katalogu";
 "Text.showMeInUserDirectory" = "Pokaż mnie w katalogu użytkowników";
 "Text.hideMeFromUserDirectory" = "Nie pokazuj mnie w katalogu użytkowników";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?\n\nYou can find them on the Network tab.";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "在用户目录中显示";
 "Text.showMeInUserDirectory" = "在用户目录中显示";
 "Text.hideMeFromUserDirectory" = "在用户目录中显示";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -31,6 +31,7 @@
 "Text.emptyHomeFeedMessage" = "And it is rather bare! Have you considered following a few users or topics?";
 "Text.startedFollowing" = "{{somebody}} started following";
 "Text.stoppedFollowing" = "{{somebody}} stopped following";
+"Text.followStats" = "Following {{numberOfFollows}} • Followed by {{numberOfFollowers}}";
 "Text.showMeInDirectory" = "Show me in the directory";
 "Text.showMeInUserDirectory" = "Show me in the user directory";
 "Text.hideMeFromUserDirectory" = "Hide me from the user directory";

--- a/Source/UI/AvatarImageView.swift
+++ b/Source/UI/AvatarImageView.swift
@@ -21,15 +21,25 @@ class AvatarImageView: ImageView {
             super.image = newValue ?? UIImage.verse.missingAbout
         }
     }
+    
+    var borderColor: UIColor?
+    var borderWidth: CGFloat?
 
-    convenience init() {
+    convenience init(borderColor: UIColor? = nil, borderWidth: CGFloat? = nil) {
         self.init(image: UIImage.verse.missingAbout)
         self.contentMode = .scaleAspectFill
+        self.borderColor = borderColor
+        self.borderWidth = borderWidth
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        self.round()
+        
+        if let color = borderColor, let width = borderWidth {
+            round(borderColor: color, borderWidth: width)
+        } else {
+            round()
+        }
     }
 
     // This is totally "just get it done" code.  Ideally there would be an

--- a/Source/UI/ContactCellView.swift
+++ b/Source/UI/ContactCellView.swift
@@ -14,7 +14,7 @@ import Logger
 
 class ContactCellView: KeyValueView {
 
-    let verticalSpace: CGFloat = 5
+    let verticalSpace: CGFloat = Layout.verticalSpacing
 
     var displayHeader = true {
         didSet {
@@ -64,7 +64,7 @@ class ContactCellView: KeyValueView {
         )
         self.textViewTopConstraint = topConstraint
 
-        self.contactView.pinBottomToSuperviewBottom()
+        contactView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
 
         isSkeletonable = true
     }

--- a/Source/UI/ContactHeaderView.swift
+++ b/Source/UI/ContactHeaderView.swift
@@ -83,15 +83,19 @@ class ContactHeaderView: UIView {
     private func update(with identity: Identity, about: About?) {
         let name = about?.nameOrIdentity ?? identity
         let string = Text.startedFollowing.text(["somebody": name])
-        let primaryColor = [NSAttributedString.Key.foregroundColor: UIColor.text.default]
-        let secondaryColor = [NSAttributedString.Key.foregroundColor: UIColor.text.detail]
-        let secondaryBold = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .regular)]
-        let attributedString = NSMutableAttributedString(string: string, attributes: secondaryColor)
+        let primaryAttributes = [
+            NSAttributedString.Key.foregroundColor: UIColor.text.default,
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .semibold)
+        ]
+        let secondaryAttributes = [
+            NSAttributedString.Key.foregroundColor: UIColor.text.detail,
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .regular)
+        ]
+        let attributedString = NSMutableAttributedString(string: string, attributes: secondaryAttributes)
         // swiftlint:disable legacy_objc_type
         let range = (string as NSString).range(of: name)
         // swiftlint:enable legacy_objc_type
-        attributedString.addAttributes(primaryColor, range: range)
-        attributedString.addAttributes(secondaryBold, range: range)
+        attributedString.addAttributes(primaryAttributes, range: range)
         
         self.nameButton.setAttributedTitle(attributedString, for: .normal)
         if let about = about {

--- a/Source/UI/ContactHeaderView.swift
+++ b/Source/UI/ContactHeaderView.swift
@@ -49,8 +49,8 @@ class ContactHeaderView: UIView {
 
         self.addSubview(self.nameButton)
         self.nameButton.pinTopToSuperview()
-        self.nameButton.constrainLeading(toTrailingOf: self.identityButton, constant: Layout.horizontalSpacing)
-        self.nameButton.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor).isActive = true
+        self.nameButton.constrainLeading(toTrailingOf: self.identityButton, constant: 10)
+        self.nameButton.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
 
         self.nameButton.constrainHeight(to: 19)
 

--- a/Source/UI/ContactHeaderView.swift
+++ b/Source/UI/ContactHeaderView.swift
@@ -85,12 +85,14 @@ class ContactHeaderView: UIView {
         let string = Text.startedFollowing.text(["somebody": name])
         let primaryColor = [NSAttributedString.Key.foregroundColor: UIColor.text.default]
         let secondaryColor = [NSAttributedString.Key.foregroundColor: UIColor.text.detail]
+        let secondaryBold = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .regular)]
         let attributedString = NSMutableAttributedString(string: string, attributes: secondaryColor)
         // swiftlint:disable legacy_objc_type
         let range = (string as NSString).range(of: name)
         // swiftlint:enable legacy_objc_type
         attributedString.addAttributes(primaryColor, range: range)
-
+        attributedString.addAttributes(secondaryBold, range: range)
+        
         self.nameButton.setAttributedTitle(attributedString, for: .normal)
         if let about = about {
             self.identityButton.setImage(for: about)

--- a/Source/UI/ContactView.swift
+++ b/Source/UI/ContactView.swift
@@ -69,7 +69,7 @@ class ContactView: KeyValueView {
         let stackView = UIStackView.forAutoLayout()
         stackView.axis = .vertical
         stackView.alignment = .leading
-        stackView.spacing = 10
+        stackView.spacing = 8
         stackView.isSkeletonable = true
         return stackView
     }()
@@ -78,9 +78,15 @@ class ContactView: KeyValueView {
         let stackView = UIStackView.forAutoLayout()
         stackView.axis = .vertical
         stackView.alignment = .leading
-        stackView.spacing = 6
+        stackView.spacing = 5
         stackView.isSkeletonable = true
         return stackView
+    }()
+    
+    let followButtonContainer: UIView = {
+        let view = UIView()
+        view.isSkeletonable = true
+        return view
     }()
 
     let followButton: FollowButton = {
@@ -92,29 +98,28 @@ class ContactView: KeyValueView {
     init() {
         super.init(frame: CGRect.zero)
         self.useAutoLayout()
-        self.backgroundColor = .cardBackground
+        self.backgroundColor = .clear
+        
+        addSubview(labelStackView)
 
-        let targetHeight: CGFloat = 120
-        let verticalMargin = floor((targetHeight - Layout.contactAvatarSize) / 2)
-
-        Layout.fillLeft(
+        Layout.fillTopLeft(
             of: self,
             with: self.imageView,
-            insets: UIEdgeInsets(top: verticalMargin, left: 0, bottom: -verticalMargin, right: 0),
             respectSafeArea: false
         )
         
         nameAndIdentityStackView.addArrangedSubview(nameLabel)
         nameAndIdentityStackView.addArrangedSubview(contactIdentity)
 
-        addSubview(labelStackView)
         labelStackView.constrainLeading(toTrailingOf: imageView, constant: Layout.horizontalSpacing)
         labelStackView.constrainTrailingToSuperview()
-        labelStackView.centerYAnchor.constraint(equalTo: imageView.centerYAnchor).isActive = true
+        labelStackView.pinTopToSuperview()
+        labelStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Layout.verticalSpacing).isActive = true
         labelStackView.addArrangedSubview(nameAndIdentityStackView)
         labelStackView.addArrangedSubview(followerCountLabel)
         labelStackView.addArrangedSubview(hashtagsLabel)
-        labelStackView.addArrangedSubview(followButton)
+        Layout.fill(view: followButtonContainer, with: followButton, insets: UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 2), respectSafeArea: false)
+        labelStackView.addArrangedSubview(followButtonContainer)
 
         hashtagsLabel.delegate = self
 

--- a/Source/UI/ContactView.swift
+++ b/Source/UI/ContactView.swift
@@ -29,6 +29,17 @@ class ContactView: KeyValueView {
         label.isSkeletonable = true
         return label
     }()
+    
+    let contactIdentity: UILabel = {
+        let label = UILabel.forAutoLayout()
+        label.lineBreakMode = .byCharWrapping
+        label.numberOfLines = 1
+        label.font = UIFont.verse.contactIdentity
+        label.lineBreakMode = .byTruncatingTail
+        label.linesCornerRadius = 7
+        label.isSkeletonable = true
+        return label
+    }()
 
     let followerCountLabel: UILabel = {
         let label = UILabel.forAutoLayout()
@@ -90,9 +101,10 @@ class ContactView: KeyValueView {
         stackView.constrainTrailingToSuperview()
         stackView.centerYAnchor.constraint(equalTo: imageView.centerYAnchor).isActive = true
         stackView.addArrangedSubview(label)
+        stackView.addArrangedSubview(contactIdentity)
         stackView.addArrangedSubview(followerCountLabel)
-        stackView.addArrangedSubview(followButton)
         stackView.addArrangedSubview(hashtagsLabel)
+        stackView.addArrangedSubview(followButton)
 
         hashtagsLabel.delegate = self
 
@@ -113,6 +125,7 @@ class ContactView: KeyValueView {
         update(socialStats: SocialStats(numberOfFollowers: 0, numberOfFollows: 0))
         label.text = "placeholder name"
         hashtagsLabel.text = "placeholder #hashtag #hashtag #hashtag"
+        contactIdentity.text = "@abc123abc123"
         hashtagsLabel.layer.cornerRadius = 7 // hack because SkeletonView won't round the corners for some reason
         stackView.arrangedSubviews.forEach { $0.isHidden = false }
         showAnimatedSkeleton()
@@ -122,7 +135,9 @@ class ContactView: KeyValueView {
         if let about = about {
             self.label.text = about.nameOrIdentity
             self.imageView.set(image: about.image)
+            self.contactIdentity.text = String(about.identity.prefix(18)) + "..."
             label.hideSkeleton()
+            contactIdentity.hideSkeleton()
             imageView.hideSkeleton()
         } else {
             self.label.text = identity
@@ -179,7 +194,7 @@ class ContactView: KeyValueView {
             hashtagsLabel.isHidden = true
         } else {
             hashtagsLabel.isHidden = false
-            let string = "Active on "
+            let string = ""
             let secondaryColor = [
                 NSAttributedString.Key.foregroundColor: UIColor.text.detail,
                 NSAttributedString.Key.font: UIFont.verse.contactFollowerCount

--- a/Source/UI/KeyValue/KeyValueTableViewCell.swift
+++ b/Source/UI/KeyValue/KeyValueTableViewCell.swift
@@ -20,6 +20,7 @@ class KeyValueTableViewCell: UITableViewCell, KeyValueUpdateable {
         super.init(style: .default, reuseIdentifier: type.reuseIdentifier)
         self.constrainKeyValueViewToContentView(height)
         self.selectionStyle = .none
+        backgroundColor = .clear
         self.keyValueView.showAnimatedSkeleton()
     }
 


### PR DESCRIPTION
@Chardot asked for a few updates to the follow layout. 

Making the spacing between lines 10px instead of the current 5px.
![image](https://user-images.githubusercontent.com/76/177903941-2f82a3ee-ff04-4273-9dd8-a3f5ecdfc83e.png)

* Add the truncated identifier below the user name, size 14, separated 6pt from the username
* Add a 2pt border around the user's avatar, in the primary color (the same used for the Follow button)
* Make the Follow button be the same size as the Follow button on the directory.
* Remove the words "Active on" and leave only the hashtags

![image](https://user-images.githubusercontent.com/76/177904051-2e23af75-1330-4586-9272-9e158519ffed.png)

This PR adds the identifier, and removes the active on text. But doesn't fix the size of the follow button or adds the 2pt border around the avatar. 

![image](https://user-images.githubusercontent.com/76/177903835-7d188939-93ac-44f0-8c88-b41dbc7e11bf.png)

The primary feedback this PR needs is somehow "Rabble started following" gets borked because it only finds the identity of rabble and not the name. It's very odd because i didn't think i changed that. HALP!