### PR TITLE
Changelog merge strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+CHANGELOG.md merge=union
 UnitTests/Resources/rabbledb.sqlite filter=lfs diff=lfs merge=lfs -text
 *.a filter=lfs diff=lfs merge=lfs -text
 UnitTests/Resources/Feed_big.sqlite filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
   pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches: main
 env:


### PR DESCRIPTION
This changes the merge strategy for `CHANGELOG.md` so that we should have fewer conflicts in that file. Basically if two commits add lines to the changelog in the same place then by default it will just accept both lines rather than creating a conflict.

I also figured out how to fix the `Skip-Changelog` label thanks to [this comment](https://github.com/dangoslen/changelog-enforcer/issues/211#issuecomment-1255549336) on the issue I opened.