### PR TITLE
Trigger refresh on view profile

### DIFF
--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -96,6 +96,8 @@ protocol Bot: AnyObject {
     ///   - completion: a handler called with the result of the operation.
     func sync(queue: DispatchQueue, peers: [MultiserverAddress], completion: @escaping SyncCompletion)
     
+    func replicate(feed: FeedIdentifier)
+    
     /// Connect to the SSB peer at the given address.
     func connect(to address: MultiserverAddress)
 

--- a/Source/Controller/AboutViewController.swift
+++ b/Source/Controller/AboutViewController.swift
@@ -49,6 +49,7 @@ class AboutViewController: ContentViewController {
         super.init(scrollable: false)
         self.aboutView.update(with: about)
         self.addActions()
+        self.triggerRefresh()
     }
 
     convenience init(with about: About) {
@@ -99,6 +100,11 @@ class AboutViewController: ContentViewController {
             self?.about = about
             self?.update(with: about)
         }
+    }
+    
+    // tells the go-bot to do a one time request to refresh this identity from peers.
+    private func triggerRefresh(){
+        Bots.current.replicate(feed: self.identity)
     }
 
     private func loadFeed() {

--- a/Source/FakeBot/FakeBot.swift
+++ b/Source/FakeBot/FakeBot.swift
@@ -138,7 +138,9 @@ class FakeBot: Bot {
     func markAllMessageAsRead(queue: DispatchQueue, completion: @escaping VoidCompletion) { }
 
     func numberOfUnreadReports(queue: DispatchQueue, completion: @escaping CountCompletion) { }
-
+    
+    func replicate(feed: FeedIdentifier) { }
+    
     required init() {}
     static let shared = FakeBot()
 

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -474,6 +474,16 @@ class GoBot: Bot {
         completion(nil, elapsed, numberOfMessages)
         NotificationCenter.default.post(name: .didSync, object: nil)
     }
+    
+    // refresh specific feed - when we view a profile we should ask gobot to refresh that feed. It might not get back in time
+    // to update what the user sees but it'll help. In particular this will happen with pubs.
+    
+    func replicate(feed: FeedIdentifier) {
+        userInitiatedQueue.async {
+            self.bot.replicate(feed: feed)
+        }
+    }
+    
 
     // MARK: Refresh
 


### PR DESCRIPTION
when you view a profile, we tell gobot to refresh the feed of that profile. Even if you're not following the person or they are in your network.

This doesn't refresh the UI, that'd be nice but more work. 