### PR TITLE
Build 1.2.5

### DIFF
--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		23CA4B93232291E1005B35E8 /* UITextView+NSMutableAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539FD4B022C19F66005A4DF2 /* UITextView+NSMutableAttributedString.swift */; };
 		23CF345722099E5D00F46A54 /* InvalidVoteMissingIdentifier.json in Resources */ = {isa = PBXBuildFile; fileRef = 23CF345622099E5D00F46A54 /* InvalidVoteMissingIdentifier.json */; };
 		23D8CE272253DB29001EB7D5 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D8CE262253DB29001EB7D5 /* Address.swift */; };
-		23D8E2C022033D31004776EA /* (null) in Resources */ = {isa = PBXBuildFile; };
+		23D8E2C022033D31004776EA /* BuildFile in Resources */ = {isa = PBXBuildFile; };
 		23E76A5623F2F0F70074F424 /* ValueTimestamp.json in Resources */ = {isa = PBXBuildFile; fileRef = 23E76A5523F2F0F70074F424 /* ValueTimestamp.json */; };
 		23E8805E22F894650074D399 /* Collection+RandomSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E8805D22F894650074D399 /* Collection+RandomSample.swift */; };
 		23E8805F22F894650074D399 /* Collection+RandomSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E8805D22F894650074D399 /* Collection+RandomSample.swift */; };
@@ -260,7 +260,7 @@
 		530F01B222DFCEED007EBAE2 /* String+IsValid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B122DFCEED007EBAE2 /* String+IsValid.swift */; };
 		530F01B422E0D3E7007EBAE2 /* TitledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B322E0D3E7007EBAE2 /* TitledToggle.swift */; };
 		530F01B622E0D930007EBAE2 /* JoinOnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B522E0D930007EBAE2 /* JoinOnboardingStep.swift */; };
-		5314EF3A22EA276A0065D02A /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		5314EF3A22EA276A0065D02A /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		5314EF3B22EA27840065D02A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62A22445BE900C57A4B /* AppConfiguration.swift */; };
 		5314EF3C22EA27920065D02A /* SSBNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F692209108F007264CB /* SSBNetwork.swift */; };
 		5314EF3D22EA27980065D02A /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01F32204F66200DFDF16 /* Secret.swift */; };
@@ -620,10 +620,10 @@
 		5B92E27E284A7B2D003127F2 /* HashtagListStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B92E279284A7A8F003127F2 /* HashtagListStrategy.swift */; };
 		5B92E27F284A7B2F003127F2 /* PopularHashtagsAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B92E27B284A7B12003127F2 /* PopularHashtagsAlgorithm.swift */; };
 		5B92E280284A7B30003127F2 /* PopularHashtagsAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B92E27B284A7B12003127F2 /* PopularHashtagsAlgorithm.swift */; };
-		5B9C69562888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */; };
-		5B9C69572888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */; };
 		5B9C6951288726F300229469 /* ClearUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C6950288726F300229469 /* ClearUnreadNotificationsOperation.swift */; };
 		5B9C6952288726F300229469 /* ClearUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C6950288726F300229469 /* ClearUnreadNotificationsOperation.swift */; };
+		5B9C69562888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */; };
+		5B9C69572888813000229469 /* CountUnreadNotificationsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */; };
 		5BAA0BB427DF9CE200C7BE63 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 5BAA0BB327DF9CE200C7BE63 /* CrashReporting */; };
 		5BAA0BB627DF9CEC00C7BE63 /* CrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 5BAA0BB527DF9CEC00C7BE63 /* CrashReporting */; };
 		5BAE9C82281E0E51008AEA84 /* JoinPlanetarySystemOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAE9C81281E0E51008AEA84 /* JoinPlanetarySystemOperation.swift */; };
@@ -686,9 +686,9 @@
 		8F6DDE5DB47CDEED56B74CB3 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EA32E74C0DFF1EF8924773F /* Pods_UnitTests.framework */; };
 		C90EBE7327E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
 		C90EBE7427E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
-		C9134DDB28184AF700595D49 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		C9134DDB28184AF700595D49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		C9134DE228184C2700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE128184C2700595D49 /* Support */; };
-		C9134DE328184D4200595D49 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		C9134DE328184D4200595D49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		C9134DE6281854E700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE5281854E700595D49 /* Support */; };
 		C923DBB1288057EB00569AAB /* HelpDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923DBB0288057EB00569AAB /* HelpDrawerView.swift */; };
 		C923DBB2288057EB00569AAB /* HelpDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923DBB0288057EB00569AAB /* HelpDrawerView.swift */; };
