### PR TITLE
Add git lfs fsck CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,5 +98,9 @@ jobs:
     name: Verify LFS files
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@main
+      with:
+        lfs: true
     - name: Run gif lfs fsck
       run: git lfs fsck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,3 +94,9 @@ jobs:
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -workspace Planetary.xcworkspace -scheme Support -destination "$SIMULATOR" | xcpretty
     - name: Run iOS tests
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -workspace Planetary.xcworkspace -scheme Support -destination "$SIMULATOR" | xcpretty
+  lfs-fsck:
+    name: Verify LFS files
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run gif lfs fsck
+      run: git lfs fsck


### PR DESCRIPTION
I had an issue yesterday where git got into an inconsistent state and it was a pain to deal with. My understanding is that this happened because someone without `git lfs` installed committed to a file tracked by `git lfs`. This adds a simple CI job that should fail if it happens again.