### PR TITLE
Optimize read notification queries

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		23CA4B93232291E1005B35E8 /* UITextView+NSMutableAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539FD4B022C19F66005A4DF2 /* UITextView+NSMutableAttributedString.swift */; };
 		23CF345722099E5D00F46A54 /* InvalidVoteMissingIdentifier.json in Resources */ = {isa = PBXBuildFile; fileRef = 23CF345622099E5D00F46A54 /* InvalidVoteMissingIdentifier.json */; };
 		23D8CE272253DB29001EB7D5 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D8CE262253DB29001EB7D5 /* Address.swift */; };
-		23D8E2C022033D31004776EA /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		23D8E2C022033D31004776EA /* (null) in Resources */ = {isa = PBXBuildFile; };
 		23E76A5623F2F0F70074F424 /* ValueTimestamp.json in Resources */ = {isa = PBXBuildFile; fileRef = 23E76A5523F2F0F70074F424 /* ValueTimestamp.json */; };
 		23E8805E22F894650074D399 /* Collection+RandomSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E8805D22F894650074D399 /* Collection+RandomSample.swift */; };
 		23E8805F22F894650074D399 /* Collection+RandomSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E8805D22F894650074D399 /* Collection+RandomSample.swift */; };
@@ -262,7 +262,7 @@
 		530F01B222DFCEED007EBAE2 /* String+IsValid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B122DFCEED007EBAE2 /* String+IsValid.swift */; };
 		530F01B422E0D3E7007EBAE2 /* TitledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B322E0D3E7007EBAE2 /* TitledToggle.swift */; };
 		530F01B622E0D930007EBAE2 /* JoinOnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B522E0D930007EBAE2 /* JoinOnboardingStep.swift */; };
-		5314EF3A22EA276A0065D02A /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		5314EF3A22EA276A0065D02A /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		5314EF3B22EA27840065D02A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62A22445BE900C57A4B /* AppConfiguration.swift */; };
 		5314EF3C22EA27920065D02A /* SSBNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F692209108F007264CB /* SSBNetwork.swift */; };
 		5314EF3D22EA27980065D02A /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01F32204F66200DFDF16 /* Secret.swift */; };
@@ -620,6 +620,8 @@
 		5B92E27E284A7B2D003127F2 /* HashtagListStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B92E279284A7A8F003127F2 /* HashtagListStrategy.swift */; };
 		5B92E27F284A7B2F003127F2 /* PopularHashtagsAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B92E27B284A7B12003127F2 /* PopularHashtagsAlgorithm.swift */; };
 		5B92E280284A7B30003127F2 /* PopularHashtagsAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B92E27B284A7B12003127F2 /* PopularHashtagsAlgorithm.swift */; };
+		5B9C69562888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */; };
+		5B9C69572888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */; };
 		5BAA0BB427DF9CE200C7BE63 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 5BAA0BB327DF9CE200C7BE63 /* CrashReporting */; };
 		5BAA0BB627DF9CEC00C7BE63 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 5BAA0BB527DF9CEC00C7BE63 /* CrashReporting */; };
 		5BAE9C82281E0E51008AEA84 /* JoinPlanetarySystemOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAE9C81281E0E51008AEA84 /* JoinPlanetarySystemOperation.swift */; };
@@ -682,9 +684,9 @@
 		8F6DDE5DB47CDEED56B74CB3 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EA32E74C0DFF1EF8924773F /* Pods_UnitTests.framework */; };
 		C90EBE7327E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
 		C90EBE7427E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
-		C9134DDB28184AF700595D49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C9134DDB28184AF700595D49 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C9134DE228184C2700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE128184C2700595D49 /* Support */; };
-		C9134DE328184D4200595D49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C9134DE328184D4200595D49 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C9134DE6281854E700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE5281854E700595D49 /* Support */; };
 		C924412F278DDECE00592E5E /* Preload.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A41F56C2488078F005BB1DE /* Preload.bundle */; };
 		C928DAF227B5AC850007C5FC /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = C928DAF127B5AC850007C5FC /* Logger */; };
@@ -884,7 +886,7 @@
 		C9724BB42809EC4F000EBCCD /* DebugOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531587B1229F33F00004E2B1 /* DebugOnboardingViewController.swift */; };
 		C9724BB52809EC57000EBCCD /* DebugUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533F4050225E9E010060B4B9 /* DebugUIViewController.swift */; };
 		C9724BB62809EC61000EBCCD /* DebugPostsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531EC40B230F6B9E001A25AD /* DebugPostsViewController.swift */; };
