### PR TITLE
Fix avatar image aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Update to Xcode 14. #839
+- Fixed incorrect aspect ratio of avatar images. #753
 
 
 ## [1.3.5] 2022-10-03

--- a/Source/UI/AvatarImageView.swift
+++ b/Source/UI/AvatarImageView.swift
@@ -19,6 +19,7 @@ class AvatarImageView: ImageView {
         }
         set {
             super.image = newValue ?? UIImage.verse.missingAbout
+            self.contentMode = .scaleAspectFill
         }
     }
     

--- a/Source/UI/AvatarImageView.swift
+++ b/Source/UI/AvatarImageView.swift
@@ -49,18 +49,17 @@ class AvatarImageView: ImageView {
     @discardableResult
     func load(for person: Person, animate: Bool = false) -> URLSessionDataTask? {
         
-        // TODO: This convert 
         if person.image_url == nil, let imageIdentifier = person.image {
             
             // cached image
             if let image = Caches.blobs.image(for: imageIdentifier) {
-                 DispatchQueue.main.async {
+                DispatchQueue.main.async {
                     if animate {
                         self.fade(to: image)
                     } else {
                         self.image = image
                     }
-                 }
+                }
                 // return(nil)
             }
 
@@ -90,8 +89,7 @@ class AvatarImageView: ImageView {
         
         Log.info("url: \(url)")
 
-        let task = URLSession.shared.dataTask(with: request) {
-            data, response, _ in
+        let task = URLSession.shared.dataTask(with: request) { data, response, _ in
             guard response?.httpStatusCodeError == nil else { return }
             guard let data = data else { return }
             guard let image = UIImage(data: data) else {


### PR DESCRIPTION
Addresses #753 . 

To test, I used this image:


![Untitled 5](https://user-images.githubusercontent.com/1332769/195759560-af9ce2cc-25ac-4345-aa56-9b0c600b993c.png)

Right side shows the fix:

![Untitled-1](https://user-images.githubusercontent.com/1332769/195759696-ddfb8b35-de75-4ebe-9050-644348aa6a20.png)
