### PR TITLE
Fix byte sink crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show the underlying SSB message for posts, replies and likes. #662
 - Fixed an issue where drafts might not be cleared after posting. #868
+- Fixed go-ssb not falling back to legacy replication when a peer does not support EBTs. #877
 - Optimized the "Patchwork" home feed algorithm (RecentlyActivePostsAndContactsAlgorithm) and made it the new default. This algorithm brings posts back up to the top of your home feed when they receive a new reply. #860
 - Optimize loading of follow message cells. #859
 

--- a/Frameworks/GoSSB.xcframework/Info.plist
+++ b/Frameworks/GoSSB.xcframework/Info.plist
@@ -8,6 +8,20 @@
 			<key>HeadersPath</key>
 			<string>Headers</string>
 			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libssb-go.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
 			<string>ios-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
 			<string>libssb-go.a</string>
@@ -20,20 +34,6 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
-		</dict>
-		<dict>
-			<key>HeadersPath</key>
-			<string>Headers</string>
-			<key>LibraryIdentifier</key>
-			<string>ios-arm64</string>
-			<key>LibraryPath</key>
-			<string>libssb-go.a</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>arm64</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>ios</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/Frameworks/GoSSB.xcframework/Info.plist
+++ b/Frameworks/GoSSB.xcframework/Info.plist
@@ -8,20 +8,6 @@
 			<key>HeadersPath</key>
 			<string>Headers</string>
 			<key>LibraryIdentifier</key>
-			<string>ios-arm64</string>
-			<key>LibraryPath</key>
-			<string>libssb-go.a</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>arm64</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>ios</string>
-		</dict>
-		<dict>
-			<key>HeadersPath</key>
-			<string>Headers</string>
-			<key>LibraryIdentifier</key>
 			<string>ios-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
 			<string>libssb-go.a</string>
@@ -34,6 +20,20 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libssb-go.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d16d46131b40f060c9b8841f75fa42b6ed0fa6f39e3680c27a91e5545d85dc0
-size 23721344
+oid sha256:7417a9559e48aa5da3dd9693461612ddc009ebf0764929a1c76a491ed9dbd8f4
+size 23721312

--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:947244fc2ceeb7712c4d8ae5e0bb85ba93c8e273544f4d9af0e42c7ffb425864
-size 23721304
+oid sha256:6d16d46131b40f060c9b8841f75fa42b6ed0fa6f39e3680c27a91e5545d85dc0
+size 23721344

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a2ec5ce05ea57db11c462f50116ad852aee0d2b60302fb78012a5f96d4d2114
-size 47175872
+oid sha256:4206cf1ed8207698de2028faf4e5e2483104a4cfcc86aeb540ea03eb618a1ab7
+size 47175832

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce8439a7b1a4d20d0719618aabcdc688d31b0d9a1c965c748c9119cf7e4d3a81
-size 47171728
+oid sha256:1a2ec5ce05ea57db11c462f50116ad852aee0d2b60302fb78012a5f96d4d2114
+size 47175872

--- a/GoSSB/Sources/go.mod
+++ b/GoSSB/Sources/go.mod
@@ -66,6 +66,6 @@ go 1.17
 
 replace golang.org/x/crypto => github.com/cryptix/golang_x_crypto v0.0.0-20200303113948-2939d6771b24
 
-replace go.cryptoscope.co/ssb => github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1
+replace go.cryptoscope.co/ssb => github.com/planetary-social/ssb v0.2.2-0.20221003135325-7f4aeeac1e84
 
 replace go.mindeco.de => github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7

--- a/GoSSB/Sources/go.mod
+++ b/GoSSB/Sources/go.mod
@@ -66,6 +66,6 @@ go 1.17
 
 replace golang.org/x/crypto => github.com/cryptix/golang_x_crypto v0.0.0-20200303113948-2939d6771b24
 
-replace go.cryptoscope.co/ssb => github.com/planetary-social/ssb v0.2.2-0.20220907154211-c7dc092193fc
+replace go.cryptoscope.co/ssb => github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1
 
 replace go.mindeco.de => github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7

