### PR TITLE
Add back shake-to-open debug menu feature

### DIFF
--- a/Source/App/AppController.swift
+++ b/Source/App/AppController.swift
@@ -224,4 +224,18 @@ class AppController: UIViewController {
     func addOperation(_ operation: Operation) {
         operationQueue.addOperation(operation)
     }
+    
+    // MARK: Debug Menu
+    
+    #if DEBUG
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        guard motion == .motionShake,
+        topViewController.presentingViewController == nil,
+        UIApplication.shared.applicationState == .active else {
+            return
+        }
+        let controller = UINavigationController(rootViewController: DebugViewController())
+        topViewController.present(controller, animated: true, completion: nil)
+    }
+    #endif
 }


### PR DESCRIPTION
I think this gets the shake-to-open-debug-menu feature back without breaking the keyboard. I implemented it on AppController rather than as an extension on UIViewController. This means it only works if you don't already have a modal view presented. But it still works in most places.