-		C9724BB72809EC68000EBCCD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C9724BB72809EC68000EBCCD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C9724BB82809EC77000EBCCD /* SecretViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FCAFDD22051C88009E9E82 /* SecretViewController.swift */; };
 		C9724BB92809EC7B000EBCCD /* BotViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62622444A1500C57A4B /* BotViewController.swift */; };
 		C9724BBA2809ECA2000EBCCD /* StatisticsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5DB7CB24AC01D9008DCB81 /* StatisticsOperation.swift */; };
@@ -1536,6 +1538,7 @@
 		5B92E2762849583C003127F2 /* HashtagListStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagListStrategyTests.swift; sourceTree = "<group>"; };
 		5B92E279284A7A8F003127F2 /* HashtagListStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagListStrategy.swift; sourceTree = "<group>"; };
 		5B92E27B284A7B12003127F2 /* PopularHashtagsAlgorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularHashtagsAlgorithm.swift; sourceTree = "<group>"; };
+		5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountUnreadNotificationsOperation.swift; sourceTree = "<group>"; };
 		5BAE9C81281E0E51008AEA84 /* JoinPlanetarySystemOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinPlanetarySystemOperation.swift; sourceTree = "<group>"; };
 		5BAE9C85281E0EA9008AEA84 /* Support+GoBot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Support+GoBot.swift"; sourceTree = "<group>"; };
 		5BAE9C8B281F5226008AEA84 /* ContactCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCellView.swift; sourceTree = "<group>"; };
@@ -1736,7 +1739,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BC2974C2804B9DE00C0CD81 /* SQLite in Frameworks */,
-				5314EF3A22EA276A0065D02A /* BuildFile in Frameworks */,
+				5314EF3A22EA276A0065D02A /* (null) in Frameworks */,
 				664DA6493E3CC0506BD71355 /* Pods_APITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1795,6 +1798,7 @@
 				0AAF8C4625C704B500FD8D0F /* UnfollowOperation.swift */,
 				5B67FFDC2863B4F40028ABE4 /* NumberOfRecentItemsOperation.swift */,
 				5B0A4656286E0CA60050D6AC /* NumberOfReportsOperation.swift */,
+				5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -3323,7 +3327,7 @@
 			mainGroup = 5344D82221C4649700704A34;
 			packageReferences = (
 				C969F434282C79CC00FF6FE3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
-				5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */,
+				5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */,
 				5B5BB8DB283E8BFC00D99AB8 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 			);
 			productRefGroup = 5344D82C21C4649700704A34 /* Products */;
@@ -3414,7 +3418,7 @@
 				5316E95B21FFD4980053832E /* InvalidChannel.json in Resources */,
 				C924412F278DDECE00592E5E /* Preload.bundle in Resources */,
 				5316E95721FFCDFF0053832E /* UnsupportedType.json in Resources */,
-				23D8E2C022033D31004776EA /* BuildFile in Resources */,
+				23D8E2C022033D31004776EA /* (null) in Resources */,
 				5316E95921FFD19F0053832E /* Invalid.json in Resources */,
 				C9F0B6A027E2728800BE2F0E /* Generated.strings in Resources */,
 				C98A014B2790C5A900E29A97 /* Feed_big.sqlite in Resources */,
@@ -3618,7 +3622,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist",
+				$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3994,7 +3998,7 @@
 				C9724B642809D6DC000EBCCD /* NotificationCellView.swift in Sources */,
 				C9724BBE2809ECCC000EBCCD /* UITextView+Verse.swift in Sources */,
 				53E29CE022D80424008A2CB1 /* Hashtag+String.swift in Sources */,
-				C9724BB72809EC68000EBCCD /* BuildFile in Sources */,
+				C9724BB72809EC68000EBCCD /* (null) in Sources */,
 				0A64A84024735520009A5EBF /* NullPushAPI.swift in Sources */,
 				23EF5AAA249D177F00469977 /* BanListAPI.swift in Sources */,
 				53E26C5E23045D34009240B2 /* Data+Person.swift in Sources */,
@@ -4010,7 +4014,7 @@
 				C9724B182809D350000EBCCD /* AppController+Progress.swift in Sources */,
 				53B4F5FA22B8602F00027C6A /* Mention+NSAttributedString.swift in Sources */,
 				0A64A84824735717009A5EBF /* PhoneVerificationAPIService.swift in Sources */,