@@ -901,7 +901,7 @@
 		C9724BB42809EC4F000EBCCD /* DebugOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531587B1229F33F00004E2B1 /* DebugOnboardingViewController.swift */; };
 		C9724BB52809EC57000EBCCD /* DebugUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533F4050225E9E010060B4B9 /* DebugUIViewController.swift */; };
 		C9724BB62809EC61000EBCCD /* DebugPostsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531EC40B230F6B9E001A25AD /* DebugPostsViewController.swift */; };
-		C9724BB72809EC68000EBCCD /* (null) in Sources */ = {isa = PBXBuildFile; };
+		C9724BB72809EC68000EBCCD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		C9724BB82809EC77000EBCCD /* SecretViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FCAFDD22051C88009E9E82 /* SecretViewController.swift */; };
 		C9724BB92809EC7B000EBCCD /* BotViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62622444A1500C57A4B /* BotViewController.swift */; };
 		C9724BBA2809ECA2000EBCCD /* StatisticsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5DB7CB24AC01D9008DCB81 /* StatisticsOperation.swift */; };
@@ -1553,8 +1553,8 @@
 		5B92E2762849583C003127F2 /* HashtagListStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagListStrategyTests.swift; sourceTree = "<group>"; };
 		5B92E279284A7A8F003127F2 /* HashtagListStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagListStrategy.swift; sourceTree = "<group>"; };
 		5B92E27B284A7B12003127F2 /* PopularHashtagsAlgorithm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularHashtagsAlgorithm.swift; sourceTree = "<group>"; };
-		5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountUnreadNotificationsOperation.swift; sourceTree = "<group>"; };
 		5B9C6950288726F300229469 /* ClearUnreadNotificationsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUnreadNotificationsOperation.swift; sourceTree = "<group>"; };
+		5B9C69552888813000229469 /* CountUnreadNotificationsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountUnreadNotificationsOperation.swift; sourceTree = "<group>"; };
 		5BAE9C81281E0E51008AEA84 /* JoinPlanetarySystemOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinPlanetarySystemOperation.swift; sourceTree = "<group>"; };
 		5BAE9C85281E0EA9008AEA84 /* Support+GoBot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Support+GoBot.swift"; sourceTree = "<group>"; };
 		5BAE9C8B281F5226008AEA84 /* ContactCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCellView.swift; sourceTree = "<group>"; };
@@ -1764,7 +1764,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BC2974C2804B9DE00C0CD81 /* SQLite in Frameworks */,
-				5314EF3A22EA276A0065D02A /* (null) in Frameworks */,
+				5314EF3A22EA276A0065D02A /* BuildFile in Frameworks */,
 				664DA6493E3CC0506BD71355 /* Pods_APITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3337,7 +3337,7 @@
 			mainGroup = 5344D82221C4649700704A34;
 			packageReferences = (
 				C969F434282C79CC00FF6FE3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
-				5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */,
+				5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */,
 				5B5BB8DB283E8BFC00D99AB8 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 			);
 			productRefGroup = 5344D82C21C4649700704A34 /* Products */;
@@ -3424,7 +3424,7 @@
 				5316E95B21FFD4980053832E /* InvalidChannel.json in Resources */,
 				C924412F278DDECE00592E5E /* Preload.bundle in Resources */,
 				5316E95721FFCDFF0053832E /* UnsupportedType.json in Resources */,
-				23D8E2C022033D31004776EA /* (null) in Resources */,
+				23D8E2C022033D31004776EA /* BuildFile in Resources */,
 				5316E95921FFD19F0053832E /* Invalid.json in Resources */,
 				C9F0B6A027E2728800BE2F0E /* Generated.strings in Resources */,
 				C98A014B2790C5A900E29A97 /* Feed_big.sqlite in Resources */,
@@ -3623,7 +3623,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist,
+				"$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -4003,7 +4003,7 @@
 				C9724B642809D6DC000EBCCD /* NotificationCellView.swift in Sources */,
 				C9724BBE2809ECCC000EBCCD /* UITextView+Verse.swift in Sources */,
 				53E29CE022D80424008A2CB1 /* Hashtag+String.swift in Sources */,
