### PR TITLE
Fix bug in FloatingButton where it wouldn't refresh the list

### DIFF
--- a/Source/UI/Home/HomeView.swift
+++ b/Source/UI/Home/HomeView.swift
@@ -26,8 +26,6 @@ struct HomeView: View, HelpDrawerHost {
     @ObservedObject
     private var helpDrawerState: HelpDrawerState
 
-    private var feedStrategyStore = FeedStrategyStore()
-
     @EnvironmentObject
     private var botRepository: BotRepository
 
@@ -50,21 +48,6 @@ struct HomeView: View, HelpDrawerHost {
     var horizontalSizeClass
 
     @State
-    private var messages: [Message]?
-
-    @State
-    private var isLoadingFromScratch = false
-
-    @State
-    private var isLoadingMoreMessages = false
-
-    @State
-    private var offset = 0
-
-    @State
-    private var noMoreMessages = false
-
-    @State
     private var numberOfNewItems = 0
 
     @State
@@ -75,14 +58,16 @@ struct HomeView: View, HelpDrawerHost {
     }
 
     var body: some View {
-        ZStack(alignment: .top) {
+        ScrollViewReader { proxy in
             MessageList(dataSource: dataSource)
                 .placeholder(when: dataSource.isEmpty) {
                     EmptyHomeView()
                 }
-            if shouldShowFloatingButton {
-                FloatingButton(count: numberOfNewItems, isLoading: isLoadingFromScratch)
-            }
+                .overlay(alignment: .top) {
+                    if shouldShowFloatingButton {
+                        FloatingButton(count: numberOfNewItems, dataSource: dataSource, proxy: proxy)
+                    }
+                }
         }
         .background(Color.appBg)
         .navigationTitle(Localized.home.text)
@@ -161,7 +146,7 @@ struct HomeView: View, HelpDrawerHost {
     }
 
     private func updateBadgeNumber(value: Int) {
-        numberOfNewItems = 0
+        numberOfNewItems = value
         lastTimeNewFeedUpdatesWasChecked = Date()
         let navigationController = appController.mainViewController?.homeFeatureViewController
         if value > 0 {
@@ -179,11 +164,10 @@ struct HomeView: View, HelpDrawerHost {
             return
         }
         let bot = botRepository.current
-        if let lastMessage = messages?.first?.key {
+        if let lastMessage = dataSource.cache?.first?.key {
             do {
                 let result = try await bot.numberOfRecentItems(since: lastMessage)
                 await MainActor.run {
-                    numberOfNewItems = result
                     updateBadgeNumber(value: result)
                 }
             } catch {

--- a/Source/UI/Message/MessageList.swift
+++ b/Source/UI/Message/MessageList.swift
@@ -17,6 +17,7 @@ struct MessageList<DataSource>: View where DataSource: MessageDataSource {
         InfiniteList(dataSource: dataSource) { message in
             if let message = message as? Message {
                 MessageButton(message: message)
+                    .id(message)
             }
         }
     }


### PR DESCRIPTION
Closes #1084 

Makes the floating button in HomeView functional again, and, as a bonus, scroll to top on tap.