### PR TITLE
Fix accounts on test network

### DIFF
--- a/Analytics/Sources/Delivery/Analytics+Bot.swift
+++ b/Analytics/Sources/Delivery/Analytics+Bot.swift
@@ -101,8 +101,8 @@ public extension Analytics {
         service.track(
             event: .did,
             element: .bot,
-            name: "814_fix_complete",
-            params: ["error": error.localizedDescription]
+            name: "814_fix_error",
+            params: ["message": error.localizedDescription]
         )
     }
     

--- a/Analytics/Sources/Delivery/Analytics+Bot.swift
+++ b/Analytics/Sources/Delivery/Analytics+Bot.swift
@@ -88,6 +88,27 @@ public extension Analytics {
         ]
         service.track(event: .did, element: .bot, name: "beta1_migration_dismiss", params: params)
     }
+    
+    func trackDidStart814Fix() {
+        service.track(event: .did, element: .bot, name: "814_fix_start")
+    }
+    
+    func trackDidComplete814Fix() {
+        service.track(event: .did, element: .bot, name: "814_fix_complete")
+    }
+    
+    func trackDidFail814Fix(error: Error) {
+        service.track(
+            event: .did,
+            element: .bot,
+            name: "814_fix_complete",
+            params: ["error": error.localizedDescription]
+        )
+    }
+    
+    func trackDidSkip814Fix() {
+        service.track(event: .did, element: .bot, name: "814_fix_skip")
+    }
 
     func trackBotDidChangeHomeFeedStrategy(to strategyName: String) {
         let params = ["strategy": strategyName]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] 2022-09-05
+
+- Added support for EBT replication algorithm. #721
+- Added a migration script for a small number of users whose accounts were created on the test network. #817
+
 ## [1.3.2] 2022-08-27
 
 - Fixed a bug where new profiles were being created on the test network.

--- a/Planetary.xcodeproj/project.pbxproj
+++ b/Planetary.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		23CA4B93232291E1005B35E8 /* UITextView+NSMutableAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539FD4B022C19F66005A4DF2 /* UITextView+NSMutableAttributedString.swift */; };
 		23CF345722099E5D00F46A54 /* InvalidVoteMissingIdentifier.json in Resources */ = {isa = PBXBuildFile; fileRef = 23CF345622099E5D00F46A54 /* InvalidVoteMissingIdentifier.json */; };
 		23D8CE272253DB29001EB7D5 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D8CE262253DB29001EB7D5 /* Address.swift */; };
-		23D8E2C022033D31004776EA /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		23D8E2C022033D31004776EA /* (null) in Resources */ = {isa = PBXBuildFile; };
 		23E76A5623F2F0F70074F424 /* ValueTimestamp.json in Resources */ = {isa = PBXBuildFile; fileRef = 23E76A5523F2F0F70074F424 /* ValueTimestamp.json */; };
 		23E8805E22F894650074D399 /* Collection+RandomSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E8805D22F894650074D399 /* Collection+RandomSample.swift */; };
 		23E8805F22F894650074D399 /* Collection+RandomSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E8805D22F894650074D399 /* Collection+RandomSample.swift */; };
@@ -264,7 +264,7 @@
 		530F01B222DFCEED007EBAE2 /* String+IsValid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B122DFCEED007EBAE2 /* String+IsValid.swift */; };
 		530F01B422E0D3E7007EBAE2 /* TitledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B322E0D3E7007EBAE2 /* TitledToggle.swift */; };
 		530F01B622E0D930007EBAE2 /* JoinOnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530F01B522E0D930007EBAE2 /* JoinOnboardingStep.swift */; };
-		5314EF3A22EA276A0065D02A /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		5314EF3A22EA276A0065D02A /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		5314EF3B22EA27840065D02A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62A22445BE900C57A4B /* AppConfiguration.swift */; };
 		5314EF3C22EA27920065D02A /* SSBNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53362F692209108F007264CB /* SSBNetwork.swift */; };
 		5314EF3D22EA27980065D02A /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EE01F32204F66200DFDF16 /* Secret.swift */; };
@@ -694,9 +694,9 @@
 		8F6DDE5DB47CDEED56B74CB3 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EA32E74C0DFF1EF8924773F /* Pods_UnitTests.framework */; };
 		C90EBE7327E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
 		C90EBE7427E0D5C900EAE560 /* PreloadedPubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90EBE7227E0D5C900EAE560 /* PreloadedPubService.swift */; };
-		C9134DDB28184AF700595D49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C9134DDB28184AF700595D49 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C9134DE228184C2700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE128184C2700595D49 /* Support */; };
-		C9134DE328184D4200595D49 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C9134DE328184D4200595D49 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C9134DE6281854E700595D49 /* Support in Frameworks */ = {isa = PBXBuildFile; productRef = C9134DE5281854E700595D49 /* Support */; };
 		C920A3A3289AFB88009C83F3 /* PlaceholderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C920A3A2289AFB88009C83F3 /* PlaceholderModifier.swift */; };
 		C920A3A4289AFB88009C83F3 /* PlaceholderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C920A3A2289AFB88009C83F3 /* PlaceholderModifier.swift */; };
@@ -712,6 +712,10 @@
 		C9313A7D289AD9D40093AC47 /* RoomInvitationRedeemer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9313A7B289AD9D40093AC47 /* RoomInvitationRedeemer.swift */; };
 		C931927C2811CBC80001FD92 /* Beta1MigrationDescriptionText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C931927B2811CBC80001FD92 /* Beta1MigrationDescriptionText.swift */; };
 		C931927D2811CBC80001FD92 /* Beta1MigrationDescriptionText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C931927B2811CBC80001FD92 /* Beta1MigrationDescriptionText.swift */; };
