### PR TITLE
Log app version on launch

### DIFF
--- a/Source/App/AppDelegate.swift
+++ b/Source/App/AppDelegate.swift
@@ -26,6 +26,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window.makeKeyAndVisible()
         self.window = window
 
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "missing"
+        let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "missing"
+        Log.info("Launching version: \(appVersion) (\(appBuild))")
         CrashReporting.shared.record("Launch")
 
         registerDefaultsFromSettingsBundle()


### PR DESCRIPTION
This will let us check the app version that users were running when the send us logs.