-				C9724BB72809EC68000EBCCD /* (null) in Sources */,
+				C9724BB72809EC68000EBCCD /* BuildFile in Sources */,
 				0A64A84024735520009A5EBF /* NullPushAPI.swift in Sources */,
 				23EF5AAA249D177F00469977 /* BanListAPI.swift in Sources */,
 				53E26C5E23045D34009240B2 /* Data+Person.swift in Sources */,
@@ -4019,7 +4019,7 @@
 				C9724B182809D350000EBCCD /* AppController+Progress.swift in Sources */,
 				53B4F5FA22B8602F00027C6A /* Mention+NSAttributedString.swift in Sources */,
 				0A64A84824735717009A5EBF /* PhoneVerificationAPIService.swift in Sources */,
-				C9134DE328184D4200595D49 /* (null) in Sources */,
+				C9134DE328184D4200595D49 /* BuildFile in Sources */,
 				C9724BE72809EEA4000EBCCD /* SimplePublishView.swift in Sources */,
 				C9724B432809D4F1000EBCCD /* UIButton+Text.swift in Sources */,
 				535754F722692B59002A6989 /* BotError.swift in Sources */,
@@ -4044,7 +4044,7 @@
 				53631EF623A9A93F009C6999 /* Blob+String.swift in Sources */,
 				C9724BC42809ED5B000EBCCD /* Blob+UIColor.swift in Sources */,
 				C9724B782809E7C1000EBCCD /* AppController+Push.swift in Sources */,
-				C9134DDB28184AF700595D49 /* (null) in Sources */,
+				C9134DDB28184AF700595D49 /* BuildFile in Sources */,
 				C9724B262809D426000EBCCD /* HomeViewController.swift in Sources */,
 				C9724BE02809EE5A000EBCCD /* Tappable.swift in Sources */,
 				C9F1C84927C92842005A3228 /* Localizable.swift in Sources */,
@@ -5416,7 +5416,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Resources/FBTT.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 348;
+				CURRENT_PROJECT_VERSION = 349;
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -5429,7 +5429,7 @@
 					"@executable_path/",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				OTHER_LDFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				STRIP_SWIFT_SYMBOLS = NO;
@@ -5448,7 +5448,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Resources/FBTT.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 348;
+				CURRENT_PROJECT_VERSION = 349;
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -5461,7 +5461,7 @@
 					"@executable_path/",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				OTHER_LDFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
 				STRIP_SWIFT_SYMBOLS = NO;
@@ -5575,7 +5575,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */ = {
+		5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stephencelis/SQLite.swift";
 			requirement = {
@@ -5626,17 +5626,17 @@
 		};
 		5BC2974528048AD800C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
 			productName = SQLite;
 		};
 		5BC297492804B98C00C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
 			productName = SQLite;
 		};
 		5BC2974B2804B9DE00C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
 			productName = SQLite;
 		};
 		5BE28DFC27CD7BA1004D7D27 /* Analytics */ = {

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -37,7 +37,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>348</string>
+	<string>349</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "Mehr anzeigen";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Blockieren";
-"Text.blocked" = "Blockiert";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Schlüssel und Identität löschen";
 "Text.follow" = "Folgen";
 "Text.following" = "Folge ich";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} hat gepostet: {{ what }} {{ link }}";
 "Text.addFriend" = "Freund hinzufügen";
 "Text.removeFriend" = "Freund entfernen";
-"Text.blockUser" = "Diesen Nutzer blockieren";
-"Text.unblockUser" = "Diesen Nutzer nicht mehr blockieren";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Beitrag melden";
 "Text.reportUser" = "Nutzer melden";
 "Text.noReplies" = "Keine Antworten";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Bist du sicher, dass du {{ name }} blockieren willst? Du wirst den Inhalt des anderen nicht mehr sehen oder dich gegenseitig kontaktieren können.";
-"Blocking.buttonTitle" = "Ja, {{ name }} blockieren";
-"Blocking.blockedUsers" = "Blockierte Benutzer";
-"Blocking.footer" = "Blockierte Benutzer können deine Beiträge nicht sehen oder dich kontaktieren. Du musst diese entsperren, bevor du ihre Beiträge sehen oder du sie kontaktieren kannst. Es kann einige Zeit dauern, bis du Benutzer und Inhalte siehst, sobald sie entsperrt wurden.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "dieser Benutzer";
-"Blocking.usersYouHaveBlocked" = "Benutzer, die du blockiert hast";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Kamera";
 "ImagePicker.cameraNotAvailable" = "Kamera ist auf diesem Gerät nicht verfügbar";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "Ver más";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Bloquear";
