### PR TITLE
Make it easier to enable trace logging

### DIFF
--- a/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28d443e3e173b250f0d7b998702ee535867dac8b5b639d6c329868751f7956d9
+oid sha256:c1adc1abdf1f460ed0d1d75e3dd2e508e34ac3a65d63da7c1e3b0ee42f22b119
 size 16697816

--- a/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
+++ b/Frameworks/GoSSB.xcframework/ios-arm64_x86_64-simulator/libssb-go.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1872f018cb59932086de8e3af4aad8977d5010b9280d40a6269a93624df4b603
+oid sha256:58cf19b3c4c3595084d1f6fcc5f0b875a2046c067ad3c82ea53bf39e78c52f3b
 size 32266576

--- a/GoSSB/Sources/api-ios.go
+++ b/GoSSB/Sources/api-ios.go
@@ -201,7 +201,7 @@ func ssbBotInit(
 func main() {}
 
 func initPreInitLogger() {
-	log = newLogger(os.Stderr)
+	log = newLogger(os.Stderr, false)
 	log = log.WithField("warning", "pre-init")
 }
 
@@ -217,11 +217,11 @@ func initLogger(config bindings.BotConfig) error {
 		return errors.Wrap(err, "failed to create debug log file")
 	}
 
-	log = newLogger(io.MultiWriter(os.Stderr, logFile))
+	log = newLogger(io.MultiWriter(os.Stderr, logFile), config.Testing)
 	return nil
 }
 
-func newLogger(w io.Writer) logging.Logger {
+func newLogger(w io.Writer, testing bool) logging.Logger {
 	const swiftLikeFormat = "2006-01-02 15:04:05.0000000 (UTC)"
 
 	customFormatter := new(logrus.TextFormatter)
@@ -230,7 +230,11 @@ func newLogger(w io.Writer) logging.Logger {
 	logrusLogger := logrus.New()
 	logrusLogger.SetOutput(w)
 	logrusLogger.SetFormatter(customFormatter)
-	logrusLogger.SetLevel(logrus.DebugLevel)
+	if testing {
+		logrusLogger.SetLevel(logrus.TraceLevel)
+	} else {
+		logrusLogger.SetLevel(logrus.DebugLevel)
+	}
 
 	return logging.NewLogrusLogger(logrusLogger).WithField("source", "golang")
 }

--- a/Source/GoBot/GoBotInternal.swift
+++ b/Source/GoBot/GoBotInternal.swift
@@ -68,12 +68,7 @@ private struct GoBotConfig: Encodable {
     let oldRepo: String
     let listenAddr: String
     let hops: UInt
-
-    #if DEBUG
-    let testing = true
-    #else
-    let testing = false
-    #endif
+    let testing: Bool
     
     func stringRepresentation() throws -> String {
         let configData = try JSONEncoder().encode(self)
@@ -143,7 +138,8 @@ class GoBotInternal {
             repo: self.repoPath,
             oldRepo: self.oldRepoPath,
             listenAddr: listenAddr,
-            hops: 2
+            hops: 2,
+            testing: false
         )
         
         var configString: String


### PR DESCRIPTION
Trace logging can be enabled by changing "testing" to true in the configuration. This is the only thing that is currently controlled by the testing parameter. I changed the config so this is not automatic as logging at this level really produces a lot of data.