### PR TITLE
Don't include VCS info in builds

### DIFF
--- a/Frameworks/GoSSB.xcframework/Info.plist
+++ b/Frameworks/GoSSB.xcframework/Info.plist
@@ -8,20 +8,6 @@
 			<key>HeadersPath</key>
 			<string>Headers</string>
 			<key>LibraryIdentifier</key>
-			<string>ios-arm64</string>
-			<key>LibraryPath</key>
-			<string>libssb-go.a</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>arm64</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>ios</string>
-		</dict>
-		<dict>
-			<key>HeadersPath</key>
-			<string>Headers</string>
-			<key>LibraryIdentifier</key>
 			<string>ios-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
 			<string>libssb-go.a</string>
@@ -34,6 +20,20 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libssb-go.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c4de1aaeeffd638f3c6b6af34ef39b320fee4012188b4251db29130de54d929
-size 16661968
+oid sha256:1afb5bc11c067728521caad6c4c216e83785c6e999cb87fc8c7c1b0cce733735
+size 16645584

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:647ad244bb61c87473c85ad8f32d4bf1e79a397ad635329292cdeb2afe57b950
-size 32193816
+oid sha256:ccc4fd1c3c238751b14fd9446bda9b91ca9b8575cff1119533bfbd18ea2b8fa5
+size 32177432

--- a/GoSSB/Sources/Makefile
+++ b/GoSSB/Sources/Makefile
@@ -66,7 +66,7 @@ GOBUILDTAGS = nommio x509omitbundledroots
 #ifeq ($(CONFIGURATION),Debug)
     GOBUILDTAGS += testing
 #else
-    GOEXTRAFLAGS += -ldflags="-s -w"
+    GOEXTRAFLAGS += -buildvcs=false -ldflags="-s -w"
 #endif
 
 # this builds multiple lib.a files for different ARCHS_PHONE


### PR DESCRIPTION
Otherwise the files show up as modified when built from different commits even if they should be identical.

- [ ] Requires rebuilding .a files