### PR TITLE
Bump scuttlego (6c4cdb2f3eb4 -> 422b735c1d53)

### DIFF
--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd9e68d5af1aa8d7f05e697602291a2ed519f28e0cc43dbffb96bb2d04ad9541
-size 16606456
+oid sha256:901d0f498a28cfbc0e32f85e41bef421be80bb3a03e2bb29b460171c6a3a6cec
+size 16662016

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9196fe53737fb4b7158a429631e1d65141e3a6c74c8b4050551315bf44f8a6b1
-size 32103328
+oid sha256:df92a0c02bb240c72ca2eda8885153abc8affc59528e379f7c1f4fdb220a6d72
+size 32193904

--- a/GoSSB/Sources/go.mod
+++ b/GoSSB/Sources/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/boreq/errors v0.1.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/pkg/errors v0.9.1
-	github.com/planetary-social/scuttlego v0.0.0-20230215205436-6c4cdb2f3eb4
+	github.com/planetary-social/scuttlego v0.0.0-20230217164342-422b735c1d53
 	github.com/sirupsen/logrus v1.8.1
 	github.com/ssbc/go-ssb v0.2.2-0.20230212123438-2cdd828cd8c8
 	github.com/ssbc/go-ssb-multiserver v0.1.5-0.20221019203850-917ae0e23d57

--- a/GoSSB/Sources/go.sum
+++ b/GoSSB/Sources/go.sum
@@ -161,8 +161,8 @@ github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetary-social/scuttlego v0.0.0-20230215205436-6c4cdb2f3eb4 h1:7W2l1XsTLLK2rmZiRs7bv3YPuQdc7QCIiSXEiqCWEXQ=
-github.com/planetary-social/scuttlego v0.0.0-20230215205436-6c4cdb2f3eb4/go.mod h1:7TkSb0gLlMteC0Dhe5N+xHEEVzDbYhYa7pQdLxOgkEA=
+github.com/planetary-social/scuttlego v0.0.0-20230217164342-422b735c1d53 h1:XFAO8jkrwsjCqD0fM6puZ0adQs6ZVHvog46+oGoiivU=
+github.com/planetary-social/scuttlego v0.0.0-20230217164342-422b735c1d53/go.mod h1:7TkSb0gLlMteC0Dhe5N+xHEEVzDbYhYa7pQdLxOgkEA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Commits:
- 61064f466774e586ae0950c36f4c74a45018c166 Push blobs to peers (#211)
- 422b735c1d53062753e1d6207905046f02c46f7c Support blobs.get requests with "key" instead of "hash" (#213)