+		C937882F28C15186003FCCC2 /* About+ViewDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C937882E28C15186003FCCC2 /* About+ViewDatabase.swift */; };
+		C937883028C15186003FCCC2 /* About+ViewDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C937882E28C15186003FCCC2 /* About+ViewDatabase.swift */; };
+		C937883328C154BF003FCCC2 /* Pub+ViewDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C937883228C154BF003FCCC2 /* Pub+ViewDatabase.swift */; };
+		C937883428C154BF003FCCC2 /* Pub+ViewDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C937883228C154BF003FCCC2 /* Pub+ViewDatabase.swift */; };
 		C93A4B3827987BCB009F963D /* GoBotIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93A4B3727987BCB009F963D /* GoBotIntegrationTests.swift */; };
 		C93A4B3A279894AC009F963D /* GoBotTestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93A4B39279894AC009F963D /* GoBotTestExtensions.swift */; };
 		C93A4B3C2798B711009F963D /* KeyValueWithReceivedSeq.json in Resources */ = {isa = PBXBuildFile; fileRef = C93A4B3B2798B711009F963D /* KeyValueWithReceivedSeq.json */; };
@@ -926,7 +930,7 @@
 		C9724BB42809EC4F000EBCCD /* DebugOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531587B1229F33F00004E2B1 /* DebugOnboardingViewController.swift */; };
 		C9724BB52809EC57000EBCCD /* DebugUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533F4050225E9E010060B4B9 /* DebugUIViewController.swift */; };
 		C9724BB62809EC61000EBCCD /* DebugPostsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531EC40B230F6B9E001A25AD /* DebugPostsViewController.swift */; };
-		C9724BB72809EC68000EBCCD /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		C9724BB72809EC68000EBCCD /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C9724BB82809EC77000EBCCD /* SecretViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FCAFDD22051C88009E9E82 /* SecretViewController.swift */; };
 		C9724BB92809EC7B000EBCCD /* BotViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5396A62622444A1500C57A4B /* BotViewController.swift */; };
 		C9724BBA2809ECA2000EBCCD /* StatisticsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5DB7CB24AC01D9008DCB81 /* StatisticsOperation.swift */; };
@@ -1033,6 +1037,8 @@
 		C9C3788E27C6CCD400238B58 /* BotStatisticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3788D27C6CCD400238B58 /* BotStatisticsService.swift */; };
 		C9C3788F27C6CCD400238B58 /* BotStatisticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3788D27C6CCD400238B58 /* BotStatisticsService.swift */; };
 		C9C3789127C6CCFB00238B58 /* GoBotStatisticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3789027C6CCFB00238B58 /* GoBotStatisticsServiceTests.swift */; };
+		C9C9BB5128C1092C00042F2F /* Fix814AccountsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C9BB5028C1092C00042F2F /* Fix814AccountsHelper.swift */; };
+		C9C9BB5228C1092C00042F2F /* Fix814AccountsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C9BB5028C1092C00042F2F /* Fix814AccountsHelper.swift */; };
 		C9D1EACA2832A0230092E098 /* AttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC02832A0220092E098 /* AttributedStringTests.swift */; };
 		C9D1EACB2832A0230092E098 /* IdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC12832A0220092E098 /* IdentifierTests.swift */; };
 		C9D1EACC2832A0230092E098 /* BlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D1EAC22832A0230092E098 /* BlobTests.swift */; };
@@ -1647,6 +1653,8 @@
 		C9313A7B289AD9D40093AC47 /* RoomInvitationRedeemer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomInvitationRedeemer.swift; sourceTree = "<group>"; };
 		C931927B2811CBC80001FD92 /* Beta1MigrationDescriptionText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beta1MigrationDescriptionText.swift; sourceTree = "<group>"; };
 		C933908F27FB5498007B5FD8 /* GoSSB.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoSSB.xcframework; path = Frameworks/GoSSB.xcframework; sourceTree = "<group>"; };
+		C937882E28C15186003FCCC2 /* About+ViewDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "About+ViewDatabase.swift"; sourceTree = "<group>"; };
+		C937883228C154BF003FCCC2 /* Pub+ViewDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Pub+ViewDatabase.swift"; sourceTree = "<group>"; };
 		C93A4B3727987BCB009F963D /* GoBotIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBotIntegrationTests.swift; sourceTree = "<group>"; };
 		C93A4B39279894AC009F963D /* GoBotTestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBotTestExtensions.swift; sourceTree = "<group>"; };
 		C93A4B3B2798B711009F963D /* KeyValueWithReceivedSeq.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = KeyValueWithReceivedSeq.json; sourceTree = "<group>"; };
@@ -1707,6 +1715,7 @@
 		C9C3788D27C6CCD400238B58 /* BotStatisticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BotStatisticsService.swift; sourceTree = "<group>"; };
 		C9C3789027C6CCFB00238B58 /* GoBotStatisticsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoBotStatisticsServiceTests.swift; sourceTree = "<group>"; };
 		C9C8F0EB27E8EC3400F78ABC /* GoSSB.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GoSSB.xcodeproj; path = GoSSB/GoSSB.xcodeproj; sourceTree = "<group>"; };
+		C9C9BB5028C1092C00042F2F /* Fix814AccountsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fix814AccountsHelper.swift; sourceTree = "<group>"; };
 		C9D1EAC02832A0220092E098 /* AttributedStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringTests.swift; sourceTree = "<group>"; };
 		C9D1EAC12832A0220092E098 /* IdentifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierTests.swift; sourceTree = "<group>"; };
 		C9D1EAC22832A0230092E098 /* BlobTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlobTests.swift; sourceTree = "<group>"; };
@@ -1809,7 +1818,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BC2974C2804B9DE00C0CD81 /* SQLite in Frameworks */,
-				5314EF3A22EA276A0065D02A /* BuildFile in Frameworks */,
+				5314EF3A22EA276A0065D02A /* (null) in Frameworks */,
 				664DA6493E3CC0506BD71355 /* Pods_APITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2116,6 +2125,7 @@
 				0AC10DE5246DBDDD00CCA22A /* KnownPubsTableViewDataSource.swift */,
 				C9C3787727C6881000238B58 /* ConnectedPeerListCoordinator.swift */,
 				C9EE7BD927FF3A5D00748106 /* Beta1MigrationCoordinator.swift */,
