### PR TITLE
Filter the hashtag character out of the hashtag search box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added queer.family pub #726
 - Max-Rai contributed a fix to the onboarding layout for smaller iOS screen sizes #703 (thanks @Max-Rai!)
 - Show the number of unread notifications in the application badge
+- Fixed an issue where searching for hashtags wouldn't work if you included the hashtag character in your query. #736
 
 ## [1.2.3] 2022-07-11
 

--- a/Source/Controller/ChannelsViewController.swift
+++ b/Source/Controller/ChannelsViewController.swift
@@ -152,9 +152,9 @@ class ChannelsViewController: ContentViewController {
         if self.searchFilter.isEmpty {
             self.channels = allChannels
         } else {
-            let filter = searchFilter.lowercased()
+            let filter = searchFilter.replacingOccurrences(of: "#", with: "").lowercased()
             channels = allChannels.filter { channel in
-                return channel.name.lowercased().contains(filter)
+                channel.name.lowercased().contains(filter)
             }
         }
     }


### PR DESCRIPTION
This is a 5 minute tweak I made because I put a whole hashtag into the hashtags search box and it didn't work.