### PR TITLE
Cleanup config

### DIFF
--- a/Frameworks/GoSSB.xcframework/Info.plist
+++ b/Frameworks/GoSSB.xcframework/Info.plist
@@ -8,20 +8,6 @@
 			<key>HeadersPath</key>
 			<string>Headers</string>
 			<key>LibraryIdentifier</key>
-			<string>ios-arm64</string>
-			<key>LibraryPath</key>
-			<string>libssb-go.a</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>arm64</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>ios</string>
-		</dict>
-		<dict>
-			<key>HeadersPath</key>
-			<string>Headers</string>
-			<key>LibraryIdentifier</key>
 			<string>ios-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
 			<string>libssb-go.a</string>
@@ -34,6 +20,20 @@
 			<string>ios</string>
 			<key>SupportedPlatformVariant</key>
 			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>HeadersPath</key>
+			<string>Headers</string>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>libssb-go.a</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
 		</dict>
 	</array>
 	<key>CFBundlePackageType</key>

--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e0278ac7ef228fbcab9a28ef57d1caae8fcd1bbaffaa35b27c0d3f677821e67
-size 16625816
+oid sha256:fb39f051f8d9305fdb9d47ff32461adf863aaa28c2a77bd84620e0211a722506
+size 16625832

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:734148e2800febaa614157a1b7bac45539842f59d156fd6563f4ac48bc1425c5
-size 32146840
+oid sha256:ada5aa33cf9474cc9265e7e82dd0e4ed5249010949d10de8c71a50a16ebde8aa
+size 32146816

--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -289,7 +289,6 @@ class GoBot: Bot, @unchecked Sendable {
             hmacKey: hmacKey,
             secret: secret,
             pathPrefix: repoPrefix,
-            disableEBT: isRestoring,
             migrationDelegate: migrationDelegate
         )
 


### PR DESCRIPTION
- removed ServicePubs and ViewDBSchemaVersion as they were unused
- renamed "app key" to "network key" for readability
- changed "hops" so that they are interpreted like in other clients/scuttlego
- made all keys lowercase to follow conventions