+				C9C9BB5028C1092C00042F2F /* Fix814AccountsHelper.swift */,
 				C982CBD02833ED1C00D8963F /* FeedStrategySelectionViewController.swift */,
 				C9EBE0462880C2C900A2CF51 /* HelpDrawerCoordinator.swift */,
 				C9313A77289A89580093AC47 /* RoomListCoordinator.swift */,
@@ -2167,6 +2177,8 @@
 				2334D04421F7786600AB28E2 /* GoBotInternal.swift */,
 				531D0A1221EACC0A008E40A8 /* GoBotViewController.swift */,
 				233A8F89220138F600CE01CE /* ViewDatabase.swift */,
+				C937883228C154BF003FCCC2 /* Pub+ViewDatabase.swift */,
+				C937882E28C15186003FCCC2 /* About+ViewDatabase.swift */,
 				236761582450681800A97140 /* ViewDatabase+Pagination.swift */,
 				231314CB2237ACDB0000C989 /* ViewDatabaseSchema.sql */,
 				0ACE91A1243D740C00EFB4E9 /* GoBotError.swift */,
@@ -3404,7 +3416,7 @@
 			mainGroup = 5344D82221C4649700704A34;
 			packageReferences = (
 				C969F434282C79CC00FF6FE3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
-				5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */,
+				5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */,
 				5B5BB8DB283E8BFC00D99AB8 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 			);
 			productRefGroup = 5344D82C21C4649700704A34 /* Products */;
@@ -3491,7 +3503,7 @@
 				5316E95B21FFD4980053832E /* InvalidChannel.json in Resources */,
 				C924412F278DDECE00592E5E /* Preload.bundle in Resources */,
 				5316E95721FFCDFF0053832E /* UnsupportedType.json in Resources */,
-				23D8E2C022033D31004776EA /* BuildFile in Resources */,
+				23D8E2C022033D31004776EA /* (null) in Resources */,
 				5316E95921FFD19F0053832E /* Invalid.json in Resources */,
 				C9F0B6A027E2728800BE2F0E /* Generated.strings in Resources */,
 				C98A014B2790C5A900E29A97 /* Feed_big.sqlite in Resources */,
@@ -3690,7 +3702,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist",
+				$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Secrets.plist,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3895,6 +3907,7 @@
 				C9D1EACB2832A0230092E098 /* IdentifierTests.swift in Sources */,
 				C982CBD72834233700D8963F /* FeedStrategyTests.swift in Sources */,
 				237D057E23351E4600973D63 /* Hashtag.swift in Sources */,
+				C937883428C154BF003FCCC2 /* Pub+ViewDatabase.swift in Sources */,
 				C9724B682809D70F000EBCCD /* AppController+URL.swift in Sources */,
 				C9724B952809EA6D000EBCCD /* Bool+YesOrNo.swift in Sources */,
 				53EE01FC220503C400DFDF16 /* Secret.swift in Sources */,
@@ -4051,6 +4064,7 @@
 				C9724B972809EA7D000EBCCD /* Comparable+Clamped.swift in Sources */,
 				C9C3788A27C6CC3200238B58 /* XCTestCase+Combine.swift in Sources */,
 				C982CBDF28353DE700D8963F /* ContactReplyView.swift in Sources */,
+				C9C9BB5228C1092C00042F2F /* Fix814AccountsHelper.swift in Sources */,
 				C9724B662809D6EC000EBCCD /* AboutCellView.swift in Sources */,
 				C9724BC82809ED75000EBCCD /* UINavigationBar+Verse.swift in Sources */,
 				C9724BDA2809EE32000EBCCD /* SendMissionOperation.swift in Sources */,
@@ -4077,7 +4091,7 @@
 				C9724B642809D6DC000EBCCD /* NotificationCellView.swift in Sources */,
 				C9724BBE2809ECCC000EBCCD /* UITextView+Verse.swift in Sources */,
 				53E29CE022D80424008A2CB1 /* Hashtag+String.swift in Sources */,
-				C9724BB72809EC68000EBCCD /* BuildFile in Sources */,
+				C9724BB72809EC68000EBCCD /* (null) in Sources */,
 				0A64A84024735520009A5EBF /* NullPushAPI.swift in Sources */,
 				23EF5AAA249D177F00469977 /* BanListAPI.swift in Sources */,
 				53E26C5E23045D34009240B2 /* Data+Person.swift in Sources */,
@@ -4093,7 +4107,7 @@
 				C9724B182809D350000EBCCD /* AppController+Progress.swift in Sources */,
 				53B4F5FA22B8602F00027C6A /* Mention+NSAttributedString.swift in Sources */,
 				0A64A84824735717009A5EBF /* PhoneVerificationAPIService.swift in Sources */,
-				C9134DE328184D4200595D49 /* BuildFile in Sources */,
+				C9134DE328184D4200595D49 /* (null) in Sources */,
 				C9724BE72809EEA4000EBCCD /* SimplePublishView.swift in Sources */,
 				C9724B432809D4F1000EBCCD /* UIButton+Text.swift in Sources */,
 				535754F722692B59002A6989 /* BotError.swift in Sources */,
@@ -4120,7 +4134,7 @@
 				C9724BC42809ED5B000EBCCD /* Blob+UIColor.swift in Sources */,
 				C9412AEB28AEE8EB00F791A7 /* RoomAliasRegistrationCoordinator.swift in Sources */,
 				C9724B782809E7C1000EBCCD /* AppController+Push.swift in Sources */,
-				C9134DDB28184AF700595D49 /* BuildFile in Sources */,
+				C9134DDB28184AF700595D49 /* (null) in Sources */,
 				C9724B262809D426000EBCCD /* HomeViewController.swift in Sources */,
 				C9724BE02809EE5A000EBCCD /* Tappable.swift in Sources */,
 				C9F1C84927C92842005A3228 /* Localizable.swift in Sources */,
@@ -4168,6 +4182,7 @@
 				2D5DC59E28B05A6F00E064A6 /* RandomAlgorithm.swift in Sources */,
 				C9724B9D2809EAA4000EBCCD /* RedeemInviteViewController.swift in Sources */,
 				0A4870F82492C05D00BCD063 /* AsynchronousBlockOperation.swift in Sources */,
