### PR TITLE
Fix Reset Forked Feed Protection button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased}
+- Fixed a case where tapping the Reset Forked Feed Protection button would cause the app to hang. #758
+
 ## [1.2.4] 2022-07-18
 
 - Added queer.family pub #726

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased}
+## [Unreleased]
+
 - Fixed a case where tapping the Reset Forked Feed Protection button would cause the app to hang. #758
 
 ## [1.2.4] 2022-07-18

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -26,7 +26,7 @@ typealias VoidCompletion = ((Result<Void, Error>) -> Void)
 /// - Error: an error if the refresh failed
 /// - TimeInterval: the amount of time the refresh took
 /// - Bool: True if the view database is fully up to date with the backing store.
-typealias RefreshCompletion = ((Error?, TimeInterval, Bool) -> Void)
+typealias RefreshCompletion = ((Result<Bool, Error>, TimeInterval) -> Void)
 typealias SecretCompletion = ((Secret?, Error?) -> Void)
 typealias SyncCompletion = ((Error?, TimeInterval, Int) -> Void)
 typealias ThreadCompletion = ((KeyValue?, PaginatedKeyValueDataProxy, Error?) -> Void)
@@ -330,11 +330,12 @@ extension Bot {
         queue: DispatchQueue = .main
     ) async throws -> (TimeInterval, Bool) {
         try await withCheckedThrowingContinuation { continuation in
-            refresh(load: load, queue: queue) { error, result2, result3 in
-                if let error = error {
+            refresh(load: load, queue: queue) { refreshResult, timeElapsed in
+                do {
+                    let finished = try refreshResult.get()
+                    continuation.resume(returning: (timeElapsed, finished))
+                } catch {
                     continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: (result2, result3))
                 }
             }
         }

--- a/Source/Bot/Operations/RefreshOperation.swift
+++ b/Source/Bot/Operations/RefreshOperation.swift
@@ -33,14 +33,16 @@ class RefreshOperation: AsynchronousOperation {
         }
         
         let queue = OperationQueue.current?.underlyingQueue ?? DispatchQueue.global(qos: .background)
-        Bots.current.refresh(load: refreshLoad, queue: queue) { [weak self, refreshLoad] (error, timeInterval, _) in
-            Analytics.shared.trackBotDidRefresh(load: refreshLoad.rawValue,
-                                                duration: timeInterval,
-                                                error: error)
+        Bots.current.refresh(load: refreshLoad, queue: queue) { [weak self, refreshLoad] (refreshResult, timeElapsed) in
+            var error: Error?
+            if case .failure(let actualError) = refreshResult {
+                error = actualError
+            }
+            Analytics.shared.trackBotDidRefresh(load: refreshLoad.rawValue, duration: timeElapsed, error: error)
             Log.optional(error)
             CrashReporting.shared.reportIfNeeded(error: error)
             
-            Log.info("RefreshOperation finished. Took \(timeInterval) seconds to refresh.")
+            Log.info("RefreshOperation finished. Took \(timeElapsed) seconds to refresh.")
             if let strongSelf = self, !strongSelf.isCancelled {
                 self?.error = error
             }

--- a/Source/Debug/AppConfigurationViewController.swift
+++ b/Source/Debug/AppConfigurationViewController.swift
@@ -181,7 +181,7 @@ class AppConfigurationViewController: DebugTableViewController {
                             let statistics = await bot.statistics()
                             self.configuration.numberOfPublishedMessages = statistics.repo.numberOfPublishedMessages
                             self.configuration.apply()
-                            UserDefaults.standard.set(false, forKey: "prevent_feed_from_forks")
+                            UserDefaults.standard.set(true, forKey: "prevent_feed_from_forks")
                             UserDefaults.standard.synchronize()
                             self.tableView.reloadData()
                             Log.info(

--- a/Source/Debug/BotViewController.swift
+++ b/Source/Debug/BotViewController.swift
@@ -119,8 +119,7 @@ class BotViewController: DebugTableViewController {
                                              actionClosure: {
                 [unowned self] cell in
                 cell.showActivityIndicator()
-                self.bot.refresh(load: .long, queue: .main) {
-                    [weak self] _, _, _ in
+                self.bot.refresh(load: .long, queue: .main) { [weak self] _, _ in
                     cell.hideActivityIndicator()
                     self?.updateSettings()
                 }

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -189,7 +189,7 @@ class FakeBot: Bot {
     func refresh(load: RefreshLoad, queue: DispatchQueue, completion: @escaping RefreshCompletion) {
         self._statistics.lastRefreshDate = Date()
         queue.async {
-            completion(nil, 0, false)
+            completion(.success(true), 0)
         }
     }
 

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -462,7 +462,7 @@ class GoBot: Bot {
     private func internalRefresh(load: RefreshLoad, queue: DispatchQueue, completion: @escaping RefreshCompletion) {
         guard self._isRefreshing == false else {
             queue.async {
-                completion(nil, 0, false)
+                completion(.success(false), 0)
             }
             return
         }
@@ -471,22 +471,11 @@ class GoBot: Bot {
         
         let elapsed = Date()
         self.utilityQueue.async {
-            self.updateReceive(limit: load.rawValue) { [weak self] error in
-                
-                // Figure out if the refresh got the ViewDatabase fully synced with the backing store.
-                var finished = false
-                do {
-                    let (_, numberOfRemainingMessages) = try self?.needsViewFill() ?? (0, -1)
-                    finished = numberOfRemainingMessages == 0
-                } catch {
-                    Log.optional(error)
-                }
-                
+            self.updateReceive(limit: load.rawValue) { [weak self] result in
                 queue.async {
                     self?.notifyRefreshComplete(
                         in: -elapsed.timeIntervalSinceNow,
-                        error: error,
-                        finished: finished,
+                        result: result,
                         completion: completion
                     )
                 }
@@ -496,8 +485,7 @@ class GoBot: Bot {
 
     private func notifyRefreshComplete(
         in elapsed: TimeInterval,
-        error: Error?,
-        finished: Bool,
+        result: Result<Bool, Error>,
         completion: @escaping RefreshCompletion
     ) {
         self._isRefreshing = false
@@ -505,7 +493,7 @@ class GoBot: Bot {
             self._statistics.lastRefreshDate = Date()
             self._statistics.lastRefreshDuration = elapsed
         }
-        completion(error, elapsed, finished)
+        completion(result, elapsed)
         NotificationCenter.default.post(name: .didRefresh, object: nil)
     }
     
@@ -773,14 +761,14 @@ class GoBot: Bot {
     }
     
     // should only be called by refresh() (which does the proper completion on mainthread)
-    private func updateReceive(limit: Int32 = 15_000, completion: @escaping ErrorCompletion) {
+    private func updateReceive(limit: Int32 = 15_000, completion: @escaping (Result<Bool, Error>) -> Void) {
         var current: Int64 = 0
         var diff: Int = 0
 
         do {
             (current, diff) = try self.needsViewFill()
         } catch {
-            completion(error)
+            completion(.failure(error))
             return
         }
         
@@ -800,7 +788,7 @@ class GoBot: Bot {
             
             guard !msgs.isEmpty else {
                 print("warning: triggered update but got no messages from receive log")
-                completion(nil)
+                completion(.success(true))
                 return
             }
             
@@ -814,18 +802,18 @@ class GoBot: Bot {
                     lastHash: msgs[msgs.count - 1].key
                 )
                 if diff < limit { // view is up2date now
-                    completion(nil)
+                    completion(.success(true))
                     // disable private messages until there is UI for it AND ADD SQLCYPHER!!!111
                     // self.updatePrivate(completion: completion)
                 } else {
                     #if DEBUG
                     print("#rx log# \(diff - Int(limit)) messages left in go-ssb offset log")
                     #endif
-                    completion(nil)
+                    completion(.success(false))
                 }
             } catch ViewDatabaseError.messageConstraintViolation(let author, let sqlErr) {
                 let (repair, error) = self.repairViewConstraints21012020(with: author, current: current)
-
+    
                 Analytics.shared.trackBotDidRepair(
                     databaseError: sqlErr,
                     error: error?.localizedDescription,
@@ -835,19 +823,19 @@ class GoBot: Bot {
                 #if DEBUG
                 print("[rx log] viewdb fill of aborted and repaired.")
                 #endif
-                completion(error)
+                completion(.failure(error ?? GoBotError.unexpectedFault("updateReceive failed")))
             } catch {
                 let encapsulatedError = GoBotError.duringProcessing("viewDB: message filling failed", error)
                 Log.optional(encapsulatedError)
                 CrashReporting.shared.reportIfNeeded(error: encapsulatedError)
-                completion(encapsulatedError)
+                completion(.failure(encapsulatedError))
             }
         } catch {
-            completion(error)
+            completion(.failure(error))
         }
     }
     
-    private func updatePrivate(completion: @escaping ErrorCompletion) {
+    private func updatePrivate(completion: @escaping (Result<Bool, Error>) -> Void) {
         var count: Int64 = 0
         do {
             let rawCount = try self.database.stats(table: .privates)
@@ -862,9 +850,9 @@ class GoBot: Bot {
                 print("[private log] private log filled with \(msgs.count) msgs (started at \(count))")
             }
             
-            completion(nil)
+            completion(.success(false))
         } catch {
-            completion(error)
+            completion(.failure(error))
         }
     }
     

--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -90,8 +90,8 @@ class GoBotIntegrationTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
         
         let refreshExpectation = self.expectation(description: "refresh completed")
-        sut.refresh(load: .long, queue: .main) { error, _, _ in
-            XCTAssertNil(error)
+        sut.refresh(load: .long, queue: .main) { result, _ in
+            XCTAssertNotNil(try? result.get())
             refreshExpectation.fulfill()
         }
         waitForExpectations(timeout: 10, handler: nil)

--- a/UnitTests/GoBotOrderedTests.swift
+++ b/UnitTests/GoBotOrderedTests.swift
@@ -305,9 +305,8 @@ class GoBotOrderedTests: XCTestCase {
         }
 
         let ex = self.expectation(description: "\(#function) refresh")
-        GoBotOrderedTests.shared.refresh(load: .short, queue: .main) {
-            err, _, _ in
-            XCTAssertNil(err, "refresh error!")
+        GoBotOrderedTests.shared.refresh(load: .short, queue: .main) { result, _ in
+            XCTAssertNotNil(try? result.get())
             ex.fulfill()
         }
         self.wait(for: [ex], timeout: 10)
@@ -380,9 +379,8 @@ class GoBotOrderedTests: XCTestCase {
         let afterUnsupported = GoBotOrderedTests.shared.testingPublish(as: "denise", content: Post(text: "after lots of unsupported"))
 
         var ex = self.expectation(description: "\(#function) 1")
-        GoBotOrderedTests.shared.refresh(load: .long, queue: .main) {
-            err, _, _ in
-            XCTAssertNil(err, "refresh error!")
+        GoBotOrderedTests.shared.refresh(load: .long, queue: .main) { result, _ in
+            XCTAssertNotNil(try? result.get(), "view refresh failed")
             ex.fulfill()
         }
         self.wait(for: [ex], timeout: 10)

--- a/UnitTests/GoBotReproductionHelper.swift
+++ b/UnitTests/GoBotReproductionHelper.swift
@@ -118,7 +118,7 @@ class API_GoBot: XCTestCase {
 
     func test05_refresh() {
         let refreshExpectation = self.expectation(description: "refresh")
-        API_GoBot.bot.refresh(load: .short, queue: .main) { (result, took) in
+        API_GoBot.bot.refresh(load: .short, queue: .main) { (result, _) in
             XCTAssertNotNil(try? result.get())
             refreshExpectation.fulfill()
         }

--- a/UnitTests/GoBotReproductionHelper.swift
+++ b/UnitTests/GoBotReproductionHelper.swift
@@ -91,9 +91,8 @@ class API_GoBot: XCTestCase {
     // make sure view db is uptodate with gosbot repo
     func test03_refresh() {
         var refreshExpectation = self.expectation(description: "refresh")
-        API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, took, _) in
-            XCTAssertNil(err)
+        API_GoBot.bot.refresh(load: .short, queue: .main) { (result, took) in
+            XCTAssertNotNil(try? result.get())
             print("ref1:\(took)")
             refreshExpectation.fulfill()
         }
@@ -101,9 +100,8 @@ class API_GoBot: XCTestCase {
         
         // TODO: retrigger refesh after repair sync
         refreshExpectation = self.expectation(description: "refresh")
-        API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, took, _) in
-            XCTAssertNil(err)
+        API_GoBot.bot.refresh(load: .short, queue: .main) { (result, took) in
+            XCTAssertNotNil(try? result.get())
             print("ref2:\(took)")
             refreshExpectation.fulfill()
         }
@@ -112,17 +110,16 @@ class API_GoBot: XCTestCase {
 
     func test04_same_msgs() async {
         let statistics = await API_GoBot.bot.statistics()
-        XCTAssertEqual(statistics.db.lastReceivedMessage, 6_699)
-        XCTAssertEqual(statistics.repo.messageCount, 6_700)
+        XCTAssertEqual(statistics.db.lastReceivedMessage, 6699)
+        XCTAssertEqual(statistics.repo.messageCount, 6700)
         
         XCTAssertTrue(API_GoBot.bot.bot.repoFSCK(.Sequences))
     }
 
     func test05_refresh() {
         let refreshExpectation = self.expectation(description: "refresh")
-        API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, _, _) in
-            XCTAssertNil(err)
+        API_GoBot.bot.refresh(load: .short, queue: .main) { (result, took) in
+            XCTAssertNotNil(try? result.get())
             refreshExpectation.fulfill()
         }
         waitForExpectations(timeout: 10)
@@ -130,21 +127,19 @@ class API_GoBot: XCTestCase {
 
     func test07_refresh() async {
         let refreshExpectation = self.expectation(description: "refresh")
-        API_GoBot.bot.refresh(load: .short, queue: .main) {
-            (err, _, _) in
-            XCTAssertNil(err)
+        API_GoBot.bot.refresh(load: .short, queue: .main) { (result, _) in
+            XCTAssertNotNil(try? result.get())
             refreshExpectation.fulfill()
         }
         await waitForExpectations(timeout: 10)
         let statistics = await API_GoBot.bot.statistics()
-        XCTAssertEqual(statistics.db.lastReceivedMessage, 6_699)
-        XCTAssertEqual(statistics.repo.messageCount, 6_700)
+        XCTAssertEqual(statistics.db.lastReceivedMessage, 6699)
+        XCTAssertEqual(statistics.repo.messageCount, 6700)
     }
 
     func test900_logout() {
         let logoutExpectation = self.expectation(description: "logout")
-        API_GoBot.bot.logout {
-            error in
+        API_GoBot.bot.logout { error in
             XCTAssertNil(error)
             logoutExpectation.fulfill()
         }

--- a/UnitTests/Test Helpers/GoBotTestExtensions.swift
+++ b/UnitTests/Test Helpers/GoBotTestExtensions.swift
@@ -22,9 +22,8 @@ extension GoBot {
 //        tc.wait(for: [syncExpectation], timeout: 30)
 
         let refreshExpectation = tc.expectation(description: "Refresh")
-        self.refresh(load: .short, queue: .main) {
-            error, _, _ in
-            XCTAssertNil(error, "view refresh failed")
+        self.refresh(load: .short, queue: .main) { result, _ in
+            XCTAssertNotNil(try? result.get(), "view refresh failed")
             refreshExpectation.fulfill()
         }
         tc.wait(for: [refreshExpectation], timeout: 30)


### PR DESCRIPTION
Fix case where tapping the Reset Forked Feed Protection button would hang. The issue is that if `fillMessages` skipped any messages we would report that it didn't finish syncing, and then the app would never finish syncing.