### PR TITLE
New logic for applying the ban list

### DIFF
--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -263,7 +263,7 @@ class GoBot: Bot {
             }
             self.preloadedPubService?.preloadPubs(in: self, from: nil)
             
-            Task.detached(priority: .utility) {
+            Task.detached(priority: .background) {
                 await self.fetchAndApplyBanList(for: secret.identity)
             }
         }
@@ -1260,22 +1260,20 @@ class GoBot: Bot {
             return
         }
             
-        var authors: [FeedIdentifier] = []
         do {
-            authors = try self.database.applyBanList(banList)
-        } catch {
-            Log.unexpected(.botError, "viewdb failed to update banned content: \(error)")
-        }
-        
-        // add as blocked peers to bot (those dont have contact messages)
-        do {
-            for a in authors {
-                // TODO: Maybe private blocks here?
-                try self.bot.nullFeed(author: a)
-                self.bot.block(feed: a)
+            let (bannedAuthors, unbannedAuthors) = try self.database.applyBanList(banList)
+            
+            // add as blocked peers to bot (those dont have contact messages)
+            for author in bannedAuthors {
+                try bot.nullFeed(author: author)
+                bot.ban(feed: author)
+            }
+            
+            for author in unbannedAuthors {
+                bot.unban(feed: author)
             }
         } catch {
-            Log.unexpected(.botError, "failed to drop and banned content: \(error)")
+            Log.unexpected(.botError, "failed to apply ban list: \(error)")
         }
     }
 

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -397,9 +397,18 @@ class GoBotInternal {
     }
     
     // MARK: manual block / replicate
-    func block(feed: FeedIdentifier) {
+    
+    /// Instructs the bot to stop replicating the current feed without publishing a message on the user's log.
+    func ban(feed: FeedIdentifier) {
         feed.withGoString {
             ssbFeedBlock($0, true)
+        }
+    }
+    
+    /// Instructs the bot to start replicating the given feed again if appropriate, undoing a call to `ban(feed:)`.
+    func unban(feed: FeedIdentifier) {
+        feed.withGoString {
+            ssbFeedBlock($0, false)
         }
     }
 


### PR DESCRIPTION
Fixes #731 

This changes the way the ban list is applies. Before this PR, the list was downloaded on app launch, used to hide messages in SQLite, and then discarded. Now we save the list to the db, delete messages instead of hiding them, and prevent banned messages from ever being written to SQLite in `fillMessages`. We also keep track of when authors are unbanned so we start replicating with them again. Unbanning messages is still not supported.