+				C937883028C15186003FCCC2 /* About+ViewDatabase.swift in Sources */,
 				5336611522D9669E00100707 /* UIColor+UIImage.swift in Sources */,
 				C941A6E527ECBE2A009B38C9 /* PreloadedBlobService.swift in Sources */,
 				2388897D22086A650030CB92 /* GoBotInternal.swift in Sources */,
@@ -4516,6 +4531,7 @@
 				5396A6352248377900C57A4B /* UIColor+Verse.swift in Sources */,
 				53C2B1342295AC000018D0A8 /* AppConfiguration+Data.swift in Sources */,
 				53E26C5A23039597009240B2 /* Dictionary+Transform.swift in Sources */,
+				C9C9BB5128C1092C00042F2F /* Fix814AccountsHelper.swift in Sources */,
 				C9412AEA28AEE8EB00F791A7 /* RoomAliasRegistrationCoordinator.swift in Sources */,
 				530F01AC22DEAE6F007EBAE2 /* BioOnboardingStep.swift in Sources */,
 				0ABCA8F92436769400D7F39C /* APIError.swift in Sources */,
@@ -4819,6 +4835,7 @@
 				53362F672208C2B3007264CB /* AppController+Lifecycle.swift in Sources */,
 				53E29CDD22D7EC6F008A2CB1 /* Hashtag+String.swift in Sources */,
 				0AD8D635240EFF8800D87A95 /* RedeemInviteViewController.swift in Sources */,
+				C937882F28C15186003FCCC2 /* About+ViewDatabase.swift in Sources */,
 				53575509226A3113002A6989 /* KeyValueTableViewDataSource.swift in Sources */,
 				531B92B122CAC203005D5255 /* PostButtonsView.swift in Sources */,
 				531D0A1321EACC0A008E40A8 /* GoBotViewController.swift in Sources */,
@@ -4858,6 +4875,7 @@
 				C9F5381F286B78240015A146 /* UniversalSearchResultsView.swift in Sources */,
 				531B92B922CD128F005D5255 /* UITextView+Mention.swift in Sources */,
 				533EDBF42389BBE8008B3565 /* Blob+UIColor.swift in Sources */,
+				C937883328C154BF003FCCC2 /* Pub+ViewDatabase.swift in Sources */,
 				8D180359234F5E77004E30AA /* IconButton.swift in Sources */,
 				0A487105249D1B3600BCD063 /* KeyValuePaginatedCollectionViewDelegate.swift in Sources */,
 				530F01A222DEADD9007EBAE2 /* PhoneOnboardingStep.swift in Sources */,
@@ -5673,7 +5691,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */ = {
+		5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stephencelis/SQLite.swift";
 			requirement = {
@@ -5724,17 +5742,17 @@
 		};
 		5BC2974528048AD800C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
 			productName = SQLite;
 		};
 		5BC297492804B98C00C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
 			productName = SQLite;
 		};
 		5BC2974B2804B9DE00C0CD81 /* SQLite */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite.swift" */;