-"Text.blocked" = "Bloqueado";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";
 "Text.follow" = "Seguir";
 "Text.following" = "Siguiendo";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} publicó: {{ what }} {{ link }}";
 "Text.addFriend" = "Añadir amigo";
 "Text.removeFriend" = "Eliminar amigos";
-"Text.blockUser" = "Bloquear este usuario";
-"Text.unblockUser" = "Desbloquear este usuario";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Reportar este post";
 "Text.reportUser" = "Reportar este usuario";
 "Text.noReplies" = "Sin respuestas";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "¿Estás seguro de que querés bloquear a {{ name }}? No vas a poder ver su contenido mutuamente ni tampoco volver a contactarse.";
-"Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";
-"Blocking.blockedUsers" = "Usuarios Bloqueados";
-"Blocking.footer" = "Los usuarios bloqueados no pueden ver tus posts ni contactarte, y vas a tener que desbloquearlos para ver sus publicaciones o contactarlos. Podría tomar un tiempo volver a ver usuarios y contenido una vez que han sido desbloqueados.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "este usuario";
-"Blocking.usersYouHaveBlocked" = "Usuarios que has bloqueado";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Cámara";
 "ImagePicker.cameraNotAvailable" = "La cámara no está disponible en este dispositivo";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "Ver más";
 "Text.likesThis" = "le gusta esto";
 "Text.dislikesThis" = "no le gusta esto";
-"Text.block" = "Bloquear";
-"Text.blocked" = "Bloqueado";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";
 "Text.follow" = "Seguir";
 "Text.following" = "Siguiendo";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} publicó: {{ what }} {{ link }}";
 "Text.addFriend" = "Añadir amigo";
 "Text.removeFriend" = "Eliminar de amigos";
-"Text.blockUser" = "Bloquear este usuario";
-"Text.unblockUser" = "Desbloquear este usuario";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Reportar esta publicación";
 "Text.reportUser" = "Reportar este usuario";
 "Text.noReplies" = "Sin respuestas";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "¿Estás seguro?";
 "Text.dismissMigrationEarlyMessage" = "Esta pantalla se cerrará y podrás usar Planetary mientras tus datos se descargan en segundo plano. ¿Estás seguro?";
 
-"Blocking.alertTitle" = "¿Estás seguro de que quieres bloquear a {{ name }}? No podrás ver el contenido de ambos ni tampoco volver a contactarse.";
-"Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";
-"Blocking.blockedUsers" = "Usuarios Bloqueados";
-"Blocking.footer" = "Los usuarios bloqueados no pueden ver tus publicaciones ni contactarte, y necesitarás desbloquearlos para ver sus publicaciones o contactarlos. Podría tomar un tiempo volver a ver usuarios y contenido una vez que han sido desbloqueados.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "este usuario";
-"Blocking.usersYouHaveBlocked" = "Usuarios que has bloqueado";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Cámara";
 "ImagePicker.cameraNotAvailable" = "La cámara no está disponible en este dispositivo";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "Ver más";
 "Text.likesThis" = "le gusta esto";
 "Text.dislikesThis" = "no le gusta esto";
-"Text.block" = "Bloquear";
-"Text.blocked" = "Bloqueado";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";
 "Text.follow" = "Seguir";
 "Text.following" = "Siguiendo";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} publicó: {{ what }} {{ link }}";
 "Text.addFriend" = "Añadir amigo";
 "Text.removeFriend" = "Eliminar amigos";
-"Text.blockUser" = "Bloquear este usuario";
-"Text.unblockUser" = "Desbloquear este usuario";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Reportar este post";
 "Text.reportUser" = "Reportar este usuario";
 "Text.noReplies" = "Sin respuestas";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "¿Estás seguro?";
 "Text.dismissMigrationEarlyMessage" = "Esta pantalla se cerrará y podrás usar Planetary mientras tus datos se descargan en segundo plano. ¿Estás seguro?";
 
-"Blocking.alertTitle" = "¿Estás seguro de que querés bloquear a {{ name }}? No vas a poder ver su contenido mutuamente ni tampoco volver a contactarse.";
-"Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";
-"Blocking.blockedUsers" = "Usuarios Bloqueados";
-"Blocking.footer" = "Los usuarios bloqueados no pueden ver tus posts ni contactarte, y vas a tener que desbloquearlos para ver sus publicaciones o contactarlos. Podría tomar un tiempo volver a ver usuarios y contenido una vez que han sido desbloqueados.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "este usuario";
-"Blocking.usersYouHaveBlocked" = "Usuarios que has bloqueado";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Cámara";
 "ImagePicker.cameraNotAvailable" = "La cámara no está disponible en este dispositivo";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "Ver más";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Bloquear";
