### PR TITLE
Bump github.com/planetary-social/scuttlego

### DIFF
--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f645b3b235c2d8fdaed94148332b162ef607e96b699e775ef1caf5fa8dec3480
-size 16625832
+oid sha256:d2ae0408902840c99ebe6864506b9747290952ffe354b012b5c7b05edcfb34ee
+size 16696912

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ede0193be36363581e5e04a6593bd7ef7936bb10ef41b4656333879a942227b4
-size 32146816
+oid sha256:7b4ed9f0dff8eaace98ab08d20ae3bd016bd696ba9832dc895b07b1504de0f3e
+size 32265056

--- a/GoSSB/Sources/go.mod
+++ b/GoSSB/Sources/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/boreq/errors v0.1.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/pkg/errors v0.9.1
-	github.com/planetary-social/scuttlego v0.0.0-20230220162145-d6d5d269bda6
+	github.com/planetary-social/scuttlego v0.0.0-20230222182349-4e9568c70477
 	github.com/sirupsen/logrus v1.8.1
 	github.com/ssbc/go-ssb v0.2.2-0.20230212123438-2cdd828cd8c8
 	github.com/ssbc/go-ssb-multiserver v0.1.5-0.20221019203850-917ae0e23d57

--- a/GoSSB/Sources/go.sum
+++ b/GoSSB/Sources/go.sum
@@ -161,8 +161,8 @@ github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetary-social/scuttlego v0.0.0-20230220162145-d6d5d269bda6 h1:VdzQP1K+tiNBCUqI8F9c2RXrO8yaarniH4WDJwjABfs=
-github.com/planetary-social/scuttlego v0.0.0-20230220162145-d6d5d269bda6/go.mod h1:7TkSb0gLlMteC0Dhe5N+xHEEVzDbYhYa7pQdLxOgkEA=
+github.com/planetary-social/scuttlego v0.0.0-20230222182349-4e9568c70477 h1:JgC1r5HCf4bhLamGjYSKG0gipU6Up7j4PeHXYY/ATAg=
+github.com/planetary-social/scuttlego v0.0.0-20230222182349-4e9568c70477/go.mod h1:7TkSb0gLlMteC0Dhe5N+xHEEVzDbYhYa7pQdLxOgkEA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
d6d5d269bda6 -> 4e9568c70477

Commits:
  - 8fe4de7be4a709a87a23af556402cc693d5ce20b Improve message buffer logging

  - 7a5daf8ce5a0276dbed3b6dcac1a3ac60750169b Fix default hops value

  - 972ed33bf3145cf6112cca4f2b75740211035535 Move the code creating wanted feeds to application

  - ae4b30f6441535d78ec8c55c8be79e2c35fc1221 Update contributing documentation

  - 5a5d6404665c760bd8cc1cd3ec0357a0f746c520 Don't replicate forked feeds with peers who have them

  - 46c35fd6e213cb38e6149e4d0860353d57ab4c50 Avoid loading the entire feed just to get the sequence

  - 4e9568c70477d58a1f0ca61aeef246434fa3aeeb Do not perform writes when listing want lists