### PR TITLE
Fix layout issue in Contact cells where cell height was too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added queer.family pub #726
 - Max-Rai contributed a fix to the onboarding layout for smaller iOS screen sizes #703 (thanks @Max-Rai!)
 - Show the number of unread notifications in the application badge
+- Fixed an issue where follow message cells could be too tall. #708
 
 ## [1.2.3] 2022-07-11
 

--- a/Source/GoBot/FeedStrategy/PostsAndContactsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/PostsAndContactsAlgorithm.swift
@@ -44,7 +44,7 @@ class PostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND (type <> 'contact'
              OR (contact_about.about_id IS NOT NULL
                  AND contact_author.author NOT IN (SELECT key FROM pubs))
-                 AND contacts.state != -1
+                 AND contacts.state == 1
                 )
         AND (authors.author IN (
                 SELECT authors.author FROM contacts
@@ -209,7 +209,7 @@ class PostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND (type <> 'contact'
              OR (contact_about.about_id IS NOT NULL
                  AND contact_author.author NOT IN (SELECT key FROM pubs))
-                 AND contacts.state != -1
+                 AND contacts.state == 1
                 )
         AND (authors.author IN (SELECT authors.author FROM contacts
                                JOIN authors ON contacts.contact_id == authors.id

--- a/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
+++ b/Source/GoBot/FeedStrategy/RecentlyActivePostsAndContactsAlgorithm.swift
@@ -34,7 +34,7 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND (type <> 'contact'
              OR (contact_about.about_id IS NOT NULL
                  AND contact_author.author NOT IN (SELECT key FROM pubs))
-                 AND contacts.state != -1
+                 AND contacts.state == 1
                 )
         AND (authors.author IN (
                 SELECT authors.author FROM contacts
@@ -188,7 +188,7 @@ class RecentlyActivePostsAndContactsAlgorithm: NSObject, FeedStrategy {
         AND (type <> 'contact'
              OR (contact_about.about_id IS NOT NULL
                  AND contact_author.author NOT IN (SELECT key FROM pubs))
-                 AND contacts.state != -1
+                 AND contacts.state == 1
                 )
         AND (authors.author IN (SELECT authors.author FROM contacts
                                JOIN authors ON contacts.contact_id == authors.id

--- a/Source/UI/AvatarImageView.swift
+++ b/Source/UI/AvatarImageView.swift
@@ -35,7 +35,7 @@ class AvatarImageView: ImageView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        if let color = borderColor, let width = borderWidth {
+        if let color = borderColor, let width = borderWidth, !sk.isSkeletonActive {
             round(borderColor: color, borderWidth: width)
         } else {
             round()

--- a/Source/UI/ContactHeaderView.swift
+++ b/Source/UI/ContactHeaderView.swift
@@ -31,6 +31,7 @@ class ContactHeaderView: UIView {
         button.titleLabel?.numberOfLines = 1
         button.titleLabel?.linesCornerRadius = 7
         button.titleLabel?.isSkeletonable = true
+        button.titleLabel?.lastLineFillPercent = 100
         button.isSkeletonable = true
         return button
     }()
@@ -72,11 +73,6 @@ class ContactHeaderView: UIView {
     func reset() {
         update(with: Identity.null, about: nil)
         showSkeleton()
-        
-        layoutSkeletonIfNeeded()
-        DispatchQueue.main.async {
-            self.layoutSkeletonIfNeeded()
-        }
     }
 
     func update(with keyValue: KeyValue) {
@@ -88,7 +84,12 @@ class ContactHeaderView: UIView {
 
     private func update(with identity: Identity, about: About?) {
         let name = about?.nameOrIdentity ?? identity
-        let string = Text.startedFollowing.text(["somebody": name])
+        var string = Text.startedFollowing.text(["somebody": name])
+        if identity == .null {
+            string = "all above the baseline"
+            // because otherwise they stick out under the skeleton
+        }
+        
         let primaryAttributes = [
             NSAttributedString.Key.foregroundColor: UIColor.text.default,
             NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .semibold)

--- a/Source/UI/ContactHeaderView.swift
+++ b/Source/UI/ContactHeaderView.swift
@@ -65,12 +65,18 @@ class ContactHeaderView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        self.identityButton.round()
+        identityButton.round()
+        layoutSkeletonIfNeeded()
     }
 
     func reset() {
         update(with: Identity.null, about: nil)
         showSkeleton()
+        
+        layoutSkeletonIfNeeded()
+        DispatchQueue.main.async {
+            self.layoutSkeletonIfNeeded()
+        }
     }
 
     func update(with keyValue: KeyValue) {

--- a/Source/UI/ContactReplyView.swift
+++ b/Source/UI/ContactReplyView.swift
@@ -20,7 +20,8 @@ class ContactReplyView: KeyValueView {
         let colorView = UIImageView.forAutoLayout()
         colorView.image = UIImage(named: "Thread")
         colorView.contentMode = .scaleToFill
-        Layout.fill(view: backgroundView, with: colorView)
+        let (_, _, bottomConstraint, _) = Layout.fill(view: backgroundView, with: colorView)
+        bottomConstraint.priority = .required
         return backgroundView
     }()
 
@@ -44,7 +45,7 @@ class ContactReplyView: KeyValueView {
         Layout.fillSouth(of: bottomBorder, with: self.degrade)
 
         Layout.fillSouth(of: degrade, with: bottomSeparator)
-        bottomSeparator.pinBottomToSuperviewBottom()
+        bottomSeparator.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
 
         isSkeletonable = true
     }
@@ -57,10 +58,14 @@ class ContactReplyView: KeyValueView {
         super.reset()
         self.contactView.reset()
         self.degrade.heightConstraint?.constant = 0
+        setNeedsLayout()
+        layoutIfNeeded()
     }
 
     override func update(with keyValue: KeyValue) {
         self.contactView.update(with: keyValue)
+        setNeedsLayout()
+        layoutIfNeeded()
     }
 }
 
@@ -69,6 +74,6 @@ extension ContactReplyView {
     /// Returns a CGFloat suitable to be used as a `UITableView.estimatedRowHeight` or
     /// `UITableViewDelegate.estimatedRowHeightAtIndexPath()`.
     static func estimatedHeight(with keyValue: KeyValue, in superview: UIView) -> CGFloat {
-        158
+        2
     }
 }

--- a/Source/UI/ContactView.swift
+++ b/Source/UI/ContactView.swift
@@ -61,6 +61,7 @@ class ContactView: KeyValueView {
         label.textContainer.lineFragmentPadding = 0
         label.isSkeletonable = true
         label.linesCornerRadius = 7
+        label.lastLineFillPercent = 100
         label.backgroundColor = .clear
         return label
     }()
@@ -108,11 +109,8 @@ class ContactView: KeyValueView {
             respectSafeArea: false
         )
         
-        nameLabel.setContentHuggingPriority(.required, for: .vertical)
-        contactIdentity.setContentHuggingPriority(.required, for: .vertical)
         nameAndIdentityStackView.addArrangedSubview(nameLabel)
         nameAndIdentityStackView.addArrangedSubview(contactIdentity)
-        nameAndIdentityStackView.setContentHuggingPriority(.required, for: .vertical)
 
         labelStackView.constrainLeading(toTrailingOf: imageView, constant: Layout.horizontalSpacing)
         labelStackView.constrainTrailingToSuperview()
@@ -122,13 +120,13 @@ class ContactView: KeyValueView {
         followerCountLabel.setContentHuggingPriority(.required, for: .vertical)
         labelStackView.addArrangedSubview(followerCountLabel)
         labelStackView.addArrangedSubview(hashtagsLabel)
-        let (_, _, bottomConstraint, _) = Layout.fill(
+        
+        Layout.fill(
             view: followButtonContainer,
             with: followButton,
             insets: UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 2),
             respectSafeArea: false
         )
-        bottomConstraint.priority = .required
         
         labelStackView.addArrangedSubview(followButtonContainer)
 
@@ -147,13 +145,14 @@ class ContactView: KeyValueView {
         super.reset()
         update(with: Identity.null, about: nil)
         update(socialStats: SocialStats(numberOfFollowers: 0, numberOfFollows: 0))
-        hashtagsLabel.layer.cornerRadius = 7 // hack because SkeletonView won't round the corners for some reason
+        nameLabel.text = "placeholder name"
+        hashtagsLabel.text = "#hashta #hashta #hashta" // no letters below the baseline
+        contactIdentity.text = "@abc123abc123"
         labelStackView.arrangedSubviews.forEach { $0.isHidden = false }
         
-        nameLabel.text = "placeholder name"
-        hashtagsLabel.text = "#hashtag"
-        contactIdentity.text = "@abc123abc123"
-        
+        // hack because SkeletonView is being weird
+        hashtagsLabel.layer.cornerRadius = 7
+
         showAnimatedSkeleton()
         layoutSkeletonIfNeeded()
         DispatchQueue.main.async {

--- a/Source/UI/ContactView.swift
+++ b/Source/UI/ContactView.swift
@@ -108,17 +108,28 @@ class ContactView: KeyValueView {
             respectSafeArea: false
         )
         
+        nameLabel.setContentHuggingPriority(.required, for: .vertical)
+        contactIdentity.setContentHuggingPriority(.required, for: .vertical)
         nameAndIdentityStackView.addArrangedSubview(nameLabel)
         nameAndIdentityStackView.addArrangedSubview(contactIdentity)
+        nameAndIdentityStackView.setContentHuggingPriority(.required, for: .vertical)
 
         labelStackView.constrainLeading(toTrailingOf: imageView, constant: Layout.horizontalSpacing)
         labelStackView.constrainTrailingToSuperview()
         labelStackView.pinTopToSuperview()
         labelStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Layout.verticalSpacing).isActive = true
         labelStackView.addArrangedSubview(nameAndIdentityStackView)
+        followerCountLabel.setContentHuggingPriority(.required, for: .vertical)
         labelStackView.addArrangedSubview(followerCountLabel)
         labelStackView.addArrangedSubview(hashtagsLabel)
-        Layout.fill(view: followButtonContainer, with: followButton, insets: UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 2), respectSafeArea: false)
+        let (_, _, bottomConstraint, _) = Layout.fill(
+            view: followButtonContainer,
+            with: followButton,
+            insets: UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 2),
+            respectSafeArea: false
+        )
+        bottomConstraint.priority = .required
+        
         labelStackView.addArrangedSubview(followButtonContainer)
 
         hashtagsLabel.delegate = self
@@ -126,8 +137,6 @@ class ContactView: KeyValueView {
         isSkeletonable = true
 
         reset()
-        
-        setNeedsLayout()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -138,12 +147,23 @@ class ContactView: KeyValueView {
         super.reset()
         update(with: Identity.null, about: nil)
         update(socialStats: SocialStats(numberOfFollowers: 0, numberOfFollows: 0))
-        nameLabel.text = "placeholder name"
-        hashtagsLabel.text = "placeholder #hashtag #hashtag #hashtag"
-        contactIdentity.text = "@abc123abc123"
         hashtagsLabel.layer.cornerRadius = 7 // hack because SkeletonView won't round the corners for some reason
         labelStackView.arrangedSubviews.forEach { $0.isHidden = false }
+        
+        nameLabel.text = "placeholder name"
+        hashtagsLabel.text = "#hashtag"
+        contactIdentity.text = "@abc123abc123"
+        
         showAnimatedSkeleton()
+        layoutSkeletonIfNeeded()
+        DispatchQueue.main.async {
+            self.layoutSkeletonIfNeeded()
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layoutSkeletonIfNeeded()
     }
     
     func update(with identity: Identity, about: About?) {

--- a/Source/UI/ContactView.swift
+++ b/Source/UI/ContactView.swift
@@ -121,12 +121,13 @@ class ContactView: KeyValueView {
         labelStackView.addArrangedSubview(followerCountLabel)
         labelStackView.addArrangedSubview(hashtagsLabel)
         
-        Layout.fill(
+        let (_, _, bottomConstraint, _) = Layout.fill(
             view: followButtonContainer,
             with: followButton,
             insets: UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 2),
             respectSafeArea: false
         )
+        bottomConstraint.priority = .required
         
         labelStackView.addArrangedSubview(followButtonContainer)
 

--- a/Source/UI/KeyValue/KeyValueTableViewCell.swift
+++ b/Source/UI/KeyValue/KeyValueTableViewCell.swift
@@ -29,7 +29,12 @@ class KeyValueTableViewCell: UITableViewCell, KeyValueUpdateable {
     }
 
     private func constrainKeyValueViewToContentView(_ height: CGFloat? = nil) {
-        Layout.fill(view: self.contentView, with: self.keyValueView, respectSafeArea: false)
+        let (_, _, bottomConstraint, _) = Layout.fill(
+            view: self.contentView,
+            with: self.keyValueView,
+            respectSafeArea: false
+        )
+        bottomConstraint.priority = .required
         guard let height = height else { return }
         let constraint = self.keyValueView.heightAnchor.constraint(lessThanOrEqualToConstant: height)
         constraint.priority = .defaultHigh

--- a/UnitTests/FeedStrategyTests.swift
+++ b/UnitTests/FeedStrategyTests.swift
@@ -61,7 +61,7 @@ class FeedStrategyTests: XCTestCase {
         let follow1 = KeyValueFixtures.keyValue(
             key: "%1",
             sequence: 1,
-            content: Content(from: Contact(contact: alice, blocking: false)),
+            content: Content(from: Contact(contact: alice, following: true)),
             timestamp: referenceDate + 1,
             receivedTimestamp: receivedDate,
             receivedSeq: 1,
@@ -186,7 +186,7 @@ class FeedStrategyTests: XCTestCase {
         let follow1 = KeyValueFixtures.keyValue(
             key: "%1",
             sequence: 1,
-            content: Content(from: Contact(contact: alice, blocking: false)),
+            content: Content(from: Contact(contact: alice, following: true)),
             timestamp: referenceDate + 1,
             receivedTimestamp: receivedDate,
             receivedSeq: 1,


### PR DESCRIPTION
This fixes part of #708, the part where the cell was too tall. I tried to fix the issue with the skeleton view not overlapping all the text, but I couldn't get the SkeletonView library to behave, and I found an open issue in their repository: https://github.com/Juanpe/SkeletonView/issues/500. Since I had so much trouble I'm not going to try to add the new follow button Sebastian designed, I will just wait and do that when we rewrite this view in SwiftUI.