-"Text.blocked" = "Bloqueado";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Eliminar este secreto e identidad";
 "Text.follow" = "Seguir";
 "Text.following" = "Siguiendo";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} publicó: {{ what }} {{ link }}";
 "Text.addFriend" = "Añadir amigo";
 "Text.removeFriend" = "Eliminar de amigos";
-"Text.blockUser" = "Bloquear este usuario";
-"Text.unblockUser" = "Desbloquear este usuario";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Reportar esta publicación";
 "Text.reportUser" = "Reportar este usuario";
 "Text.noReplies" = "Sin respuestas";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "¿Estás seguro de que quieres bloquear a {{ name }}? No podrás ver el contenido de ambos ni tampoco volver a contactarse.";
-"Blocking.buttonTitle" = "Sí, bloquear a {{ name }}";
-"Blocking.blockedUsers" = "Usuarios Bloqueados";
-"Blocking.footer" = "Los usuarios bloqueados no pueden ver tus publicaciones ni contactarte, y necesitarás desbloquearlos para ver sus publicaciones o contactarlos. Podría tomar un tiempo volver a ver usuarios y contenido una vez que han sido desbloqueados.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "este usuario";
-"Blocking.usersYouHaveBlocked" = "Usuarios que has bloqueado";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Cámara";
 "ImagePicker.cameraNotAvailable" = "La cámara no está disponible en este dispositivo";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "Więcej";
 "Text.likesThis" = "lubi to";
 "Text.dislikesThis" = "nie lubi tego";
-"Text.block" = "Zablokuj";
-"Text.blocked" = "Zablokowani";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Usuń ten sekret i tożsamość";
 "Text.follow" = "Obserwuj";
 "Text.following" = "Obserwowani";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} opublikował: {{ what }} {{ link }}";
 "Text.addFriend" = "Dodaj znajomego";
 "Text.removeFriend" = "Usuń ze znajomych";
-"Text.blockUser" = "Zablokuj tego użytkownika";
-"Text.unblockUser" = "Odblokuj tego użytkownika";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Zgłoś tę wiadomość";
 "Text.reportUser" = "Zgłoś użytkownika";
 "Text.noReplies" = "Bez odpowiedzi";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Czy na pewno?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Czy na pewno chcesz zablokować {{ name }}? You will no longer see each other's content or be able to contact each other. Nie będziecie już widzieć wzajemnych treści ani nie będziecie mogli się ze sobą kontaktować.";
-"Blocking.buttonTitle" = "Tak, zablokuj {{ name }}";
-"Blocking.blockedUsers" = "Zablokowani Użytkownicy";
-"Blocking.footer" = "Zablokowani użytkownicy nie mogą widzieć Twoich postów ani kontaktować się z Tobą, a przed wyświetleniem ich postów lub skontaktowaniem się z nimi musisz ich odblokować. Wyświetlenie użytkowników i ich treści po odblokowaniu może zająć trochę czasu.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "ten użytkownik";
-"Blocking.usersYouHaveBlocked" = "Użytkownicy, których zablokowałeś";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Aparat";
 "ImagePicker.cameraNotAvailable" = "Aparat nie jest dostępny na tym urządzeniu";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "Więcej";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Zablokuj";
-"Text.blocked" = "Zablokowani";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Usuń ten sekret i tożsamość";
 "Text.follow" = "Obserwuj";
 "Text.following" = "Obserwowani";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} opublikował: {{ what }} {{ link }}";
 "Text.addFriend" = "Dodaj znajomego";
 "Text.removeFriend" = "Usuń ze znajomych";
-"Text.blockUser" = "Zablokuj tego użytkownika";
-"Text.unblockUser" = "Odblokuj tego użytkownika";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Zgłoś tę wiadomość";
 "Text.reportUser" = "Zgłoś użytkownika";
 "Text.noReplies" = "Bez odpowiedzi";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Czy na pewno chcesz zablokować {{ name }}? You will no longer see each other's content or be able to contact each other. Nie będziecie już widzieć wzajemnych treści ani nie będziecie mogli się ze sobą kontaktować.";
