### PR TITLE
Bump github.com/planetary-social/scuttlego (422b735c1d53 -> d6d5d269bda6)

### DIFF
--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:901d0f498a28cfbc0e32f85e41bef421be80bb3a03e2bb29b460171c6a3a6cec
-size 16662016
+oid sha256:a4e612fb334ffb4205c28a49036157954d2cbc76fb02d504c4889fb570ee7057
+size 16662040

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df92a0c02bb240c72ca2eda8885153abc8affc59528e379f7c1f4fdb220a6d72
-size 32193904
+oid sha256:ca8f9379a45a3eebe68d399d57b16f0fa727e8a2f9580a52d10135a731b3e055
+size 32193920

--- a/GoSSB/Sources/go.mod
+++ b/GoSSB/Sources/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/boreq/errors v0.1.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/pkg/errors v0.9.1
-	github.com/planetary-social/scuttlego v0.0.0-20230217164342-422b735c1d53
+	github.com/planetary-social/scuttlego v0.0.0-20230220162145-d6d5d269bda6
 	github.com/sirupsen/logrus v1.8.1
 	github.com/ssbc/go-ssb v0.2.2-0.20230212123438-2cdd828cd8c8
 	github.com/ssbc/go-ssb-multiserver v0.1.5-0.20221019203850-917ae0e23d57

--- a/GoSSB/Sources/go.sum
+++ b/GoSSB/Sources/go.sum
@@ -161,8 +161,8 @@ github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetary-social/scuttlego v0.0.0-20230217164342-422b735c1d53 h1:XFAO8jkrwsjCqD0fM6puZ0adQs6ZVHvog46+oGoiivU=
-github.com/planetary-social/scuttlego v0.0.0-20230217164342-422b735c1d53/go.mod h1:7TkSb0gLlMteC0Dhe5N+xHEEVzDbYhYa7pQdLxOgkEA=
+github.com/planetary-social/scuttlego v0.0.0-20230220162145-d6d5d269bda6 h1:VdzQP1K+tiNBCUqI8F9c2RXrO8yaarniH4WDJwjABfs=
+github.com/planetary-social/scuttlego v0.0.0-20230220162145-d6d5d269bda6/go.mod h1:7TkSb0gLlMteC0Dhe5N+xHEEVzDbYhYa7pQdLxOgkEA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Commits:
  - ab28d505e4cacbd2f8a8f2c5cd7eab50b5a709ad Remove an unnecessary pointer

  - 66a808ea0abf5f2668a1438dad3eda63493c3755 Make useful types in transport public

  - 386f10b9743bcc163b016eb38c9be3e7a0e08185 Change package to a test package

  - 688b2ceb45dab10df6cccb2224a59fa87a3e025a Make log debugger handle invalid UTF-8

  - d6d5d269bda656b7b8e2c853b3b65a8bf6c3bf71 Fix handling duplicate sequences in message buffer