### PR TITLE
Fix draft not clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fixed an issue where drafts might not be cleared after posting. #868
+
 ## [1.3.4]
 
 - Show the underlying SSB message for posts, replies and likes. #662


### PR DESCRIPTION
Closes #868. There was a data race here where the call to clear a draft could be executed before a previous call to save the draft was executed.