-"Blocking.buttonTitle" = "Tak, zablokuj {{ name }}";
-"Blocking.blockedUsers" = "Zablokowani Użytkownicy";
-"Blocking.footer" = "Zablokowani użytkownicy nie mogą widzieć Twoich postów ani kontaktować się z Tobą, a przed wyświetleniem ich postów lub skontaktowaniem się z nimi musisz ich odblokować. Wyświetlenie użytkowników i ich treści po odblokowaniu może zająć trochę czasu.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "ten użytkownik";
-"Blocking.usersYouHaveBlocked" = "Użytkownicy, których zablokowałeś";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Aparat";
 "ImagePicker.cameraNotAvailable" = "Aparat nie jest dostępny na tym urządzeniu";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "查看更多";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "区块";
-"Text.blocked" = "屏蔽";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "您确定要屏蔽 {{ name }} 吗？您将不再看到对方的内容或能够相互联系。";
-"Blocking.buttonTitle" = "是，封禁 {{ name }}";
-"Blocking.blockedUsers" = "已屏蔽用户";
-"Blocking.footer" = "被屏蔽的用户无法看到您的帖子或联系您，您需要先解除屏蔽他们，然后才能看到他们的帖子或联系他们。 解锁用户和内容后可能需要一些时间。";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "此用户";
-"Blocking.usersYouHaveBlocked" = "您已屏蔽的用户";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "照相机";
 "ImagePicker.cameraNotAvailable" = "此功能在设备上无效";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -58,8 +58,8 @@
 "Text.seeMore" = "See more";
 "Text.likesThis" = "likes this";
 "Text.dislikesThis" = "dislikes this";
-"Text.block" = "Block";
-"Text.blocked" = "Blocked";
+"Text.block" = "Ignore";
+"Text.blocked" = "Ignored";
 "Text.deleteSecretAndIdentity" = "Delete this secret and identity";
 "Text.follow" = "Follow";
 "Text.following" = "Following";
@@ -80,8 +80,8 @@
 "Text.shareThisMessageText" = "{{ who }} posted: {{ what }} {{ link }}";
 "Text.addFriend" = "Add friend";
 "Text.removeFriend" = "Remove from friends";
-"Text.blockUser" = "Block this user";
-"Text.unblockUser" = "Unblock this user";
+"Text.blockUser" = "Ignore this user";
+"Text.unblockUser" = "Unignore this user";
 "Text.reportPost" = "Report this post";
 "Text.reportUser" = "Report this user";
 "Text.noReplies" = "No replies";
@@ -140,12 +140,12 @@
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
 
-"Blocking.alertTitle" = "Are you sure you want to block {{ name }}? You will no longer see each other's content or be able to contact each other.";
-"Blocking.buttonTitle" = "Yes, block {{ name }}";
-"Blocking.blockedUsers" = "Blocked Users";
-"Blocking.footer" = "Blocked users cannot see your posts or contact you, and you will need to unblock them before you can see their posts or contact them. It may take some time to see users and content once they have been unblocked.";
+"Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
+"Blocking.buttonTitle" = "Yes, ignore {{ name }}";
+"Blocking.blockedUsers" = "Ignored Users";
+"Blocking.footer" = "Ignored users cannot see your posts or contact you, and you will need to unignore them before you can see their posts or contact them. It may take some time to see users and content once they have been unignored.";
 "Blocking.thisUser" = "this user";
-"Blocking.usersYouHaveBlocked" = "Users that you have blocked";
+"Blocking.usersYouHaveBlocked" = "Users that you have ignored";
 
 "ImagePicker.camera" = "Camera";
 "ImagePicker.cameraNotAvailable" = "Camera is not available on this device";

--- a/UITests/Info.plist
+++ b/UITests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>348</string>
+	<string>349</string>
 	<key>PLTestingNetworkHMAC</key>
 	<string>$(TESTING_NETWORK_HMAC)</string>
 	<key>PLTestingNetworkKey</key>


### PR DESCRIPTION
Fixes #773 

- Fixed a race condition that could prevent blobs from loading.
- Add a more obvious dismissal button to the migration screen.
- Added a pressed state to the Mark all notifications as read button.
- Updated the Directory to show useful information like the number of followers and hashtags the user has used recently.
- Updated the design of follow messages to display a smaller follow button.
- Fixed a case where tapping the Reset Forked Feed Protection button would cause the app to hang.