### PR TITLE
Fix legacy gossip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed an issue where drafts might not be cleared after posting. #868
+- Fixed go-ssb not falling back to legacy replication when a peer does not support EBTs. #877
 
 ## [1.3.4]
 

--- a/Frameworks/GoSSB.xcframework/Info.plist
+++ b/Frameworks/GoSSB.xcframework/Info.plist
@@ -8,6 +8,20 @@
 			<key>HeadersPath</key>
 			<string>Headers</string>
 			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libssb-go.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
 			<string>ios-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
 			<string>libssb-go.a</string>
@@ -20,20 +34,6 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
-		</dict>
-		<dict>
-			<key>HeadersPath</key>
-			<string>Headers</string>
-			<key>LibraryIdentifier</key>
-			<string>ios-arm64</string>
-			<key>LibraryPath</key>
-			<string>libssb-go.a</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>arm64</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>ios</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:947244fc2ceeb7712c4d8ae5e0bb85ba93c8e273544f4d9af0e42c7ffb425864
-size 23721304
+oid sha256:08bd280452d5d0e3d52a76e7da239acae378639a948f98570d3df9ba14aed166
+size 23721120

--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:08bd280452d5d0e3d52a76e7da239acae378639a948f98570d3df9ba14aed166
-size 23721120
+oid sha256:4a4664a0f033e8f961233d53098d93cf8a238d896d1063d81954cdda90df38cd
+size 23720448

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d86e646a932aba9d4fc8d76fb04f94b430add9fd826a4ca23ada43cd3bc877dc
-size 47180000
+oid sha256:5841cbb11c50fdb067961e95090d9406b2ebc75d31a643f53bc077636c467eee
+size 47174992

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce8439a7b1a4d20d0719618aabcdc688d31b0d9a1c965c748c9119cf7e4d3a81
-size 47171728
+oid sha256:d86e646a932aba9d4fc8d76fb04f94b430add9fd826a4ca23ada43cd3bc877dc
+size 47180000

--- a/GoSSB/Sources/go.mod
+++ b/GoSSB/Sources/go.mod
@@ -66,6 +66,6 @@ go 1.17
 
 replace golang.org/x/crypto => github.com/cryptix/golang_x_crypto v0.0.0-20200303113948-2939d6771b24
 
-replace go.cryptoscope.co/ssb => github.com/planetary-social/ssb v0.2.2-0.20220907154211-c7dc092193fc
+replace go.cryptoscope.co/ssb => github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1
 
 replace go.mindeco.de => github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7

--- a/GoSSB/Sources/go.sum
+++ b/GoSSB/Sources/go.sum
@@ -295,8 +295,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7 h1:1S33MMjKxP3XvQATW0N28OnY3Y02L5/21lrx1pwdc0Q=
 github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7/go.mod h1:dZty08izAk/rSX8wSLen4gMR4WDPYmA6vUTE0QtepHA=
-github.com/planetary-social/ssb v0.2.2-0.20220907154211-c7dc092193fc h1:3vajc04Aji4nlG7It6tZco3aWkuaqimqmoUybKU1nms=
-github.com/planetary-social/ssb v0.2.2-0.20220907154211-c7dc092193fc/go.mod h1:aVHa4tYy6ucGATXL2YvKGFR7nFrzqKuhFeMyA0XRI0s=
+github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1 h1:0FjA3otKzmYvkvjzV4s7zwTCZE/9adtP760NzClZ2Ik=
+github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1/go.mod h1:aVHa4tYy6ucGATXL2YvKGFR7nFrzqKuhFeMyA0XRI0s=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/Source/App/AppConfiguration.swift
+++ b/Source/App/AppConfiguration.swift
@@ -158,6 +158,18 @@ class AppConfiguration: NSObject, NSCoding, Identifiable {
             .appending("/FBTT")
             .appending("/\(networkKey.hexEncodedString())")
     }
+    
+    override var description: String {
+        """
+        id: \(id)
+        name: \(name)
+        identity: \(identity)
+        joinedPlanetarySystem: \(joinedPlanetarySystem)
+        numberOfPublishedMessages: \(numberOfPublishedMessages)
+        networkKey: \(String(describing: network?.string))
+        networkHMAC: -omitted-
+        """
+    }
 
     // MARK: Lifecycle
 

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -89,7 +89,7 @@ class SendMissionOperation: AsynchronousOperation {
             
             // If we don't have enough peers, supplement with the Planetary pubs
             let minPeers = JoinPlanetarySystemOperation.minNumberOfStars
-            if joinedPubs.count < minPeers && config.joinedPlanetarySystem {
+            if joinedPubs.count < 1 {
                 let systemPubs = Set(config.systemPubs).map { $0.address.multiserver }
                 let someSystemPubs = systemPubs.randomSample(UInt(minPeers - joinedPubs.count))
                 joinedPubs += someSystemPubs

--- a/Source/Controller/LaunchViewController.swift
+++ b/Source/Controller/LaunchViewController.swift
@@ -95,7 +95,7 @@ class LaunchViewController: UIViewController {
         // TODO this should be an analytics track()
         // TODO include app installation UUID
         // Analytics.shared.app(launch)
-        Log.info("Launching with configuration '\(configuration.name)'")
+        Log.info("Launching with configuration:\n\(configuration)")
         
         Task {
             login: do {


### PR DESCRIPTION
This is a temporary fix for #847. It makes three changes:
- Planetary will connect to the the Planetary pubs if you have no other pubs or rooms to connect to, even if `joinedPlanetarySystem` option is false. This fixes the flow where you imported your key into Planetary. When importing a key we automatically set `joinedPlanetarySystem` to `false` to prevent auto-publishing of pub messages and forking your feed. However if you have no peers on your local network you have no one to download your own feed from. This should be a temporary fix until we can at least implement #874. Really we need to redo our whole imported key flow.
- Fixes go-ssb so that it correctly falls back to legacy gossip when a peer does not support EBTs.
- Prints the AppConfiguration details on launch for easier debugging.