-				C9134DE328184D4200595D49 /* BuildFile in Sources */,
+				C9134DE328184D4200595D49 /* (null) in Sources */,
 				C9724BE72809EEA4000EBCCD /* SimplePublishView.swift in Sources */,
 				C9724B432809D4F1000EBCCD /* UIButton+Text.swift in Sources */,
 				535754F722692B59002A6989 /* BotError.swift in Sources */,
@@ -4035,7 +4039,7 @@
 				53631EF623A9A93F009C6999 /* Blob+String.swift in Sources */,
 				C9724BC42809ED5B000EBCCD /* Blob+UIColor.swift in Sources */,
 				C9724B782809E7C1000EBCCD /* AppController+Push.swift in Sources */,
-				C9134DDB28184AF700595D49 /* BuildFile in Sources */,
+				C9134DDB28184AF700595D49 /* (null) in Sources */,
 				C9724B262809D426000EBCCD /* HomeViewController.swift in Sources */,
 				C9724BE02809EE5A000EBCCD /* Tappable.swift in Sources */,
 				C9F1C84927C92842005A3228 /* Localizable.swift in Sources */,
@@ -4121,6 +4125,7 @@
 				53E29CCE22D2974B008A2CB1 /* String+HashtagSubstrings.swift in Sources */,
 				C9724BE52809EE96000EBCCD /* FollowingTableViewController.swift in Sources */,
 				C9724BC72809ED6F000EBCCD /* AppDelegate.swift in Sources */,
+				5B9C69572888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */,
 				C9724B4A2809D563000EBCCD /* Notification+Keyboard.swift in Sources */,
 				C9724B4C2809D57E000EBCCD /* ImagePicker.swift in Sources */,
 				0ACE91A4243D741300EFB4E9 /* GoBotError.swift in Sources */,
@@ -4581,6 +4586,7 @@
 				53E26C6D23062CD3009240B2 /* Layout+FillSuperview.swift in Sources */,
 				531B92B722CD0E65005D5255 /* MentionTextViewDelegate.swift in Sources */,
 				530F019622DE87CD007EBAE2 /* PhotoOnboardingStep.swift in Sources */,
+				5B9C69562888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */,
 				53AD3FD7226FC4B8005228F9 /* UITableView+Verse.swift in Sources */,
 				53AD3FDD22712CE0005228F9 /* KeyValueTableViewDelegate.swift in Sources */,
 				536255DE23AC4C46001007D0 /* UIViewController+Sync.swift in Sources */,
@@ -5583,7 +5589,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */ = {
+		5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stephencelis/SQLite.swift";
 			requirement = {
@@ -5634,17 +5640,17 @@
 		};
 		5BC2974528048AD800C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
 			productName = SQLite;
 		};
 		5BC297492804B98C00C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
 			productName = SQLite;
 		};
 		5BC2974B2804B9DE00C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
 			productName = SQLite;
 		};
 		5BE28DFC27CD7BA1004D7D27 /* Analytics */ = {

--- a/Source/App/AppDelegate+Push.swift
+++ b/Source/App/AppDelegate+Push.swift
@@ -205,14 +205,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     private func updateApplicationBadgeNumber() {
-        Task {
-            do {
-                let count = try await Bots.current.numberOfUnreadReports()
-                UIApplication.shared.applicationIconBadgeNumber = count
-                AppController.shared.mainViewController?.setNotificationsTabBarIcon()
-            } catch {
-                Log.optional(error)
-            }
-        }
+        let operation = CountUnreadNotificationsOperation()
+        AppController.shared.operationQueue.addOperation(operation)
     }
 }

