### PR TITLE
Maybe fix blobs not loading sometimes

### DIFF
--- a/Source/GoBot/GoBot.swift
+++ b/Source/GoBot/GoBot.swift
@@ -911,11 +911,6 @@ class GoBot: Bot, @unchecked Sendable {
             return
         }
         
-        guard !isRestoring else {
-            completion(identifier, nil, BotError.restoring)
-            return
-        }
-
         userInitiatedQueue.async {
 
             // get non-empty data from blob storage


### PR DESCRIPTION
This might fix #1192. My theory for what is happening is that the `guessIsRestoring()` function thought we were restoring because forked feed protection was tripped because the scuttlego migration fixed my soft fork. I removed the early exit on blob loading if we think the user is restoring their feed. This was an optimization but maybe we don't need it anymore on scuttlego. 

I think there may be some other issue where my name isn't loading at first on every app launch which is weird. I posted about that here. https://planetary-app.slack.com/archives/CE6RE7ND6/p1677697080087179