### PR TITLE
Fix a bug where the JoinPlanetarySystemOperation would hang

### DIFF
--- a/Source/App/AppConfiguration.swift
+++ b/Source/App/AppConfiguration.swift
@@ -37,13 +37,7 @@ class AppConfiguration: NSObject, NSCoding, Identifiable {
     /// The number of messages this user has published. This number is used to prevent the user from publishing before
     /// their feed has fully synced, which "forks" or breaks it forever.
     /// Should be kept up-to-date by the `Bot`.
-    var numberOfPublishedMessages: Int = 0 {
-        didSet {
-            if numberOfPublishedMessages > oldValue {
-                print("id: \(self.id), numberOfPublishedMessages: \(numberOfPublishedMessages)")
-            }
-        }
-    }
+    var numberOfPublishedMessages: Int = 0
     
     /// A bool indicating whether the user has opted to join the "Planetary System". Joining the Planetary System means
     /// the system pubs will follow you automatically.

--- a/Source/App/AppConfiguration.swift
+++ b/Source/App/AppConfiguration.swift
@@ -37,7 +37,13 @@ class AppConfiguration: NSObject, NSCoding, Identifiable {
     /// The number of messages this user has published. This number is used to prevent the user from publishing before
     /// their feed has fully synced, which "forks" or breaks it forever.
     /// Should be kept up-to-date by the `Bot`.
-    var numberOfPublishedMessages: Int = 0
+    var numberOfPublishedMessages: Int = 0 {
+        didSet {
+            if numberOfPublishedMessages > oldValue {
+                print("id: \(self.id), numberOfPublishedMessages: \(numberOfPublishedMessages)")
+            }
+        }
+    }
     
     /// A bool indicating whether the user has opted to join the "Planetary System". Joining the Planetary System means
     /// the system pubs will follow you automatically.

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -48,10 +48,7 @@ class SendMissionOperation: AsynchronousOperation {
         }
         
         Task {
-            let joinPlanetaryOperation = self.createJoinPlanetaryOperation(
-                config: appConfiguration,
-                queue: self.operationQueue
-            )
+            let joinPlanetaryOperation = self.createJoinPlanetaryOperation(config: appConfiguration)
             let syncOperation = await self.createSyncOperation(bot: bot, config: appConfiguration)
             
             var operations: [Operation] = [syncOperation]
@@ -68,11 +65,8 @@ class SendMissionOperation: AsynchronousOperation {
         }
     }
     
-    func createJoinPlanetaryOperation(
-        config: AppConfiguration,
-        queue: OperationQueue
-    ) -> JoinPlanetarySystemOperation? {
-        JoinPlanetarySystemOperation(appConfiguration: config, operationQueue: queue)
+    func createJoinPlanetaryOperation(config: AppConfiguration) -> JoinPlanetarySystemOperation? {
+        JoinPlanetarySystemOperation(appConfiguration: config)
     }
     
     func createSyncOperation(bot: Bot, config: AppConfiguration) async -> SyncOperation {


### PR DESCRIPTION
This fixes the issue I found when doing final QA for 1.3.4. The JoinPlanetarySystem operation was adding operations to the same queue it was on, then tried to wait for that queue to be empty... which meant it was waiting on itself to finish. Who wrote this terrible code? It was me.