### PR TITLE
Revert "add type to posthog events to separate bot from user actions"

### DIFF
--- a/Analytics/Sources/Domain/Services/AnalyticsService.swift
+++ b/Analytics/Sources/Domain/Services/AnalyticsService.swift
@@ -26,11 +26,6 @@ extension AnalyticsService {
         if let param = param, let value = value {
             params[param] = value
         }
-        switch event.rawValue {
-        case "did": params["type"] = "bot"
-        default: params["type"] = "user"
-        }
-        
         self.track(event: event, element: element, name: name, params: params)
     }
 }


### PR DESCRIPTION
Reverts planetary-social/planetary-ios#903

Seems to be breaking posthog