### PR TITLE
Fix the thread view for users without names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fix the thread view when repliers do not have a name published. #850
+
 ## [1.3.4]
 
 - Filter posts from followed users in the Discover feed when the Random algorithm is selected. #822

--- a/Source/GoBot/KeyValue+ViewDatabase.swift
+++ b/Source/GoBot/KeyValue+ViewDatabase.swift
@@ -72,7 +72,7 @@ extension KeyValue {
         if hasReplies {
             let numberOfReplies = try row.get(Expression<Int>("replies_count"))
             let replies = try row.get(Expression<String?>("replies"))
-            let abouts = replies?.split(separator: ";").map { About(about: String($0)) } ?? []
+            let abouts = Set(replies?.split(separator: ";").map { About(about: String($0)) } ?? [])
             keyValue.metadata.replies.count = numberOfReplies
             keyValue.metadata.replies.abouts = abouts
         }

--- a/Source/GoBot/ViewDatabase.swift
+++ b/Source/GoBot/ViewDatabase.swift
@@ -1159,7 +1159,7 @@ class ViewDatabase {
             .join(self.msgs, on: self.msgs[colMessageID] == self.contacts[colMessageRef])
             .join(self.msgKeys, on: self.msgKeys[colID] == self.contacts[colMessageRef])
             .join(self.authors, on: self.authors[colID] == self.contacts[colAuthorID])
-            .join(self.abouts, on: self.abouts[colAboutID] == self.contacts[colAuthorID])
+            .join(.leftOuter, self.abouts, on: self.abouts[colAboutID] == self.contacts[colAuthorID])
             .filter(colContactID == feedID)
             .filter(colContactState == 1)
             .order(colClaimedAt.desc)
@@ -1421,6 +1421,10 @@ class ViewDatabase {
 
     // turns an array of messages into an array of (msg, #people replied)
     private func addNumberOfPeopleReplied(msgs: [KeyValue]) throws -> KeyValues {
+        guard let db = self.openDB else {
+            throw ViewDatabaseError.notOpen
+        }
+        
         var r: KeyValues = []
         for (index, _) in msgs.enumerated() {
             var msg = msgs[index]
@@ -1430,14 +1434,14 @@ class ViewDatabase {
                 .select(colAuthorID.distinct, colAuthor, colName, colDescr, colImage)
                 .join(self.msgs, on: self.msgs[colMessageID] == self.tangles[colMessageRef])
                 .join(self.authors, on: self.msgs[colAuthorID] == self.authors[colID])
-                .join(self.abouts, on: self.authors[colID] == self.abouts[colAboutID])
+                .join(.leftOuter, self.abouts, on: self.authors[colID] == self.abouts[colAboutID])
                 .filter(colMsgType == ContentType.post.rawValue || colMsgType == ContentType.vote.rawValue)
                 .filter(colRoot == msgID)
 
-            let count = try self.openDB!.scalar(replies.count)
+            let count = try db.scalar(replies.count)
 
             var abouts: [About] = []
-            for row in try self.openDB!.prepare(replies.limit(3, offset: 0)) {
+            for row in try db.prepare(replies) {
                 let about = About(about: row[colAuthor],
                                   name: row[colName],
                                   description: row[colDescr],
@@ -1446,7 +1450,7 @@ class ViewDatabase {
             }
 
             msg.metadata.replies.count = count
-            msg.metadata.replies.abouts = abouts
+            msg.metadata.replies.abouts = Set(abouts)
             r.append(msg)
         }
         return r
@@ -1465,7 +1469,7 @@ class ViewDatabase {
             .join(self.msgKeys, on: self.msgKeys[colID] == self.tangles[colMessageRef])
             .join(self.msgs, on: self.msgs[colMessageID] == self.tangles[colMessageRef])
             .join(self.authors, on: self.authors[colID] == self.msgs[colAuthorID])
-            .join(self.abouts, on: self.abouts[colAboutID] == self.msgs[colAuthorID])
+            .join(.leftOuter, self.abouts, on: self.abouts[colAboutID] == self.msgs[colAuthorID])
             .join(.leftOuter, self.posts, on: self.posts[colMessageRef] == self.tangles[colMessageRef])
             .join(.leftOuter, self.votes, on: self.votes[colMessageRef] == self.tangles[colMessageRef])
             .filter(colMsgType == ContentType.post.rawValue || colMsgType == ContentType.vote.rawValue )
@@ -1559,7 +1563,7 @@ class ViewDatabase {
             .join(self.posts, on: self.posts[colMessageRef] == self.msgs[colMessageID])
             .join(self.msgKeys, on: self.msgKeys[colID] == self.msgs[colMessageID])
             .join(self.authors, on: self.authors[colID] == self.msgs[colAuthorID])
-            .join(self.abouts, on: self.abouts[colAboutID] == self.msgs[colAuthorID])
+            .join(.leftOuter, self.abouts, on: self.abouts[colAboutID] == self.msgs[colAuthorID])
             .join(.leftOuter, self.tangles, on: self.tangles[colMessageRef] == self.msgs[colMessageID])
             .filter(colFeedID == self.currentUserID)
             .filter(colAuthorID != self.currentUserID)
@@ -1662,7 +1666,7 @@ class ViewDatabase {
             LEFT OUTER JOIN votes ON (votes.msg_ref = messages.msg_id)
             INNER JOIN messagekeys ON (messagekeys.id = messages.msg_id)
             INNER JOIN authors ON (authors.id = messages.author_id)
-            INNER JOIN abouts ON (abouts.about_id = messages.author_id)
+            LEFT JOIN abouts ON (abouts.about_id = messages.author_id)
             LEFT OUTER JOIN tangles ON (tangles.msg_ref = messages.msg_id)
             LEFT OUTER JOIN read_messages ON (
                 (read_messages.msg_id = messages.msg_id) AND (read_messages.author_id = reports.author_id)
@@ -1710,7 +1714,7 @@ class ViewDatabase {
             LEFT OUTER JOIN votes ON (votes.msg_ref = messages.msg_id)
             INNER JOIN messagekeys ON (messagekeys.id = messages.msg_id)
             INNER JOIN authors ON (authors.id = messages.author_id)
-            INNER JOIN abouts ON (abouts.about_id = messages.author_id)
+            LEFT JOIN abouts ON (abouts.about_id = messages.author_id)
             LEFT OUTER JOIN tangles ON (tangles.msg_ref = messages.msg_id)
             LEFT OUTER JOIN read_messages ON (
                 (read_messages.msg_id = messages.msg_id) AND (read_messages.author_id = reports.author_id)
@@ -2041,7 +2045,7 @@ class ViewDatabase {
             .join(self.msgKeys, on: self.msgKeys[colID] == self.channelAssigned[colMessageRef])
             .join(self.msgs, on: self.msgs[colMessageID] == self.channelAssigned[colMessageRef])
             .join(self.authors, on: self.authors[colID] == self.msgs[colAuthorID])
-            .join(self.abouts, on: self.abouts[colAboutID] == self.msgs[colAuthorID])
+            .join(.leftOuter, self.abouts, on: self.abouts[colAboutID] == self.msgs[colAuthorID])
             .join(.leftOuter, self.tangles, on: self.tangles[colMessageRef] == self.channelAssigned[colMessageRef])
             .join(.leftOuter, self.posts, on: self.posts[colMessageRef] == self.channelAssigned[colMessageRef])
             .order(colMessageID.desc)

--- a/Source/Model/KeyValue.swift
+++ b/Source/Model/KeyValue.swift
@@ -57,8 +57,13 @@ struct KeyValue: Codable {
         var author = Author()
 
         struct Replies {
+            
+            /// The number of replies to this message
             var count: Int = 0
-            var abouts: [About] = []
+            
+            /// Metadata about the authors of the replies.
+            var abouts: Set<About> = Set([])
+            
             var isEmpty: Bool {
                 // swiftlint:disable empty_count
                 count <= 0


### PR DESCRIPTION
I got myself very confused this morning and thought the whole app was broken. It turns out that the thread view is just totally broken if the replies are from users without names. This fixes that by doing LEFT OUTER joins instead of LEFT INNER on the `about` table when loading replies, and tweaking the PostReplyHeader to handle this case.