--- a/Source/Bot/Operations/CountUnreadNotificationsOperation.swift
+++ b/Source/Bot/Operations/CountUnreadNotificationsOperation.swift
@@ -1,0 +1,35 @@
+//
+//  CountUnreadNotificationsOperation.swift
+//  Planetary
+//
+//  Created by Martin Dutra on 20/7/22.
+//  Copyright © 2022 Verse Communications Inc. All rights reserved.
+//
+
+import CrashReporting
+import Foundation
+import Logger
+import UIKit
+
+/// Counts the number unread notifications and sets the application badge
+class CountUnreadNotificationsOperation: AsynchronousOperation {
+
+    override func main() {
+        Log.info("CountUnreadNotificationsOperation started.")
+        let queue = OperationQueue.current?.underlyingQueue ?? DispatchQueue.global(qos: .background)
+        Bots.current.numberOfUnreadReports(queue: queue) { [weak self] result in
+            switch result {
+            case .success(let count):
+                DispatchQueue.main.async {
+                    UIApplication.shared.applicationIconBadgeNumber = count
+                    AppController.shared.mainViewController?.setNotificationsTabBarIcon()
+                }
+            case .failure(let error):
+                Log.optional(error)
+                CrashReporting.shared.reportIfNeeded(error: error)
+            }
+            self?.finish()
+            Log.info("CountUnreadNotificationsOperation finished.")
+        }
+    }
+}