--- a/GoSSB/Sources/go.sum
+++ b/GoSSB/Sources/go.sum
@@ -295,8 +295,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7 h1:1S33MMjKxP3XvQATW0N28OnY3Y02L5/21lrx1pwdc0Q=
 github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7/go.mod h1:dZty08izAk/rSX8wSLen4gMR4WDPYmA6vUTE0QtepHA=
-github.com/planetary-social/ssb v0.2.2-0.20220907154211-c7dc092193fc h1:3vajc04Aji4nlG7It6tZco3aWkuaqimqmoUybKU1nms=
-github.com/planetary-social/ssb v0.2.2-0.20220907154211-c7dc092193fc/go.mod h1:aVHa4tYy6ucGATXL2YvKGFR7nFrzqKuhFeMyA0XRI0s=
+github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1 h1:0FjA3otKzmYvkvjzV4s7zwTCZE/9adtP760NzClZ2Ik=
+github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1/go.mod h1:aVHa4tYy6ucGATXL2YvKGFR7nFrzqKuhFeMyA0XRI0s=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/GoSSB/Sources/go.sum
+++ b/GoSSB/Sources/go.sum
@@ -295,8 +295,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7 h1:1S33MMjKxP3XvQATW0N28OnY3Y02L5/21lrx1pwdc0Q=
 github.com/planetary-social/go-toolbelt v0.0.0-20220509144343-0f7ad206c2b7/go.mod h1:dZty08izAk/rSX8wSLen4gMR4WDPYmA6vUTE0QtepHA=
-github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1 h1:0FjA3otKzmYvkvjzV4s7zwTCZE/9adtP760NzClZ2Ik=
-github.com/planetary-social/ssb v0.2.2-0.20220929194333-e991d0f744c1/go.mod h1:aVHa4tYy6ucGATXL2YvKGFR7nFrzqKuhFeMyA0XRI0s=
+github.com/planetary-social/ssb v0.2.2-0.20221003135325-7f4aeeac1e84 h1:PrfCDrWIlMlFcaBq3DDyGoOTvntzSUB8YZT6YiuZnjg=
+github.com/planetary-social/ssb v0.2.2-0.20221003135325-7f4aeeac1e84/go.mod h1:aVHa4tYy6ucGATXL2YvKGFR7nFrzqKuhFeMyA0XRI0s=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/Source/App/AppConfiguration.swift
+++ b/Source/App/AppConfiguration.swift
@@ -158,6 +158,18 @@ class AppConfiguration: NSObject, NSCoding, Identifiable {
             .appending("/FBTT")
             .appending("/\(networkKey.hexEncodedString())")
     }
+    
+    override var description: String {
+        """
+        id: \(id)
+        name: \(name)
+        identity: \(identity)
+        joinedPlanetarySystem: \(joinedPlanetarySystem)
+        numberOfPublishedMessages: \(numberOfPublishedMessages)
+        networkKey: \(String(describing: network?.string))
+        networkHMAC: -omitted-
+        """
+    }
 
     // MARK: Lifecycle
 

--- a/Source/Bot/Operations/SendMissionOperation.swift
+++ b/Source/Bot/Operations/SendMissionOperation.swift
@@ -89,7 +89,7 @@ class SendMissionOperation: AsynchronousOperation {
             
             // If we don't have enough peers, supplement with the Planetary pubs
             let minPeers = JoinPlanetarySystemOperation.minNumberOfStars
-            if joinedPubs.count < minPeers && config.joinedPlanetarySystem {
+            if joinedPubs.count < 1 {
                 let systemPubs = Set(config.systemPubs).map { $0.address.multiserver }
                 let someSystemPubs = systemPubs.randomSample(UInt(minPeers - joinedPubs.count))
                 joinedPubs += someSystemPubs

--- a/Source/Controller/LaunchViewController.swift
+++ b/Source/Controller/LaunchViewController.swift
@@ -95,7 +95,7 @@ class LaunchViewController: UIViewController {
         // TODO this should be an analytics track()
         // TODO include app installation UUID
         // Analytics.shared.app(launch)
-        Log.info("Launching with configuration '\(configuration.name)'")
+        Log.info("Launching with configuration:\n\(configuration)")
         
         Task {
             login: do {


### PR DESCRIPTION
This fixes a crash introduced in #877. It points go-ssb at https://github.com/planetary-social/ssb/pull/8 instead of https://github.com/planetary-social/ssb/pull/6.