### PR TITLE
Add missing step required before cloning the project to avoid build/run failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,17 +16,19 @@ From the Terminal:
 
 1. `brew install git-lfs swiftlint`
 
-2. `git clone git@github.com:planetary-social/planetary-ios.git`
+2. `git lfs install`
 
-3. `cd planetary-ios`
+3. `git clone git@github.com:planetary-social/planetary-ios.git`
 
-4. Prevent git from commiting your API keys (see below, The Secrets.plist configuration file) in the public repository
+4. `cd planetary-ios`
+
+5. Prevent git from commiting your API keys (see below, The Secrets.plist configuration file) in the public repository
 
 ```sh
 git update-index --skip-worktree Resources/Secrets.debug.plist
 ```
 
-5. Open the Planetary project in Xcode:
+6. Open the Planetary project in Xcode:
 
 ```sh
 open Planetary.xcworkspace
@@ -34,7 +36,7 @@ open Planetary.xcworkspace
 
 In Xcode:
 
-6. In the menu bar choose Product -> Build
+7. In the menu bar choose Product -> Build
 
 ## Running
 


### PR DESCRIPTION
Add missing step installing Git LFS > `git lfs install` to allow pulling frameworks over git when cloning

Otherwise it fails showing something like this:

```
ld: warning: ignoring file ~/Library/Developer/Xcode/DerivedData/Planetary-fjsowinuoajswjaxifmsuhhptcol/Build/Products/Debug-iphonesimulator/libssb-go.a, building for iOS Simulator-x86_64 but attempting to link with file built for unknown-unsupported file format ( 0x76 0x65 0x72 0x73 0x69 0x6F 0x6E 0x20 0x68 0x74 0x74 0x70 0x73 0x3A 0x2F 0x2F )
Undefined symbols for architecture x86_64:
  "_ssbBlobsAdd", referenced from:
      _$s9Planetary13GoBotInternalC8blobsAdd4data10completiony10Foundation4DataV_ySS_s5Error_pSgtctF in GoBotInternal.o
  "_ssbBlobsWant", referenced from:
      _$s9Planetary13GoBotInternalC9blobsWant3refySS_tKFySo10gostring_taXEfU_ in GoBotInternal.o
  "_ssbBotInit", referenced from:
      _$s9Planetary13GoBotInternalC5login7network7hmacKey6secret10pathPrefixs5Error_pSgAA07NetworkH0C_AA7HMACKeyCSgAA6SecretVSStFySo10gostring_taXEfU0_ in GoBotInternal.o
  "_ssbBotIsRunning", referenced from:
      _$s9Planetary13GoBotInternalC9isRunningSbvg in GoBotInternal.o
  "_ssbBotStatus", referenced from:
      _$s9Planetary13GoBotInternalC6statusAA012ScuttlegobotC6StatusVyKF in GoBotInternal.o
  "_ssbBotStop", referenced from:
      _$s9Planetary13GoBotInternalC6logoutSbyF in GoBotInternal.o
  "_ssbConnectPeer", referenced from:
      _$s9Planetary13GoBotInternalC7dialOne4peerSbAA18MultiserverAddressV_tFySo10gostring_taXEfU_ in GoBotInternal.o
  "_ssbDisconnectAllPeers", referenced from:
      _$s9Planetary13GoBotInternalC13disconnectAllyyF in GoBotInternal.o
      _$s9Planetary13GoBotInternalC13dialSomePeers4fromSbSayAA18MultiserverAddressVG_tF in GoBotInternal.o
  "_ssbDropIndexData", referenced from:
      _$s9Planetary20LaunchViewControllerC18handleLoginFailure4with13configurationys5Error_p_AA16AppConfigurationCtFySo13UIAlertActionCcfU_ysAG_pSgcfU_ in LaunchViewController.o
      _$s9Planetary20LaunchViewControllerC18handleLoginFailure4with13configurationys5Error_p_AA16AppConfigurationCtFySo13UIAlertActionCcfU0_ysAG_pSgcfU_ in LaunchViewController.o
  "_ssbFeedBlock", referenced from:
      _$s9Planetary13GoBotInternalC3ban4feedySS_tFySo10gostring_taXEfU_ in GoBotInternal.o
      _$s9Planetary13GoBotInternalC5unban4feedySS_tFySo10gostring_taXEfU_ in GoBotInternal.o
      _$s9Planetary13GoBotInternalC7unblock4feedySS_tFySo10gostring_taXEfU_ in GoBotInternal.o
  "_ssbFeedReplicate", referenced from:
      _$s9Planetary13GoBotInternalC9replicate4feedySS_tFySo10gostring_taXEfU_ in GoBotInternal.o
      _$s9Planetary13GoBotInternalC13dontReplicate4feedySS_tFySo10gostring_taXEfU_ in GoBotInternal.o
  "_ssbGenKey", referenced from:
      _$s9Planetary5GoBotC12createSecret10completionyyAA0E0VSg_s5Error_pSgtXE_tF in GoBot.o
  "_ssbGetRawMessage", referenced from:
      _$s9Planetary5GoBotC3raw2of10completionyAA7MessageV_ys6ResultOySSs5Error_pGctFyycfU_ySo10gostring_taXEfU_ in GoBot.o
  "_ssbHealRepo", referenced from:
      _$s9Planetary13GoBotInternalC13fsckAndRepairSb_AA22ScuttlegobotHealReportVSgtyF in GoBotInternal.o
  "_ssbInviteAccept", referenced from:
      _$s9Planetary5GoBotC16redeemInvitation2to15completionQueue0G0yAA4StarV_So17OS_dispatch_queueCys5Error_pSgctFyycfU_ySbcfU_ySo10gostring_taXEfU_ in GoBot.o
  "_ssbNullContent", referenced from:
      _$s9Planetary13GoBotInternalC11nullContent6author8sequenceySS_SutKFySo10gostring_taXEfU_ in GoBotInternal.o
  "_ssbNullFeed", referenced from:
      _$s9Planetary13GoBotInternalC8nullFeed6authorySS_tKFySo10gostring_taXEfU_ in GoBotInternal.o
  "_ssbOffsetFSCK", referenced from:
      _$s9Planetary13GoBotInternalC8repoFSCKySbAA20ScuttlegobotFSCKModeOF in GoBotInternal.o
  "_ssbOpenConnections", referenced from:
      _$s9Planetary13GoBotInternalC15openConnectionsSuyF in GoBotInternal.o
  "_ssbPublish", referenced from:
      _$s9Planetary13GoBotInternalC7publish_10completionyAA14ContentCodable_p_ySS_s5Error_pSgtctFySo10gostring_taXEfU_ in GoBotInternal.o
  "_ssbReplicateUpTo", referenced from:
      _$s9Planetary13GoBotInternalC11getFeedList10completionyySDySSSiG_s5Error_pSgtc_tF in GoBotInternal.o
  "_ssbRepoStats", referenced from:
      _$s9Planetary13GoBotInternalC9repoStatsAA22ScuttlegobotRepoCountsVyKF in GoBotInternal.o
  "_ssbRoomsAliasRegister", referenced from:
      _$s9Planetary13GoBotInternalC8register5alias2inSbSS_AA4RoomVtFSo27ssbRoomsAliasRegisterReturnVSo10gostring_taXEfU_AjLXEfU_ in GoBotInternal.o
  "_ssbStreamPrivateLog", referenced from:
      _$s9Planetary13GoBotInternalC13getPrivateLog8startSeq5limitSayAA7MessageVGs5Int64V_SitKF in GoBotInternal.o
  "_ssbStreamPublishedLog", referenced from:
      _$s9Planetary13GoBotInternalC15getPublishedLog5afterSayAA7MessageVGs5Int64V_tKF in GoBotInternal.o
  "_ssbStreamRootLog", referenced from:
      _$s9Planetary13GoBotInternalC13getReceiveLog8startSeq5limitSayAA7MessageVGs6UInt64V_s5Int32VtKF in GoBotInternal.o
  "_ssbVersion", referenced from:
      _$s9Planetary13GoBotInternalC7versionSSvg in GoBotInternal.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```