### PR TITLE
Reenable testLoginLogoutLoop

### DIFF
--- a/UnitTests/GoBotIntegrationTests.swift
+++ b/UnitTests/GoBotIntegrationTests.swift
@@ -212,16 +212,16 @@ class GoBotIntegrationTests: XCTestCase {
     }
 
     // Disabled until scuttlego #908
-//    func testLoginLogoutLoop() async throws {
-//        // These failure expectations are only good for one use each, so here are a bunch
-//        XCTExpectFailure("go-ssb sometimes hangs when logging out", strict: false)
-//        try await sut.login(config: appConfig)
-//
-//        await sut.exit()
-//        try await sut.logout()
-//
-//        try await sut.login(config: appConfig)
-//    }
+    func testLoginLogoutLoop() async throws {
+        // These failure expectations are only good for one use each, so here are a bunch
+        XCTExpectFailure("go-ssb sometimes hangs when logging out", strict: false)
+        try await sut.login(config: appConfig)
+
+        await sut.exit()
+        try await sut.logout()
+
+        try await sut.login(config: appConfig)
+    }
 
     // MARK: - Publishing
     


### PR DESCRIPTION
This was disabled due to failures related to go-ssb. Scuttlego should not fail like this and if it does it needs to be fixed.