--- a/Source/Controller/NotificationsViewController.swift
+++ b/Source/Controller/NotificationsViewController.swift
@@ -159,9 +159,9 @@ class NotificationsViewController: ContentViewController {
         let currentReports = self.dataSource.reports
         let reportAtTop = currentReports.first
         if let report = reportAtTop {
+            lastTimeNewReportsUpdatesWasChecked = Date()
             let operation = NumberOfReportsOperation(lastReport: report)
             operation.completionBlock = { [weak self] in
-                self?.lastTimeNewReportsUpdatesWasChecked = Date()
                 let numberOfNewReports = operation.numberOfReports
                 if numberOfNewReports > 0 {
                     DispatchQueue.main.async { [weak self] in

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -1398,15 +1398,14 @@ class GoBot: Bot {
         userInitiatedQueue.async {
             do {
                 let isRead = try self.database.isReportRead(for: message)
-                guard !isRead else {
-                    return
-                }
                 try self.database.markMessageAsRead(identifier: message, isRead: true)
-                NotificationCenter.default.post(
-                    name: .didUpdateReportReadStatus,
-                    object: nil,
-                    userInfo: nil
-                )
+                if let isRead = isRead, !isRead {
+                    NotificationCenter.default.post(
+                        name: .didUpdateReportReadStatus,
+                        object: nil,
+                        userInfo: nil
+                    )
+                }
             } catch {
                 Log.optional(error)
             }

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -1397,13 +1397,13 @@ class GoBot: Bot {
     func markMessageAsRead(_ message: MessageIdentifier) {
         userInitiatedQueue.async {
             do {
-                let report = try self.database.report(for: message)
+                let isRead = try self.database.isReportRead(for: message)
                 try self.database.markMessageAsRead(identifier: message, isRead: true)
-                if let report = report, report.isUnread {
+                if !isRead {
                     NotificationCenter.default.post(
                         name: .didUpdateReportReadStatus,
                         object: nil,
-                        userInfo: ["report": report]
+                        userInfo: nil
                     )
                 }
             } catch {

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -1397,9 +1397,10 @@ class GoBot: Bot {
     func markMessageAsRead(_ message: MessageIdentifier) {
         userInitiatedQueue.async {
             do {
-                let isRead = try self.database.isReportRead(for: message)
+                let wasAlreadRead = try self.database.isMessageForReportRead(for: message)
                 try self.database.markMessageAsRead(identifier: message, isRead: true)
-                if let isRead = isRead, !isRead {
+                let shouldPostReadReportNotification = wasAlreadRead == false
+                if shouldPostReadReportNotification {
                     NotificationCenter.default.post(
                         name: .didUpdateReportReadStatus,
                         object: nil,

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -1398,14 +1398,15 @@ class GoBot: Bot {
         userInitiatedQueue.async {
             do {
                 let isRead = try self.database.isReportRead(for: message)
-                try self.database.markMessageAsRead(identifier: message, isRead: true)
-                if !isRead {
-                    NotificationCenter.default.post(
-                        name: .didUpdateReportReadStatus,
-                        object: nil,
-                        userInfo: nil
-                    )
+                guard !isRead else {
+                    return
                 }
+                try self.database.markMessageAsRead(identifier: message, isRead: true)
+                NotificationCenter.default.post(
+                    name: .didUpdateReportReadStatus,
+                    object: nil,
+                    userInfo: nil
+                )
             } catch {
                 Log.optional(error)
             }

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1459,19 +1459,19 @@ class ViewDatabase {
         }
         let queryString = """
         SELECT
-          read_messages.is_read AS is_read
+            read_messages.is_read AS is_read
         FROM
-          reports
-          INNER JOIN messagekeys ON (messagekeys.id = reports.msg_ref)
-          LEFT OUTER JOIN read_messages ON (
-            (read_messages.msg_id = messagekeys.id)
-            AND (read_messages.author_id = reports.author_id)
-          )
+            reports
+            INNER JOIN messagekeys ON (messagekeys.id = reports.msg_ref)
+            LEFT OUTER JOIN read_messages ON (
+                (read_messages.msg_id = messagekeys.id)
+                AND (read_messages.author_id = reports.author_id)
+            )
         WHERE
-          reports.author_id = ?
-          AND messagekeys.key = ?
+            reports.author_id = ?
+            AND messagekeys.key = ?
         LIMIT
-          1
+            1
         """
         guard let row = try connection.prepare(queryString, currentUserID, message).prepareRowIterator().next() else {
             return nil

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1452,7 +1452,7 @@ class ViewDatabase {
     /// - parameter message: The message associated to the wanted report
     ///
     /// It returns true/false either if it was read or not, nil if the message doesn't exist or a report for the
-    /// message doesn't exiss.
+    /// message doesn't exist.
     func isReportRead(for message: MessageIdentifier) throws -> Bool? {
         guard let connection = self.openDB else {
             throw ViewDatabaseError.notOpen

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1453,7 +1453,7 @@ class ViewDatabase {
     ///
     /// It returns true/false either if it was read or not, nil if the message doesn't exist or a report for the
     /// message doesn't exist.
-    func isReportRead(for message: MessageIdentifier) throws -> Bool? {
+    func isMessageForReportRead(for message: MessageIdentifier) throws -> Bool? {
         guard let connection = self.openDB else {
             throw ViewDatabaseError.notOpen
         }

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1451,9 +1451,9 @@ class ViewDatabase {
     /// Returns a boolean indicating if the report was already read by the user.
     /// - parameter message: The message associated to the wanted report
     ///
-    /// It returns false either if it was not read, the message doesn't exist, a report for the message doesn't exist
-    /// or the report is in fact marked as not read.
-    func isReportRead(for message: MessageIdentifier) throws -> Bool {
+    /// It returns true/false either if it was read or not, nil if the message doesn't exist or a report for the
+    /// message doesn't exiss.
+    func isReportRead(for message: MessageIdentifier) throws -> Bool? {
         guard let connection = self.openDB else {
             throw ViewDatabaseError.notOpen
         }
@@ -1473,9 +1473,8 @@ class ViewDatabase {
         LIMIT
           1
         """
-
         guard let row = try connection.prepare(queryString, currentUserID, message).prepareRowIterator().next() else {
-            return false
+            return nil
         }
         let isRead = try? row.get(Expression<Bool?>("is_read"))
         return isRead ?? false
@@ -1705,7 +1704,7 @@ class ViewDatabase {
         (SELECT id FROM messagekeys WHERE key = ? LIMIT 1),
         ?)
         """
-        try connection.prepare(query).bind(currentUserID, identifier, isRead).run()
+        try connection.prepare(query, currentUserID, identifier, isRead).run()
     }
     
     // MARK: - Fetching Posts

--- a/UnitTests/ReportTests.swift
+++ b/UnitTests/ReportTests.swift
@@ -51,8 +51,14 @@ class ReportTests: XCTestCase {
 
         XCTAssertEqual(try db.countNumberOfUnreadReports(), 2)
 
+        XCTAssertNil(try db.isMessageForReportRead(for: "%0"))
+        XCTAssertNil(try db.isMessageForReportRead(for: "%1"))
+        XCTAssertFalse(try XCTUnwrap(try db.isMessageForReportRead(for: "%2")))
+        XCTAssertFalse(try XCTUnwrap(try db.isMessageForReportRead(for: "%3")))
+
         try db.markMessageAsRead(identifier: "%2")
 
+        XCTAssertTrue(try XCTUnwrap(try db.isMessageForReportRead(for: "%2")))
         XCTAssertEqual(try db.countNumberOfUnreadReports(), 1)
 
         let firstReport = try XCTUnwrap(try db.report(for: "%3"))


### PR DESCRIPTION
- Before setting a report as read, we need to check if it alread read so we don't generate notifications for alread read reports. This query was a bit expensive, this PR makes it more lightweight by just querying the read status (not building the report object)
- When creating reports, a didCreateReport notification was generated for each one of them. This PR changes it so it generates one single notification.