### PR TITLE
Cleanup types returned by ssbBotStatus

### DIFF
--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1afb5bc11c067728521caad6c4c216e83785c6e999cb87fc8c7c1b0cce733735
-size 16645584
+oid sha256:e1017a367bef545ea58d2079793bdde76b75497a9da9f77c680aaab25cef0a8e
+size 16644896

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ccc4fd1c3c238751b14fd9446bda9b91ca9b8575cff1119533bfbd18ea2b8fa5
-size 32177432
+oid sha256:31bb096aa40c4547db91725495110276113a13489c1c4dbfcb0f2562a745c6a8
+size 32168184

--- a/GoSSB/Sources/debug.go
+++ b/GoSSB/Sources/debug.go
@@ -3,10 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/ssbc/go-ssb"
 )
 
 import "C"
@@ -30,18 +28,14 @@ func ssbBotStatus() *C.char {
 		return nil
 	}
 
-	rv := ssb.Status{ // todo return something else, cleanup the interface
-		PID:      1,
-		Peers:    nil,
-		Blobs:    make([]ssb.BlobWant, 0),
-		Root:     1,
-		Indicies: nil,
+	rv := botStatus{
+		Peers: nil,
 	}
 
 	for _, peer := range status.Peers {
-		rv.Peers = append(rv.Peers, ssb.PeerStatus{
-			Addr:  fmt.Sprintf("net:1.2.3.4:8008~shs:%s", peer.Identity.String()), // todo change this so we just return the key
-			Since: "since_is_not_supported",
+		rv.Peers = append(rv.Peers, botStatusPeer{
+			PublicKey: peer.Identity.PublicKey(),
+			Address:   "1.2.3.4:8008",
 		})
 	}
 
@@ -108,6 +102,15 @@ func ssbRepoStats() *C.char {
 	}
 
 	return C.CString(string(countsBytes))
+}
+
+type botStatus struct {
+	Peers []botStatusPeer `json:"peers"`
+}
+
+type botStatusPeer struct {
+	PublicKey []byte `json:"publicKey"`
+	Address   string `json:"address"`
 }
 
 type repoStats struct {

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -54,20 +54,13 @@ struct ScuttlegobotRepoCounts: Decodable {
 // these structs are set this way to match the Go code
 // swiftlint:disable identifier_name
 
-struct ScuttlegobotBlobWant: Decodable {
-    let Ref: String
-    let Dist: Int
-}
-
 struct ScuttlegobotPeerStatus: Decodable {
-    let Addr: String
-    let Since: String
+    let publicKey: String
+    let address: String
 }
 
 struct ScuttlegobotBotStatus: Decodable {
-    let Root: Int
-    let Peers: [ScuttlegobotPeerStatus]
-    let Blobs: [ScuttlegobotBlobWant]
+    let peers: [ScuttlegobotPeerStatus]
 }
 
 enum ScuttlegobotFSCKMode: UInt32 {
@@ -255,23 +248,8 @@ class GoBotInternal {
     func openConnectionList() -> [(String, Identity)] {
         var open: [(String, Identity)] = []
         if let status = try? self.status() {
-            for p in  status.Peers {
-                // split of multiserver addr format
-                // ex: net:1.2.3.4:8008~shs:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-                if !p.Addr.hasPrefix("net:") {
-                    continue
-                }
-
-                let hostWithPubkey = p.Addr.dropFirst(4)
-                guard let startOfPubKey = hostWithPubkey.firstIndex(of: "~") else {
-                    continue
-                }
-
-                let host = hostWithPubkey[..<startOfPubKey]
-                let keyB64Start = hostWithPubkey.index(startOfPubKey, offsetBy: 5) // ~shs:
-                let pubkey = hostWithPubkey[keyB64Start...]
-
-                open.append((String(host), String(pubkey)))
+            for p in  status.peers {
+                open.append((String(p.address), String(p.publicKey)))
             }
         }
         return open


### PR DESCRIPTION
- Removed unused fields: PID, Blobs, Root, Indices.
- Made peer information easier to parse by replacing multiserver address with two separate fields: publicKey and address.
- In effect simplified Swift code.

New data format:

    {
      "peers": [
        {
          "publicKey": "<string depicting base64-encoded raw public key>",
          "address": "1.2.3.4:8000"
        }
      ]
    }