### PR TITLE
Disable the onboarding bio step because it doesn't work on iOS 15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.7] 2022-08-19
+
+- Fixed an issue where onboarding could get stuck on the bio step
+
 ## [1.2.6] 2022-08-03
 
 - Added beta support for replicating via room servers. #783

--- a/Source/Onboarding/OnboardingViewController.swift
+++ b/Source/Onboarding/OnboardingViewController.swift
@@ -31,7 +31,7 @@ class OnboardingViewController: UINavigationController, OnboardingStepDelegate {
 //        DirectoryOnboardingStep(),      // Bot and API calls
         PhotoOnboardingStep(),
         PhotoConfirmOnboardingStep(),   // Bot and API calls
-        BioOnboardingStep(),            // Bot and API calls
+//        BioOnboardingStep(),            // Bot and API calls
         DoneOnboardingStep(),           // Bot and API calls
     ]
 
@@ -40,7 +40,7 @@ class OnboardingViewController: UINavigationController, OnboardingStepDelegate {
         // DirectoryOnboardingStep(),      // Bot and API calls
         // PhotoOnboardingStep(),
         // PhotoConfirmOnboardingStep(),   // Bot and API calls
-        BioOnboardingStep(),            // Bot and API calls
+//        BioOnboardingStep(),            // Bot and API calls
         DoneOnboardingStep(),           // Bot and API calls
     ]
 

--- a/Source/Onboarding/Steps/PhotoOnboardingStep.swift
+++ b/Source/Onboarding/Steps/PhotoOnboardingStep.swift
@@ -59,7 +59,7 @@ class PhotoOnboardingStep: OnboardingStep, UIImagePickerControllerDelegate, UINa
     }
 
     override func performSecondaryAction(sender button: UIButton) {
-        self.next(.bio)
+        self.next(.done)
     }
 
     @objc override func performPrimaryAction(sender button: UIButton) {


### PR DESCRIPTION
Fixes an issue where bio screen in onboarding would freeze on iOS 15.6. By removing the bio onboarding screen.