+			package = 5BC2974428048AD800C0CD81 /* XCRemoteSwiftPackageReference "SQLite" */;
 			productName = SQLite;
 		};
 		5BE28DFC27CD7BA1004D7D27 /* Analytics */ = {

--- a/Shared/Extensions/UIViewController+Alert.swift
+++ b/Shared/Extensions/UIViewController+Alert.swift
@@ -108,6 +108,35 @@ extension UIViewController: AlertRouter {
 
         self.choose(from: [confirm, cancel], title: title, message: message, sourceView: sourceView)
     }
+    
+    /// An async version of `confirm(...)` that returns `true` if the user confirmed the action and false otherwise.
+    @MainActor
+    func confirm(
+        from sourceView: UIView? = nil,
+        title: String? = nil,
+        message: String,
+        isDestructive: Bool = false,
+        cancelTitle: String = Text.cancel.text,
+        confirmTitle: String = Text.ok.text
+    ) async -> Bool {
+        
+        await withCheckedContinuation { continuation in
+            confirm(
+                from: sourceView,
+                title: title,
+                message: message,
+                isDestructive: isDestructive,
+                cancelTitle: cancelTitle,
+                cancelClosure: {
+                    continuation.resume(with: .success(false))
+                },
+                confirmTitle: confirmTitle,
+                confirmClosure: {
+                    continuation.resume(with: .success(true))
+                }
+            )
+        }
+    }
 
     /// Convenience func to present multiple alert actions in an iPhone
     /// and iPad compatible way.  UIAlertController management can be tedious

--- a/Source/App/AppConfiguration+Keychain.swift
+++ b/Source/App/AppConfiguration+Keychain.swift
@@ -16,7 +16,7 @@ extension AppConfigurations {
 
     static func add(_ configuration: AppConfiguration) {
         if let existingIndex = Keychain.configurations.firstIndex(where: {
-            configuration.identity == $0.identity}) {
+            configuration.id == $0.id }) {
             Keychain.configurations[existingIndex] = configuration
         } else {
             Keychain.configurations += [configuration]

--- a/Source/App/AppConfiguration.swift
+++ b/Source/App/AppConfiguration.swift
@@ -233,12 +233,7 @@ extension AppConfiguration {
     }
     
     var isCurrent: Bool {
-        self.identity == AppConfiguration.current?.identity
-    }
-
-    static func isCurrent(_ identity: Identity) -> Bool {
-        guard let configuration = self.current else { return false }
-        return configuration.identity == identity
+        self.id == AppConfiguration.current?.id
     }
 }
 

--- a/Source/App/AppConfiguration.swift
+++ b/Source/App/AppConfiguration.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CryptoKit
 
 /// Represents the set of high-level properties governing the app, like the user's identity, network key, etc.
 /// These configurations can be switched out at runtime much like logging in/out of an account.
@@ -16,7 +17,18 @@ import Foundation
 /// one can be in use at a time.
 ///
 /// The AppConfiguration is also used to prevent feed forks in some cases by storing the number of published messages.
-class AppConfiguration: NSObject, NSCoding {
+class AppConfiguration: NSObject, NSCoding, Identifiable {
+    
+    var id: String {
+        let idComponents: [String] = [
+            secret.identity,
+            name,
+            hmacKey?.string ?? "null",
+            network?.string ?? "null",
+        ]
+        let idString = idComponents.joined(separator: "&@!(#$*")
+        return SHA256.hash(data: idString.data(using: .utf8)!).description
+    }
 
     // MARK: Editable properties
 

--- a/Source/Controller/Fix814AccountsHelper.swift
+++ b/Source/Controller/Fix814AccountsHelper.swift
@@ -1,0 +1,103 @@
+//
+//  Fix814AccountsHelper.swift
+//  Planetary
+//
+//  Created by Matthew Lorentz on 9/1/22.
+//  Copyright © 2022 Verse Communications Inc. All rights reserved.
+//
+
+import Foundation
+import Analytics
+import Logger
+
+enum Fix814AccountsHelper {
+
+    /// This contains a fix for https://github.com/planetary-social/planetary-ios/issues/814, where all new profiles
+    /// (who opted to follow the Planetary account during onboarding) were erroneously being created on the Planetary
+    /// Test Network and not the main SSB network.
+    ///
+    /// This function will detect these accounts, prompt for consent from the user, and then copy their posts
+    /// to a new feed on the main network.
+    static func fix814Account(
+        _ configuration: AppConfiguration,
+        appController: AppController,
+        userDefaults: UserDefaults
+    ) async throws -> AppConfiguration? {
+        guard let bot = configuration.bot as? GoBot else {
+            return nil
+        }
+        
+        let hasPromptedKey = "hasPromptedFor814Fix-\(configuration.id)"
+        let hasPromptedAlready = userDefaults.bool(forKey: hasPromptedKey)
+        
+        try await bot.login(config: configuration)
+        
+        // Check if account was created on the test network between the given dates.
+        guard !hasPromptedAlready,
+            configuration.network == Environment.Networks.test.key,
+            let identityCreationDate = try? bot.database.currentUserCreatedDate(),
+            identityCreationDate > Date(timeIntervalSince1970: 1_661_265_000), // 2022-08-23 10:30am
+            identityCreationDate < Date(timeIntervalSince1970: 1_662_587_210), // 2022-09-07
+            let publishedMessages = try? bot.database.publishedMessagesForCurrentUser() else {
+            try await bot.logout()
+            return nil
+        }
+        
+        Log.info("Running 814 fix. Found \(publishedMessages.count) published messages")
+        
+        try await bot.logout()
+        
+        // Confirm with the user
+        defer {
+            userDefaults.set(true, forKey: hasPromptedKey)
+            userDefaults.synchronize()
+        }
+        let confirmed = await appController.confirm(
+            message: Text.confirmCopyToMainNetwork.text
+        )
+        if !confirmed {
+            let areYouSure = await appController.confirm(
+                message: Text.confirmSkipCopyToMainNetwork.text
+            )
+            if areYouSure {
+                Log.info("User opted out of 814 fix")
+                Analytics.shared.trackDidSkip814Fix()
+                return nil
+            }
+        }
+        
+        Log.info("User opted into 814 fix")
+        Analytics.shared.trackDidStart814Fix()
+        
+        do {
+            // create new configuration on the main network
+            let newConfiguration = AppConfiguration(with: configuration.secret)
+            newConfiguration.name = configuration.name + "-814fixed"
+            newConfiguration.joinedPlanetarySystem = configuration.joinedPlanetarySystem
+            newConfiguration.bot = bot
+            newConfiguration.ssbNetwork = Environment.Networks.mainNet
+            
+            try await bot.login(config: newConfiguration)
+            
+            // copy published messages
+            for message in publishedMessages {
+                if let codableMessage = message.value.content.codableContent {
+                    _ = try await bot.publish(content: codableMessage)
+                }
+            }
+            
+            Log.info("Finished copying messages. Applying configuration.")
+            
+            newConfiguration.apply()
+            
+            Log.info("814 fix complete.")
+            Analytics.shared.trackDidComplete814Fix()
+            return newConfiguration
+        } catch {
+            Log.info("814 fix failed.")
+            Log.optional(error)
+            Analytics.shared.trackDidFail814Fix(error: error)
+            throw error
+        }
+    }
+}

--- a/Source/Controller/Fix814AccountsHelper.swift
+++ b/Source/Controller/Fix814AccountsHelper.swift
@@ -30,11 +30,14 @@ enum Fix814AccountsHelper {
         let hasPromptedKey = "hasPromptedFor814Fix-\(configuration.id)"
         let hasPromptedAlready = userDefaults.bool(forKey: hasPromptedKey)
         
+        guard !hasPromptedAlready else {
+            return nil
+        }
+        
         try await bot.login(config: configuration)
         
         // Check if account was created on the test network between the given dates.
-        guard !hasPromptedAlready,
-            configuration.network == Environment.Networks.test.key,
+        guard configuration.network == Environment.Networks.test.key,
             let identityCreationDate = try? bot.database.currentUserCreatedDate(),
             identityCreationDate > Date(timeIntervalSince1970: 1_661_265_000), // 2022-08-23 10:30am
             identityCreationDate < Date(timeIntervalSince1970: 1_662_587_210), // 2022-09-07
@@ -88,7 +91,7 @@ enum Fix814AccountsHelper {
                 }
             }
             
-            Log.info("Finished copying messages. Applying configuration.")
+            Log.info("Finished copying \(newConfiguration.numberOfPublishedMessages) messages. Applying configuration.")
             
             newConfiguration.apply()
             

--- a/Source/Controller/Fix814AccountsHelper.swift
+++ b/Source/Controller/Fix814AccountsHelper.swift
@@ -43,7 +43,7 @@ enum Fix814AccountsHelper {
             return nil
         }
         
-        Log.info("Running 814 fix. Found \(publishedMessages.count) published messages")
+        Log.info("Prompting for 814 fix. Found \(publishedMessages.count) published messages")
         
         try await bot.logout()
         
@@ -56,10 +56,12 @@ enum Fix814AccountsHelper {
             message: Text.confirmCopyToMainNetwork.text
         )
         if !confirmed {
-            let areYouSure = await appController.confirm(
-                message: Text.confirmSkipCopyToMainNetwork.text
+            let secondConfirm = await appController.confirm(
+                message: Text.confirmSkipCopyToMainNetwork.text,
+                cancelTitle: Text.yes.text,
+                confirmTitle: Text.no.text
             )
-            if areYouSure {
+            if !secondConfirm {
                 Log.info("User opted out of 814 fix")
                 Analytics.shared.trackDidSkip814Fix()
                 return nil

--- a/Source/Controller/LaunchViewController.swift
+++ b/Source/Controller/LaunchViewController.swift
@@ -142,30 +142,30 @@ class LaunchViewController: UIViewController {
     }
 
     func handleLoginFailure(with error: Error, configuration: AppConfiguration) {
-        guard let network = configuration.network else { return }
-        guard let bot = configuration.bot else { return }
-        let secret = configuration.secret
-        
         Log.error("Bot.login failed")
         Log.optional(error)
         CrashReporting.shared.reportIfNeeded(
             error: error,
             metadata: [
                 "action": "login-from-launch",
-                "network": network,
-                "identity": secret.identity
+                "network": configuration.network?.string ?? "",
+                "identity": configuration.secret.identity
             ]
         )
         
-        let controller = UIAlertController(title: Text.error.text,
-                                           message: Text.Error.login.text,
-                                           preferredStyle: .alert)
+        guard let bot = configuration.bot else { return }
+        
+        let controller = UIAlertController(
+            title: Text.error.text,
+            message: Text.Error.login.text,
+            preferredStyle: .alert
+        )
         let action = UIAlertAction(title: "Restart", style: .default) { _ in
             Log.debug("Restarting launch...")
-            bot.logout { err in
+            bot.logout { error in
                 // Don't report error here becuase the normal path is to actually receive
                 // a notLoggedIn error
-                Log.optional(err)
+                Log.optional(error)
                 
                 ssbDropIndexData()
                 

--- a/Source/Controller/LaunchViewController.swift
+++ b/Source/Controller/LaunchViewController.swift
@@ -98,13 +98,13 @@ class LaunchViewController: UIViewController {
         
         Task {
             login: do {
-                if let newConfiguration = try await self.fix814AccountsIfNecessary(using: configuration) {
-                    configuration = newConfiguration
+                let isMigrating = try await self.migrateIfNeeded(using: configuration)
+                if isMigrating {
                     break login
                 }
                 
-                let isMigrating = try await self.migrateIfNeeded(using: configuration)
-                if isMigrating {
+                if let newConfiguration = try await self.fix814AccountsIfNecessary(using: configuration) {
+                    configuration = newConfiguration
                     break login
                 }
                 

--- a/Source/Debug/DebugViewController.swift
+++ b/Source/Debug/DebugViewController.swift
@@ -199,7 +199,7 @@ class DebugViewController: DebugTableViewController {
                                                  valueClosure: {
                     cell in
                     cell.detailTextLabel?.text = configuration.network?.name
-                    let selected = (configuration.identity == AppConfiguration.current?.identity)
+                    let selected = (configuration.id == AppConfiguration.current?.id)
                     cell.accessoryType = selected ? .checkmark : .disclosureIndicator
                 },
                                                  actionClosure: {

--- a/Source/GoBot/About+ViewDatabase.swift
+++ b/Source/GoBot/About+ViewDatabase.swift
@@ -1,0 +1,24 @@
+//
+//  About+ViewDatabase.swift
+//  Planetary
+//
+//  Created by Matthew Lorentz on 9/1/22.
+//  Copyright © 2022 Verse Communications Inc. All rights reserved.
+//
+
+import Foundation
+import SQLite
+
+extension About {
+    init(row: Row, db: ViewDatabase) throws {
+        let abouts = db.abouts
+        let aboutID = try db.author(from: try row.get(abouts[db.colAboutID]))
+        self.init(
+            about: aboutID,
+            name: try row.get(abouts[db.colName]),
+            description: try row.get(abouts[db.colDescr]),
+            imageLink: try row.get(abouts[db.colImage]),
+            publicWebHosting: try row.get(abouts[db.colPublicWebHosting])
+        )
+    }
+}

--- a/Source/GoBot/Contact+ViewDatabase.swift
+++ b/Source/GoBot/Contact+ViewDatabase.swift
@@ -10,9 +10,15 @@ import Foundation
 import SQLite
 
 extension Contact {
-    init?(row: Row, db: ViewDatabase) throws {
+    init?(row: Row, db: ViewDatabase, useNamespacedTables: Bool = false) throws {
         if let state = try? row.get(db.colContactState) {
-            let identifier = try row.get(Expression<Identifier>("contact_identifier"))
+            
+            var identifier: Identifier
+            if useNamespacedTables {
+                identifier = try row.get(db.contactTarget[db.colAuthor])
+            } else {
+                identifier = try row.get(Expression<Identifier>("contact_identifier"))
+            }
             if state == 1 {
                 self.init(contact: identifier, following: true)
             } else if state == -1 {

--- a/Source/GoBot/KeyValue+ViewDatabase.swift
+++ b/Source/GoBot/KeyValue+ViewDatabase.swift
@@ -37,10 +37,22 @@ extension KeyValue {
         
         let db = database
         
-        let msgKey = try row.get(db.colKey)
-        let msgAuthor = try row.get(db.colAuthor)
+        let msgKey: MessageIdentifier
+        let msgAuthor: Identity
+        if useNamespacedTables {
+            msgKey = try row.get(db.msgKeys[db.colKey])
+            msgAuthor = try row.get(db.authors[db.colAuthor])
+        } else {
+            msgKey = try row.get(db.colKey)
+            msgAuthor = try row.get(db.colAuthor)
+        }
 
-        guard let value = try Value(row: row, db: db, hasMentionColumns: hasMentionColumns) else {
+        guard let value = try Value(
+            row: row,
+            db: db,
+            useNamespacedTables: useNamespacedTables,
+            hasMentionColumns: hasMentionColumns
+        ) else {
             return nil
         }
 

--- a/Source/GoBot/Pub+ViewDatabase.swift
+++ b/Source/GoBot/Pub+ViewDatabase.swift
@@ -1,0 +1,27 @@
+//
+//  Pub+ViewDatabase.swift
+//  Planetary
+//
+//  Created by Matthew Lorentz on 9/1/22.
+//  Copyright © 2022 Verse Communications Inc. All rights reserved.
+//
+
+import Foundation
+import SQLite
+
+extension Pub {
+    init(row: Row, db: ViewDatabase) throws {
+        let host = try row.get(db.colHost)
+        let port = try row.get(db.colPort)
+        let key: Identifier = try row.get(db.pubs[db.colKey])
+        
+        self.init(
+            type: .pub,
+            address: PubAddress(
+                key: key,
+                host: host,
+                port: UInt(port)
+            )
+        )
+    }
+}

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1828,6 +1828,8 @@ class ViewDatabase {
         return msgs
     }
     
+    /// Fetches all published messages for the current user in chronological order. If the message is not a supported
+    /// message type it will not show up in the returned array.
     func publishedMessagesForCurrentUser() throws -> KeyValues {
         guard let db = self.openDB else {
             throw ViewDatabaseError.notOpen
@@ -1861,10 +1863,9 @@ class ViewDatabase {
                 return nil
             }
         }
-
-        return try mapQueryToKeyValue(qry: query, useNamespacedTables: true)
     }
     
+    /// Returns the claimed post date of the current user's first published message, or nil if they have none.
     func currentUserCreatedDate() throws -> Date? {
         guard let db = self.openDB else {
             throw ViewDatabaseError.notOpen

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1857,7 +1857,7 @@ class ViewDatabase {
                     hasReplies: false
                 )
             } catch {
-                Log.optional(error)
+                Log.error("Error parsing published message \(row[colKey]): \(error.localizedDescription)")
                 return nil
             }
         }

--- a/Source/Localization/Text.swift
+++ b/Source/Localization/Text.swift
@@ -226,6 +226,10 @@ start using Planetary right away, but:
 """
     case areYouSure = "Are you sure?"
     case dismissMigrationEarlyMessage = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?"
+    
+    // MARK: - 814 fix strings
+    case confirmCopyToMainNetwork = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network."
+    case confirmSkipCopyToMainNetwork = "You will not be prompted to run this fix again. Are you sure you want to skip it?"
 }
 
 // MARK: - ImagePicker

--- a/Source/Localization/af-ZA.lproj/Generated.strings
+++ b/Source/Localization/af-ZA.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/ar-SA.lproj/Generated.strings
+++ b/Source/Localization/ar-SA.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/ca-ES.lproj/Generated.strings
+++ b/Source/Localization/ca-ES.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/cs-CZ.lproj/Generated.strings
+++ b/Source/Localization/cs-CZ.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/da-DK.lproj/Generated.strings
+++ b/Source/Localization/da-DK.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/de-DE.lproj/Generated.strings
+++ b/Source/Localization/de-DE.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/el-GR.lproj/Generated.strings
+++ b/Source/Localization/el-GR.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/en-US.lproj/Generated.strings
+++ b/Source/Localization/en-US.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/en.lproj/Generated.strings
+++ b/Source/Localization/en.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/es-AR.lproj/Generated.strings
+++ b/Source/Localization/es-AR.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/es-ES.lproj/Generated.strings
+++ b/Source/Localization/es-ES.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "¿Estás seguro?";
 "Text.dismissMigrationEarlyMessage" = "Esta pantalla se cerrará y podrás usar Planetary mientras tus datos se descargan en segundo plano. ¿Estás seguro?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/es-UY.lproj/Generated.strings
+++ b/Source/Localization/es-UY.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "¿Estás seguro?";
 "Text.dismissMigrationEarlyMessage" = "Esta pantalla se cerrará y podrás usar Planetary mientras tus datos se descargan en segundo plano. ¿Estás seguro?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/es.lproj/Generated.strings
+++ b/Source/Localization/es.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/fi-FI.lproj/Generated.strings
+++ b/Source/Localization/fi-FI.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/fr-FR.lproj/Generated.strings
+++ b/Source/Localization/fr-FR.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/he-IL.lproj/Generated.strings
+++ b/Source/Localization/he-IL.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/hu-HU.lproj/Generated.strings
+++ b/Source/Localization/hu-HU.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/it-IT.lproj/Generated.strings
+++ b/Source/Localization/it-IT.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/ja-JP.lproj/Generated.strings
+++ b/Source/Localization/ja-JP.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/ko-KR.lproj/Generated.strings
+++ b/Source/Localization/ko-KR.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/mi-NZ.lproj/Generated.strings
+++ b/Source/Localization/mi-NZ.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/nl-NL.lproj/Generated.strings
+++ b/Source/Localization/nl-NL.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/no-NO.lproj/Generated.strings
+++ b/Source/Localization/no-NO.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/pl-PL.lproj/Generated.strings
+++ b/Source/Localization/pl-PL.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Czy na pewno?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/pl.lproj/Generated.strings
+++ b/Source/Localization/pl.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/pt-BR.lproj/Generated.strings
+++ b/Source/Localization/pt-BR.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• você apenas conseguirá postar algo ou seguir alguém quando o feed completo for baixado\n\n• é possível que apenas consiga visualizar todas as mensagens anteriores quando elas forem baixadas.";
 "Text.areYouSure" = "Tem certeza?";
 "Text.dismissMigrationEarlyMessage" = "Esta tela será descartada e você poderá usar o Planetary enquanto seus dados continuam sendo baixados em segundo plano. Tem certeza?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Tem certeza de que deseja ignorar {{ name }}? Vocês não conseguirão mais ver o conteúdo um do outro nem conseguirão entrar em contato um com o outro. Esta ação será publicamente visível.";
 "Blocking.buttonTitle" = "Sim, ignorar {{ name }}";

--- a/Source/Localization/pt-PT.lproj/Generated.strings
+++ b/Source/Localization/pt-PT.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/ro-RO.lproj/Generated.strings
+++ b/Source/Localization/ro-RO.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/ru-RU.lproj/Generated.strings
+++ b/Source/Localization/ru-RU.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/sr-SP.lproj/Generated.strings
+++ b/Source/Localization/sr-SP.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/sv-SE.lproj/Generated.strings
+++ b/Source/Localization/sv-SE.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/tr-TR.lproj/Generated.strings
+++ b/Source/Localization/tr-TR.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/uk-UA.lproj/Generated.strings
+++ b/Source/Localization/uk-UA.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/vi-VN.lproj/Generated.strings
+++ b/Source/Localization/vi-VN.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/zh-CN.lproj/Generated.strings
+++ b/Source/Localization/zh-CN.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Localization/zh-TW.lproj/Generated.strings
+++ b/Source/Localization/zh-TW.lproj/Generated.strings
@@ -144,6 +144,8 @@
 "Text.beta1Disclaimers" = "\n• you won't be able to post or follow until your whole feed is downloaded\n\n• you may not see all previous messages until they are downloaded.";
 "Text.areYouSure" = "Are you sure?";
 "Text.dismissMigrationEarlyMessage" = "This screen will dismiss and you can use Planetary while your data continues downloading in the background. Are you sure?";
+"Text.confirmCopyToMainNetwork" = "Due to a bug your profile was created on Planetary's test network instead of the main SSB network. The app will now copy your profile to the main network.";
+"Text.confirmSkipCopyToMainNetwork" = "You will not be prompted to run this fix again. Are you sure you want to skip it?";
 
 "Blocking.alertTitle" = "Are you sure you want to ignore {{ name }}? You will no longer see each other's content or be able to contact each other. This will be publicly visible.";
 "Blocking.buttonTitle" = "Yes, ignore {{ name }}";

--- a/Source/Model/Address.swift
+++ b/Source/Model/Address.swift
@@ -13,7 +13,7 @@ import Logger
 /// Replaces the old 'pub' message type (`Pub` in Planetary code.
 ///
 /// https://github.com/ssbc/ssb-device-address
-struct Address: Codable {
+struct Address: ContentCodable {
     
     let type: ContentType
     

--- a/Source/Model/Content.swift
+++ b/Source/Model/Content.swift
@@ -64,6 +64,13 @@ struct Content: Codable {
         self.typeException = nil
         self.about = about
     }
+    
+    init(from pub: Pub) {
+        self.type = .pub
+        self.typeString = "pub"
+        self.typeException = nil
+        self.pub = pub
+    }
 
     /// The first responsibility of this decoder is to ensure that
     /// it never throws even when the supplied data does not contain
@@ -123,7 +130,7 @@ struct Content: Codable {
                 case .pub: self.pub = try Pub(from: decoder)
                 case .post: self.post = try Post(from: decoder)
                 case .vote: self.vote = try ContentVote(from: decoder)
-                default: ()
+                case .unknown, .unsupported: ()
             }
         } catch {
             self.contentException = error.localizedDescription
@@ -144,6 +151,19 @@ struct Content: Codable {
     var isContact: Bool { self.isValid && self.type == .contact && self.contact != nil }
     var isPost: Bool { self.isValid && self.type == .post && self.post != nil }
     var isVote: Bool { self.isValid && self.type == .vote && self.vote != nil }
+    
+    var codableContent: ContentCodable? {
+        switch type {
+        case .about: return about
+        case .address: return address
+        case .contact: return contact
+        case .dropContentRequest: return dropContentRequest
+        case .pub: return pub
+        case .post: return post
+        case .vote: return vote
+        case .unknown, .unsupported: return nil
+        }
+    }
 }
 
 // TODO it seems valuable to perform operations on [Content]

--- a/Source/Model/Identifier.swift
+++ b/Source/Model/Identifier.swift
@@ -122,18 +122,13 @@ extension Identifier {
     // TODO: this is a iOS13 specific way to do sha25 hashing....
     // TODO: also it retuns a hex string but i have spent to much time on this already
     var sha256hash: String {
-        if #available(iOS 13.0, *) {
-            let input = self.data(using: .utf8)!
-            let hashed = SHA256.hash(data: input)
-            // using description is silly but i couldnt figure out https://developer.apple.com/documentation/cryptokit/sha256digest Accessing Underlying Storage
-            let descr = hashed.description
-            let prefix = "SHA256 digest: "
-            guard descr.hasPrefix(prefix) else { fatalError("oh gawd whhyyyy") }
-            return String(descr.dropFirst(prefix.count))
-        } else {
-            // https://augmentedcode.io/2018/04/29/hashing-data-using-commoncrypto/ ?
-            fatalError("TODO: get CommonCrypto method to work or find another swift 5 method")
-        }
+        let input = self.data(using: .utf8)!
+        let hashed = SHA256.hash(data: input)
+        // using description is silly but i couldnt figure out https://developer.apple.com/documentation/cryptokit/sha256digest Accessing Underlying Storage
+        let descr = hashed.description
+        let prefix = "SHA256 digest: "
+        guard descr.hasPrefix(prefix) else { fatalError("oh gawd whhyyyy") }
+        return String(descr.dropFirst(prefix.count))
     }
 }
 

--- a/Source/Onboarding/OnboardingViewController.swift
+++ b/Source/Onboarding/OnboardingViewController.swift
@@ -130,6 +130,7 @@ class OnboardingViewController: UINavigationController, OnboardingStepDelegate {
 
     private func done() {
         // AppController.shared.showDirectoryViewController()
+        Analytics.shared.trackOnboardingEnd()
         AppController.shared.showMainViewController()
     }
 


### PR DESCRIPTION
This adds a migration flow at app launch that tries to detect users whose accounts were affected by #814 and fix them by copying their feed into a new identity on the main network.