### PR TITLE
Fix xcode can't find git-lfs

### DIFF
--- a/GoSSB/Sources/Makefile
+++ b/GoSSB/Sources/Makefile
@@ -54,7 +54,7 @@ $(BUILD_DIR)/$(PLATFORM_SIM)-arm64_x86_64/libssb-go.a: $(foreach ARCH,$(ARCHS_SI
 
 GOROOT ?= $(TEMP_ROOT)/.goroot
 export GOPATH := $(BUILDDIR)/gopath
-export PATH := $(GOROOT)/bin:$(PATH)
+export PATH := /opt/homebrew/bin:$(GOROOT)/bin:$(PATH)
 
 GO := $(GOROOT)/bin/go
 


### PR DESCRIPTION
We probably need a better fix in the future but for now I just added homebrew's bin dir to path.