### PR TITLE
Bugfix/reports from blocked users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Filter blocked users from the notifications screen. #824
+
 ## [1.3.4]
 
 - Filter posts from followed users in the Discover feed when the Random algorithm is selected. #822

--- a/Source/Bot/Bot.swift
+++ b/Source/Bot/Bot.swift
@@ -406,9 +406,17 @@ extension Bot {
             }
         }
     }
-    
-    func reports(completion: @escaping (([Report], Error?) -> Void)) {
-        self.reports(queue: .main, completion: completion)
+
+    func reports() async throws -> [Report] {
+        try await withCheckedThrowingContinuation { continuation in
+            reports(queue: DispatchQueue.global(qos: .background)) { reports, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: reports)
+                }
+            }
+        }
     }
 
     /// Returns the number of reports newer than a particular report (offset).

--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -585,6 +585,320 @@ class GoBotIntegrationTests: XCTestCase {
         XCTAssertEqual(hashtags.count, 2)
     }
 
+    // MARK: Reports
+
+    func testReportsWithoutFollows() async throws {
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+        XCTAssertEqual(reports.count, 0)
+        XCTAssertEqual(numberOfUnreadReports, 0)
+    }
+
+    func testReportsWithOneFollow() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let testingIdentity = botTestsKey.identity
+
+        // Publish follow
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+        sut.testingPublish(as: "alice", content: Contact(contact: testingIdentity, following: true))
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+        XCTAssertEqual(reports.count, 1)
+        XCTAssertEqual(numberOfUnreadReports, 1)
+    }
+
+    func testReportsWithOneFollowFromABlockedUser() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let myself = botTestsKey.identity
+
+        // Publish an about for Alice
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+
+        // Publish block
+        try sut.testingBlock(nick: "alice")
+
+        // Publish follow
+        sut.testingPublish(as: "alice", content: Contact(contact: myself, following: true))
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+        XCTAssertEqual(reports.count, 0)
+        XCTAssertEqual(numberOfUnreadReports, 0)
+    }
+
+    func testReportsWithOneMention() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let testingIdentity = botTestsKey.identity
+
+        // Publish mention
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+        sut.testingPublish(
+            as: "alice",
+            content: Post(
+                blobs: nil,
+                branches: nil,
+                hashtags: nil,
+                mentions: [Mention(link: testingIdentity)],
+                root: nil,
+                text: "Hello \(testingIdentity)"
+            )
+        )
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+
+        XCTAssertEqual(reports.count, 1)
+        XCTAssertEqual(numberOfUnreadReports, 1)
+    }
+
+    func testReportsWithOneMentionFromABlockedUser() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let myself = botTestsKey.identity
+
+        // Publish an about for Alice
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+
+        // Publish block
+        try sut.testingBlock(nick: "alice")
+
+        // Publish mention
+        sut.testingPublish(
+            as: "alice",
+            content: Post(
+                blobs: nil,
+                branches: nil,
+                hashtags: nil,
+                mentions: [Mention(link: myself)],
+                root: nil,
+                text: "Hello \(myself)"
+            )
+        )
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+
+        XCTAssertEqual(reports.count, 0)
+        XCTAssertEqual(numberOfUnreadReports, 0)
+    }
+    
+    func testReportsWithManyMentions() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let bob = try XCTUnwrap(keypairs["bob"])
+        let myself = botTestsKey.identity
+
+        // Publish an about for myself, Alice and Bob
+        _ = try await sut.publish(content: About(about: myself, name: "Myself"))
+        sut.testingPublish(as: "bob", content: About(about: bob, name: "Bob"))
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+
+        // Publish block
+        try sut.testingBlock(nick: "alice")
+
+        // Create a mention to myself
+        let mention = Post(
+            blobs: nil,
+            branches: nil,
+            hashtags: nil,
+            mentions: [Mention(link: myself)],
+            root: nil,
+            text: "Hello \(myself)"
+        )
+
+        // Publish two mentions from Bob
+        sut.testingPublish(as: "bob", content: mention)
+        try await sut.refresh(load: .short)
+        sleep(1)
+        sut.testingPublish(as: "bob", content: mention)
+        try await sut.refresh(load: .short)
+        sleep(1)
+        // Publish one mention from Alice
+        sut.testingPublish(as: "alice", content: mention)
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+        XCTAssertEqual(reports.count, 2)
+        XCTAssertEqual(numberOfUnreadReports, 2)
+
+        let firstReport = reports[1]
+        let numerOfReportsSinceTheFirstOne = try await sut.numberOfReports(since: firstReport)
+        XCTAssertEqual(numerOfReportsSinceTheFirstOne, 1)
+
+        let secondReport = reports[0]
+        let numerOfReportsSinceTheSecondOne = try await sut.numberOfReports(since: secondReport)
+        XCTAssertEqual(numerOfReportsSinceTheSecondOne, 0)
+    }
+
+    func testReportsWithOneReply() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let myself = botTestsKey.identity
+
+        // Publish a post
+        let root = try await sut.publish(Post(text: "Hello, World!"))
+
+        // Publish an about for Alice
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+
+        // Publish a reply
+        sut.testingPublish(
+            as: "alice",
+            content: Post(
+                blobs: nil,
+                branches: [root],
+                hashtags: nil,
+                mentions: [Mention(link: myself)],
+                root: root,
+                text: "Hello \(myself)"
+            )
+        )
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+
+        XCTAssertEqual(reports.count, 1)
+        XCTAssertEqual(numberOfUnreadReports, 1)
+    }
+
+    func testReportsWithOneReplyFromABlockedUser() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let myself = botTestsKey.identity
+
+        // Publish a post
+        let root = try await sut.publish(Post(text: "Hello, World!"))
+
+        // Publish an about for Alice
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+
+        // Publish block
+        try sut.testingBlock(nick: "alice")
+
+        // Publish a reply
+        sut.testingPublish(
+            as: "alice",
+            content: Post(
+                blobs: nil,
+                branches: [root],
+                hashtags: nil,
+                mentions: [Mention(link: myself)],
+                root: root,
+                text: "Hello \(myself)"
+            )
+        )
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+
+        XCTAssertEqual(reports.count, 0)
+        XCTAssertEqual(numberOfUnreadReports, 0)
+    }
+
+    func testReportsWithOneComment() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let bob = try XCTUnwrap(keypairs["bob"])
+        let myself = botTestsKey.identity
+
+        // Publish an about for myself, Alice and Bob
+        _ = try await sut.publish(content: About(about: myself, name: "Myself"))
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+        sut.testingPublish(as: "bob", content: About(about: bob, name: "Bob"))
+
+        // Bob publishes a post
+        let root = sut.testingPublish(as: "bob", content: Post(text: "Hello, World!"))
+
+        // I reply to it
+        _ = try await sut.publish(
+            content: Post(blobs: nil, branches: [root], hashtags: nil, mentions: nil, root: root, text: "Hello Bob")
+        )
+
+        // Alice also replies to Bob
+        sut.testingPublish(
+            as: "alice",
+            content: Post(
+                blobs: nil,
+                branches: [root],
+                hashtags: nil,
+                mentions: nil,
+                root: root,
+                text: "Hello Bob and Myself"
+            )
+        )
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+
+        XCTAssertEqual(reports.count, 1)
+        XCTAssertEqual(numberOfUnreadReports, 1)
+    }
+
+    func testReportsWithOneCommentFromABlockedUser() async throws {
+        let keypairs = try sut.testingGetNamedKeypairs()
+        let alice = try XCTUnwrap(keypairs["alice"])
+        let bob = try XCTUnwrap(keypairs["bob"])
+        let myself = botTestsKey.identity
+
+        // Publish an about for myself, Alice and Bob
+        _ = try await sut.publish(
+            content: About(about: myself, name: "Myself")
+        )
+        sut.testingPublish(as: "alice", content: About(about: alice, name: "Alice"))
+        sut.testingPublish(as: "bob", content: About(about: bob, name: "Bob"))
+
+        // Bob publishes a post
+        let root = sut.testingPublish(as: "bob", content: Post(text: "Hello, World!"))
+
+        // I reply to it
+        _ = try await sut.publish(
+            content: Post(blobs: nil, branches: [root], hashtags: nil, mentions: nil, root: root, text: "Hello Bob")
+        )
+
+        // Publish block
+        try sut.testingBlock(nick: "alice")
+
+        // Alice also replies to Bob
+        sut.testingPublish(
+            as: "alice",
+            content: Post(
+                blobs: nil,
+                branches: [root],
+                hashtags: nil,
+                mentions: nil,
+                root: root,
+                text: "Hello Bob and Myself"
+            )
+        )
+
+        try await sut.refresh(load: .short)
+
+        let reports = try await sut.reports()
+        let numberOfUnreadReports = try await sut.numberOfUnreadReports()
+
+        XCTAssertEqual(reports.count, 0)
+        XCTAssertEqual(numberOfUnreadReports, 0)
+    }
+
     // MARK: Number of followers
 
     func testNumberOfFollowers() async throws {

--- a/UnitTests/GoBotOrderedTests.swift
+++ b/UnitTests/GoBotOrderedTests.swift
@@ -412,41 +412,6 @@ class GoBotOrderedTests: XCTestCase {
         self.wait(for: [ex], timeout: 10)
     }
 
-    // MARK: notifications
-
-    func test121_first_notification_empty() {
-        let ex = self.expectation(description: "\(#function)")
-        GoBotOrderedTests.shared.reports {
-            reports, err in
-            XCTAssertNil(err)
-            XCTAssertEqual(reports.count, 0)
-            ex.fulfill()
-        }
-        self.wait(for: [ex], timeout: 10)
-    }
-
-    func test122_first_notification() {
-        let followRef = GoBotOrderedTests.shared.testingPublish(
-            as: "alice",
-            content: Contact(contact: botTestsKey.identity, following: true))
-
-        GoBotOrderedTests.shared.testRefresh(self)
-
-        let ex = self.expectation(description: "\(#function) notify")
-        GoBotOrderedTests.shared.reports {
-            reports, err in
-            defer { ex.fulfill() }
-            XCTAssertNil(err)
-            guard reports.count == 1 else {
-                XCTFail("expected 1 message in notification")
-                return
-            }
-            XCTAssertEqual(reports[0].messageIdentifier, followRef)
-            XCTAssertEqual(reports[0].keyValue.value.author, GoBotOrderedTests.pubkeys["alice"]!)
-        }
-        self.wait(for: [ex], timeout: 10)
-    }
-
     // MARK: recent
     
     func test135_recent_paginated_feed() {

--- a/UnitTests/Test Helpers/GoBotTestExtensions.swift
+++ b/UnitTests/Test Helpers/GoBotTestExtensions.swift
@@ -110,6 +110,32 @@ extension GoBot {
         return id
     }
 
+    @discardableResult
+    func testingBlock(nick: String) throws -> MessageIdentifier {
+        guard let keypairs = try? testingGetNamedKeypairs() else {
+            return MessageIdentifier.null
+        }
+        guard let keypair = keypairs[nick] else {
+            return MessageIdentifier.null
+        }
+        let contact = Contact(contact: keypair, blocking: true)
+        let content = try XCTUnwrap(contact.encodeToData().string())
+        var identifier: MessageIdentifier?
+        content.withGoString { goStrContent in
+            guard let refCstr = ssbPublish(goStrContent) else {
+                XCTFail("publish failed!")
+                return
+            }
+            identifier = String(cString: refCstr)
+        }
+        let id = try XCTUnwrap(identifier)
+        XCTAssertTrue(id.hasPrefix("%"))
+        XCTAssertTrue(id.hasSuffix(".sha256"))
+        print(content)
+        return id
+    }
+
+    @discardableResult
     func testingPublish(as nick: String, recipients: [Identity]? = nil, content: ContentCodable) -> MessageIdentifier {
         let c = try! content.encodeToData().string()!
         var identifier: MessageIdentifier?


### PR DESCRIPTION
Fixes #824 

It adds filter clause to the reports functions of GoBot to filter out reports generated by blocked users.